### PR TITLE
Fix-fixes net bursting & Color memory-leaks/performance

### DIFF
--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -124,7 +124,7 @@ local texturecache, texturecachehttp
 local function CheckURLDownloads()
 	local numqueued = #LoadingURLQueue
 	local urltable = LoadingURLQueue[numqueued]
-	
+
 	if urltable then
 		if urltable.Panel then
 			if not urltable.Panel:IsLoading() then
@@ -135,16 +135,16 @@ local function CheckURLDownloads()
 					tex:Download()
 					urltable.Panel:Remove()
 					if urltable.cb then urltable.cb() end
-				end)	
-				LoadingURLQueue[numqueued] = nil					
+				end)
+				LoadingURLQueue[numqueued] = nil
 			else
 				if CurTime() > urltable.Timeout then
 					urltable.Panel:Remove()
 					LoadingURLQueue[numqueued] = nil
 				end
 			end
-		
-		else		
+
+		else
 			local Panel = vgui.Create( "DHTML" )
 			Panel:SetSize( 1024, 1024 )
 			Panel:SetAlpha( 0 )
@@ -152,8 +152,8 @@ local function CheckURLDownloads()
 			Panel:SetHTML(
 			[[
 				<style type="text/css">
-					html 
-					{			
+					html
+					{
 						overflow:hidden;
 						margin: -8px -8px;
 					}
@@ -167,7 +167,7 @@ local function CheckURLDownloads()
 						width: 100%;
 					}
 				</style>
-				
+
 				<body>
 					<div class="imagebox"></div>
 				</body>
@@ -177,13 +177,13 @@ local function CheckURLDownloads()
 			urltable.Panel = Panel
 		end
 	end
-	
+
 	if #LoadingURLQueue == 0 then
 		timer.Destroy("SF_URLMaterialChecker")
 	end
 end
 
-local cv_max_url_materials = CreateConVar( "sf_render_maxurlmaterials", "30", { FCVAR_REPLICATED, FCVAR_ARCHIVE } ) 
+local cv_max_url_materials = CreateConVar( "sf_render_maxurlmaterials", "30", { FCVAR_REPLICATED, FCVAR_ARCHIVE } )
 
 local function LoadURLMaterial( url, cb )
 	--Count the number of materials
@@ -193,20 +193,20 @@ local function LoadURLMaterial( url, cb )
 		if not key then break end
 		totalMaterials = totalMaterials + 1
 	end
-	
+
 	local queuesize = #LoadingURLQueue
 	totalMaterials = totalMaterials + queuesize
-	
+
 	if totalMaterials>=cv_max_url_materials:GetInt() then
 		return
 	end
-	
+
 	local urlmaterial = sfCreateMaterial("SF_TEXTURE_" .. util.CRC(url .. SysTime()))
-				
+
 	if queuesize == 0 then
 		timer.Create("SF_URLMaterialChecker",1,0,function() CheckURLDownloads() end)
 	end
-	
+
 	LoadingURLQueue[queuesize + 1] = {Material = urlmaterial, Url = url, cb = cb}
 	return urlmaterial
 end
@@ -342,11 +342,19 @@ end
 
 --- Sets the draw color
 -- @param clr Color type
-function render_library.setColor ( clr )
+function render_library.setColor( clr )
 	SF.CheckType( clr, SF.Types[ "Color" ] )
 	currentcolor = clr
 	surface.SetDrawColor( clr )
 	surface.SetTextColor( clr )
+end
+
+--- Sets the draw color by RGBA values
+function render_library.setRGBA( r, g, b, a )
+	SF.CheckType( r, "number" ) SF.CheckType( g, "number" ) SF.CheckType( b, "number" ) SF.CheckType( a, "number" )
+	currentcolor = Color( r, g, b, a )
+	surface.SetDrawColor( r, g, b, a )
+	surface.SetTextColor( r, g, b, a )
 end
 
 --- Looks up a texture by file name. Use with render.setTexture to draw with it.
@@ -360,9 +368,9 @@ function render_library.getTextureID ( tx, cb )
 		tx = string.gsub( tx, "[^%w _~%.%-/:]", function( str )
 			return string.format( "%%%02X", string.byte( str ) )
 		end )
-		
+
 		local instance = SF.instance
-		
+
 		local tbl = {}
 		texturecachehttp[ tbl ] = LoadURLMaterial( tx, function()
 			if cb then
@@ -381,13 +389,13 @@ function render_library.getTextureID ( tx, cb )
 			if not mat then return end
 			local cacheentry = sfCreateMaterial( "SF_TEXTURE_" .. id )
 			cacheentry:SetTexture( "$basetexture", mat:GetTexture( "$basetexture" ) )
-			
+
 			local tbl = {}
 			texturecache[ tbl ] = cacheentry
 			return tbl
 		end
 	end
-	
+
 end
 
 --- Sets the texture
@@ -468,7 +476,7 @@ function render_library.setRenderTargetTexture ( name )
 	local data = SF.instance.data.render
 	if not data.isRendering then SF.throw( "Not in rendering hook.", 2 ) end
 	SF.CheckType( name, "string" )
-	
+
 	local rtname = data.rendertargets[ name ]
 	if rtname and globalRTs[ rtname ] then
 		RT_Material:SetTexture( "$basetexture", globalRTs[ rtname ][ 1 ] )
@@ -508,7 +516,7 @@ function render_library.clear ( clr )
 	end
 end
 
---- Draws a rectangle using the current color. 
+--- Draws a rectangle using the current color.
 -- @param x Top left corner x coordinate
 -- @param y Top left corner y coordinate
 -- @param w Width
@@ -672,7 +680,7 @@ end
 -- \- DejaVu Sans Mono (shipped, monospaced)
 function render_library.createFont(font,size,weight,antialias,additive,shadow,outline,blur)
 	if not validfonts[font] then SF.throw( "invalid font", 2 ) end
-	
+
 	size = tonumber(size) or 16
 	weight = tonumber(weight) or 400
 	blur = tonumber(blur) or 0
@@ -680,14 +688,14 @@ function render_library.createFont(font,size,weight,antialias,additive,shadow,ou
 	additive = additive and true or false
 	shadow = shadow and true or false
 	outline = outline and true or false
-	
+
 	local name = string.format("sf_screen_font_%s_%d_%d_%d_%d%d%d%d",
 		font, size, weight, blur,
 		antialias and 1 or 0,
 		additive and 1 or 0,
 		shadow and 1 or 0,
 		outline and 1 or 0)
-	
+
 	if not defined_fonts[name] then
 		surface.CreateFont(name, {size = size, weight = weight,
 			antialias=antialias, additive = additive, font = font,
@@ -703,7 +711,7 @@ end
 -- @return height of the text
 function render_library.getTextSize( text )
 	SF.CheckType(text,"string")
-	
+
 	surface.SetFont(SF.instance.data.render.font or defaultFont)
 	return surface.GetTextSize( text )
 end
@@ -735,9 +743,9 @@ function render_library.drawText ( x, y, text, alignment )
 	if alignment then
 		SF.CheckType( alignment, "number" )
 	end
-	
+
 	local font = SF.instance.data.render.font or defaultFont
-	
+
 	draw.DrawText( text, font, x, y, currentcolor, alignment or TEXT_ALIGN_LEFT )
 end
 
@@ -789,32 +797,32 @@ function render_library.cursorPos( ply )
 
 	ply = SF.Entities.Unwrap( ply )
 	if not ply then SF.throw("Invalid Player", 2) end
-	
+
 	local Normal, Pos
 	-- Get monitor screen pos & size
 
 	Pos = screen:LocalToWorld( screen.Origin )
-		
+
 	Normal = -screen.Transform:GetUp():GetNormalized()
-	
+
 	local Start = ply:GetShootPos()
 	local Dir = ply:GetAimVector()
-	
+
 	local A = Normal:Dot(Dir)
-	
+
 	-- If ray is parallel or behind the screen
 	if A == 0 or A > 0 then return nil end
-	
+
 	local B = Normal:Dot(Pos-Start) / A
 	if (B >= 0) then
 		local w = 512/screen.Aspect
 		local HitPos = WorldToLocal( Start + Dir * B, Angle(), screen.Transform:GetTranslation(), screen.Transform:GetAngles() )
 		local x = HitPos.x/screen.Scale
 		local y = HitPos.y/screen.Scale
-		if x < 0 or x > w or y < 0 or y > 512 then return nil end -- Aiming off the screen 
+		if x < 0 or x > w or y < 0 or y > 512 then return nil end -- Aiming off the screen
 		return x, y
 	end
-	
+
 	return nil
 end
 
@@ -822,7 +830,7 @@ end
 -- Note: this does a table copy so move it out of your draw hook
 -- @param e The screen to get info from.
 -- @return A table describing the screen.
-function render_library.getScreenInfo( e )	
+function render_library.getScreenInfo( e )
 	local screen = SF.Entities.Unwrap( e )
 	if screen then
 		return SF.Sanitize( screen.ScreenInfo )
@@ -853,7 +861,7 @@ function render_library.readPixel ( x, y )
 	if not data.isRendering then
 		SF.throw( "Not in rendering hook.", 2 )
 	end
-	
+
 	SF.CheckType( x, "number" )
 	SF.CheckType( y, "number" )
 

--- a/lua/starfall/libs_sh/color.lua
+++ b/lua/starfall/libs_sh/color.lua
@@ -2,9 +2,18 @@ SF.Color = {}
 
 --- Color type
 --@shared
-local color_methods, color_metatable = SF.Typedef( "Color" )
+local color_methods, color_metatable = SF.Typedef( "Color", {} )
 
-local wrap, unwrap = SF.CreateWrapper( color_metatable, true, false, debug.getregistry().Color )
+local function wrap_color( table )
+	return setmetatable( table, color_metatable )
+end
+
+local function unwrap_color( obj )
+	return Color( (obj[1] or 255), (obj[2] or 255),
+		(obj[3] or 255), (obj[4] or 255) )
+end
+
+local wrap, unwrap = wrap_color, unwrap_color
 
 SF.Color.Methods = color_methods
 SF.Color.Metatable = color_metatable
@@ -12,7 +21,7 @@ SF.Color.Wrap = wrap
 SF.Color.Unwrap = unwrap
 
 local dgetmeta = debug.getmetatable
---- Same as the Gmod Color type
+--- Creates a table struct that resembles a Color/
 -- @name SF.DefaultEnvironment.Color
 -- @class function
 -- @param r - Red
@@ -21,19 +30,19 @@ local dgetmeta = debug.getmetatable
 -- @param a - Alpha
 -- @return New color
 SF.DefaultEnvironment.Color = function ( ... )
-	return wrap( Color( ... ) )
+	return wrap( { ... } )
 end
 
 -- Lookup table.
 -- Index 1->4 have associative rgba for use in __index. Saves lots of checks
 -- String based indexing returns string, just a pass through.
 -- Think of rgb as a template for members of Color that are expected.
-local rgb = { [ 1 ] = "r", [ 2 ] = "g", [ 3 ] = "b", [ 4 ] = "a", r = "r", g = "g", b = "b", a = "a" }
+local rgb = { r = 1, g = 2, b = 3, a = 4, h = 1, s = 2, v = 3, l = 3 }
 
 --- __newindex metamethod
 function color_metatable.__newindex ( t, k, v )
 	if rgb[ k ] then
-		rawset( SF.UnwrapObject( t ), rgb[ k ], v )
+		rawset( t, rgb[ k ], v )
 	else
 		rawset( t, k, v )
 	end
@@ -44,9 +53,9 @@ local _p = color_metatable.__index
 --- __index metamethod
 function color_metatable.__index ( t, k )
 	if rgb[ k ] then
-		return rawget( SF.UnwrapObject( t ), rgb[ k ] )
+		return rawget( t, rgb[ k ] )
 	else
-		return _p[ k ]
+		return rawget( t, k )
 	end
 end
 
@@ -65,7 +74,7 @@ end
 function color_metatable:__eq ( c )
 	SF.CheckType( self, color_metatable )
 	SF.CheckType( c, color_metatable )
-	return unwrap( self ):__eq( unwrap( c ) )
+	return ( unwrap(self):__eq(unwrap(c)) )
 end
 
 local clamp = math.Clamp
@@ -77,8 +86,8 @@ local clamp = math.Clamp
 function color_metatable.__add ( lhs, rhs )
 	SF.CheckType( lhs, color_metatable )
 	SF.CheckType( rhs, color_metatable )
-	local a, b = unwrap( lhs ), unwrap( rhs )
-	return wrap( Color( clamp( a.r + b.r, 0, 255 ), clamp( a.g + b.g, 0, 255 ), clamp( a.b + b.b, 0, 255 ), clamp( a.a + b.a, 0, 255 ) ) )
+	local a, b = lhs, rhs
+	return wrap( { clamp( a.r + b.r, 0, 255 ), clamp( a.g + b.g, 0, 255 ), clamp( a.b + b.b, 0, 255 ), clamp( a.a + b.a, 0, 255 ) } )
 end
 
 --- subtraction metamethod
@@ -88,8 +97,8 @@ end
 function color_metatable.__sub ( lhs, rhs )
 	SF.CheckType( lhs, color_metatable )
 	SF.CheckType( rhs, color_metatable )
-	local a, b = unwrap( lhs ), unwrap( rhs )
-	return wrap( Color( clamp( a.r - b.r, 0, 255 ), clamp( a.g - b.g, 0, 255 ), clamp( a.b - b.b, 0, 255 ), clamp( a.a - b.a, 0, 255 ) ) )
+	local a, b = lhs, rhs
+	return wrap( { clamp( a.r - b.r, 0, 255 ), clamp( a.g - b.g, 0, 255 ), clamp( a.b - b.b, 0, 255 ), clamp( a.a - b.a, 0, 255 ) } )
 end
 
 --- multiplication metamethod
@@ -99,12 +108,12 @@ end
 function color_metatable.__mul ( lhs, rhs )
 	if dgetmeta( lhs ) == color_metatable then
 		SF.CheckType( rhs, "number" )
-		local c = unwrap( lhs )
-		return wrap( Color( clamp( c.r * rhs, 0, 255 ), clamp( c.g * rhs, 0, 255 ), clamp( c.b * rhs, 0, 255 ), clamp( c.a * rhs, 0, 255 ) ) )
+		local c = lhs
+		return wrap( { clamp( c.r * rhs, 0, 255 ), clamp( c.g * rhs, 0, 255 ), clamp( c.b * rhs, 0, 255 ), clamp( c.a * rhs, 0, 255 ) } )
 	else
 		SF.CheckType( lhs, "number" )
-		local c = unwrap( rhs )
-		return wrap( Color( clamp( c.r * lhs, 0, 255 ), clamp( c.g * lhs, 0, 255 ), clamp( c.b * lhs, 0, 255 ), clamp( c.a * lhs, 0, 255 ) ) )
+		local c = rhs
+		return wrap( { clamp( c.r * lhs, 0, 255 ), clamp( c.g * lhs, 0, 255 ), clamp( c.b * lhs, 0, 255 ), clamp( c.a * lhs, 0, 255 ) } )
 	end
 end
 
@@ -113,8 +122,8 @@ end
 -- @return Scaled color.
 function color_metatable:__div ( rhs )
 	SF.CheckType( rhs, "number" )
-	local c = unwrap( self )
-	return wrap( Color( clamp( c.r / rhs, 0, 255 ), clamp( c.g / rhs, 0, 255 ), clamp( c.b / rhs, 0, 255 ), clamp( c.a / rhs, 0, 255 ) ) )
+	local c = self
+	return wrap( { clamp( c.r / rhs, 0, 255 ), clamp( c.g / rhs, 0, 255 ), clamp( c.b / rhs, 0, 255 ), clamp( c.a / rhs, 0, 255 ) } )
 end
 
 --- Converts the color from RGB to HSV.
@@ -128,5 +137,6 @@ end
 --@shared
 --@return A triplet of numbers representing HSV.
 function color_methods:hsvToRGB ()
-	return wrap( HSVToColor( self.r, self.g, self.b ) )
+	local rgb = HSVToColor( self.r, self.g, self.b )
+	return wrap( { rgb.r, rgb.g, rgb.b, (rgb.a or 255) } )
 end

--- a/lua/starfall/libs_sh/net.lua
+++ b/lua/starfall/libs_sh/net.lua
@@ -22,7 +22,6 @@ end
 
 local function write( instance, type, size, ... )
 	instance.data.net.size = instance.data.net.size + size
-	burst_tick()
 
 	instance.data.net.data[#instance.data.net.data+1] = { "Write" .. type, {...} }
 end
@@ -74,7 +73,7 @@ function net_library.send ( target )
 	burst_tick()
 	instance.data.net.burst = instance.data.net.burst - instance.data.net.size
 
-	if instance.data.net.burst < -8 then -- 8 bytes overhead because we're dealing with floating point calculations
+	if instance.data.net.burst < -8 then -- 8 bytes overhead
 		SF.throw( "Net message exceeds limit!", 3 )
 	end
 
@@ -395,7 +394,7 @@ end
 -- @return number of bytes that can be sent
 function net_library.getBytesLeft()
 	burst_tick()
-	return SF.instance.data.net.burst
+	return SF.instance.data.net.burst - SF.instance.data.net.size
 end
 
 net.Receive( "SF_netmessage", function( len, ply )

--- a/lua/starfall/libs_sh/net.lua
+++ b/lua/starfall/libs_sh/net.lua
@@ -13,12 +13,17 @@ local burst_limit = CreateConVar( "sf_net_burst_limit", "10", { FCVAR_ARCHIVE, F
 local burst_interval = CreateConVar( "sf_net_burst_interval", "0.1", { FCVAR_ARCHIVE, FCVAR_REPLICATED },
 						"The interval of the timer that adds 1kB more available net message." )
 
+local function burst_tick()
+	local instance = SF.instance
+
+	instance.data.net.burst 	= math.min( burst_limit:GetFloat()*1000, instance.data.net.burst + math.max( 0, ( ( CurTime() - instance.data.net.last_tick ) / burst_interval:GetFloat() ) * 1000 ) )
+	instance.data.net.last_tick = CurTime()
+end
 
 local function write( instance, type, size, ... )
-	instance.data.net.burst = instance.data.net.burst - size
-	if instance.data.net.burst < 0 then
-		SF.throw( "Net message exceeds limit!", 3 )
-	end
+	instance.data.net.size = instance.data.net.size + size
+	burst_tick()
+
 	instance.data.net.data[#instance.data.net.data+1] = { "Write" .. type, {...} }
 end
 
@@ -27,7 +32,8 @@ SF.Libraries.AddHook( "initialize", function( instance )
 	instance.data.net = {
 		started = false,
 		burst = burst_limit:GetInt()*1000,
-		last_send = CurTime(),
+		size = 0,
+		last_tick = CurTime(),
 		data = {},
 	}
 end)
@@ -47,11 +53,12 @@ end
 function net_library.start( name )
 	SF.CheckType( name, "string" )
 	local instance = SF.instance
-	if instance.data.net.started then SF.throw( "net message was already started", 2) end
+	if instance.data.net.started then SF.throw( "net message was already started", 2 ) end
 
 	instance.data.net.started = true
-	instance.data.net.burst = math.min( burst_limit:GetFloat()*1000, instance.data.net.burst + ( ( CurTime() - instance.data.net.last_send ) / burst_interval:GetFloat() ) * 1000 )
-	instance.data.net.last_send = CurTime()
+
+	burst_tick()
+	instance.data.net.size = 0
 	instance.data.net.data = {}
 
 	write( instance, "String", #name, name )
@@ -64,6 +71,13 @@ function net_library.send ( target )
 	local instance = SF.instance
 	if not instance.data.net.started then SF.throw( "net message not started", 2 ) end
 
+	burst_tick()
+	instance.data.net.burst = instance.data.net.burst - instance.data.net.size
+
+	if instance.data.net.burst < -8 then -- 8 bytes overhead because we're dealing with floating point calculations
+		SF.throw( "Net message exceeds limit!", 3 )
+	end
+
 	local data = instance.data.net.data
 	if #data == 0 then return false end
 	net.Start( "SF_netmessage" )
@@ -71,7 +85,6 @@ function net_library.send ( target )
 	for i = 1, #data do
 		net[ data[ i ][ 1 ] ]( unpack( data[ i ][ 2 ] ) )
 	end
-
 
 	if SERVER then
 		local sendfunc, newtarget
@@ -381,6 +394,7 @@ end
 --- Returns available bandwidth in bytes
 -- @return number of bytes that can be sent
 function net_library.getBytesLeft()
+	burst_tick()
 	return SF.instance.data.net.burst
 end
 

--- a/lua/starfall/libs_sh/net.lua
+++ b/lua/starfall/libs_sh/net.lua
@@ -48,12 +48,12 @@ function net_library.start( name )
 	SF.CheckType( name, "string" )
 	local instance = SF.instance
 	if instance.data.net.started then SF.throw( "net message was already started", 2) end
-	
+
 	instance.data.net.started = true
-	instance.data.net.burst = math.min( burst_limit:GetFloat()*1000, instance.data.net.burst + ( CurTime() - instance.data.net.last_send ) / burst_interval:GetFloat() * 1000 )
+	instance.data.net.burst = math.min( burst_limit:GetFloat()*1000, instance.data.net.burst + ( ( CurTime() - instance.data.net.last_send ) / burst_interval:GetFloat() ) * 1000 )
 	instance.data.net.last_send = CurTime()
 	instance.data.net.data = {}
-	
+
 	write( instance, "String", #name, name )
 end
 
@@ -72,7 +72,7 @@ function net_library.send ( target )
 		net[ data[ i ][ 1 ] ]( unpack( data[ i ][ 2 ] ) )
 	end
 
-	
+
 	if SERVER then
 		local sendfunc, newtarget
 
@@ -97,7 +97,7 @@ function net_library.send ( target )
 	else
 		net.SendToServer()
 	end
-	
+
 	instance.data.net.started = false
 end
 


### PR DESCRIPTION
I have implemented the `burst_tick` function, which basically does the same as was done in `net_library.start`.  
  
The difference is that it is called before every operation requiring the `burst` value to be updated; therefor I have moved the exception throwing for too large net packets to `net_library.send`, as no net_library-network traffic *should* occur before that.  
  
To be able to do this I added a `size` value which stores the size of the current net message, this is incremented in the local `write( ...` function and set to `0` in `net_library.start`.  
  
I have also permitted *8 bytes of overhead*, as we are dealing with floating-point calculations, and 8 bytes of overhead is perfectly reasonable.  
  
This might be considered a dirty fix, but it seems to work, for the time being.