### PR TITLE
Add enableCursor function

### DIFF
--- a/lua/entities/starfall_hud/cl_init.lua
+++ b/lua/entities/starfall_hud/cl_init.lua
@@ -75,6 +75,7 @@ function ConnectHUD( ent )
 		LocalPlayer():ChatPrint("Starfall HUD Connected.")
 	end
 	SF.ConnectedHuds[ent] = true
+	hook.Run( "starfall_hud_connect", ent )
 end
 
 function DisconnectHUD( ent )
@@ -85,6 +86,7 @@ function DisconnectHUD( ent )
 	hook.Remove("CalcView", hookname)
 	LocalPlayer():ChatPrint("Starfall HUD Disconnected.")
 	SF.ConnectedHuds[ent] = nil
+	hook.Run( "starfall_hud_disconnect", ent )
 end
 
 net.Receive( "starfall_hud_set_enabled" , function()

--- a/lua/starfall/libs_sh/input.lua
+++ b/lua/starfall/libs_sh/input.lua
@@ -103,6 +103,37 @@ function input_methods.getCursorPos( )
 	return input.GetCursorPos( )
 end
 
+local cursor = {}
+---- Sets the state of the mouse cursor
+--- @param enabled Whether or not the cursor should be enabled
+function input_methods.enableCursor( enabled )
+	SF.CheckType( enabled, "boolean" )
+	SF.Permissions.check( SF.instance.player, nil, "input" )
+	
+	local foundlink
+	for hud, _ in pairs( SF.ConnectedHuds ) do
+		if hud.link == SF.instance.data.entity then
+			foundlink = hud
+			break
+		end
+	end
+	
+	if not foundlink then
+		SF.throw( "No HUD component connected", 2 )
+		return
+	end
+	
+	cursor[ foundlink ] = enabled
+	gui.EnableScreenClicker( enabled )
+end
+
+hook.Add( "starfall_hud_disconnect", "starfall_disable_cursor", function( hud )
+	if cursor[ hud ] then
+		gui.EnableScreenClicker( false )
+	end
+	cursor[ hud ] = nil
+end )
+
 function CheckButtonPerms(instance, ply, button)
 	if (IsFirstTimePredicted() or game.SinglePlayer()) and SF.Permissions.hasAccess( instance.player, nil, "input" ) then
 		return true, {button}


### PR DESCRIPTION
Currently the input.getCursorPos does nothing of value because the cursor is always in the center of the screen. This function enables the cursor to move around like the context menu. If the state is changed by a chip, it is reset when the chip is removed.

Should a console command be added to reset the cursor state? There is no function in GMod to get the state that the cursor is in, so it can't be stored for later resets, meaning that this could be used when it shouldn't. 