### PR TITLE
Added HUD connection hooks

### DIFF
--- a/lua/entities/starfall_hud/cl_init.lua
+++ b/lua/entities/starfall_hud/cl_init.lua
@@ -75,7 +75,7 @@ function ConnectHUD( ent )
 		LocalPlayer():ChatPrint("Starfall HUD Connected.")
 	end
 	SF.ConnectedHuds[ent] = true
-	hook.Run( "starfall_hud_connect", ent )
+	hook.Run( "starfall_hud_connect", ent.link.instance )
 end
 
 function DisconnectHUD( ent )
@@ -86,7 +86,7 @@ function DisconnectHUD( ent )
 	hook.Remove("CalcView", hookname)
 	LocalPlayer():ChatPrint("Starfall HUD Disconnected.")
 	SF.ConnectedHuds[ent] = nil
-	hook.Run( "starfall_hud_disconnect", ent )
+	hook.Run( "starfall_hud_disconnect", ent.link.instance )
 end
 
 net.Receive( "starfall_hud_set_enabled" , function()

--- a/lua/starfall/instance.lua
+++ b/lua/starfall/instance.lua
@@ -271,6 +271,20 @@ function SF.Instance:deinitialize()
 	self.error = true
 end
 
+if CLIENT then
+--- Check if a HUD Component is connected to the SF instance
+-- @return true if a HUD Component is connected
+	function SF.Instance:isHUDConnected()
+		local foundlink
+		for hud, _ in pairs( SF.ConnectedHuds ) do
+			if hud.link == self.data.entity then
+				return true
+			end
+		end
+		return false
+	end
+end
+
 --- Errors the instance. Should only be called from the tips of the call tree (aka from places such as the hook library, timer library, the entity's think function, etc)
 function SF.Instance:Error(msg,traceback)
 	

--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -7,6 +7,26 @@
 -- @class hook
 -- @client
 
+--- Called when the player connects to a HUD component linked to the Starfall Chip
+-- @name hudconnect
+-- @class hook
+-- @client
+hook.Add( "starfall_hud_connect", "hudconnect", function( instance )
+	if instance then
+		instance:runScriptHook( "hudconnect" )
+	end
+end )
+
+--- Called when the player disconnects from a HUD component linked to the Starfall Chip
+-- @name huddisconnect
+-- @class hook
+-- @client
+hook.Add( "starfall_hud_disconnect", "huddisconnect", function( instance )
+	if instance then
+		instance:runScriptHook( "huddisconnect" )
+	end
+end )
+
 --- Called before opaque entities are drawn. (Only works with HUD)
 -- @name predrawopaquerenderables
 -- @class hook
@@ -1213,6 +1233,11 @@ function render_library.traceSurfaceColor( vec1, vec2 )
 	SF.CheckType( vec2, vector_meta )
 
 	return vwrap( render.GetSurfaceColor( vunwrap( vec1 ), vunwrap( vec2 ) ) )
+end
+
+--- Checks if a hud component is connected to the Starfall Chip
+function render_library.isHUDConnected()
+	return SF.instance:isHUDConnected()
 end
 
 --- Called when a player uses the screen

--- a/lua/starfall/libs_sh/input.lua
+++ b/lua/starfall/libs_sh/input.lua
@@ -109,29 +109,21 @@ local cursor = {}
 function input_methods.enableCursor( enabled )
 	SF.CheckType( enabled, "boolean" )
 	SF.Permissions.check( SF.instance.player, nil, "input" )
-	
-	local foundlink
-	for hud, _ in pairs( SF.ConnectedHuds ) do
-		if hud.link == SF.instance.data.entity then
-			foundlink = hud
-			break
-		end
-	end
-	
-	if not foundlink then
+		
+	if not SF.instance:isHUDConnected() then
 		SF.throw( "No HUD component connected", 2 )
 		return
 	end
 	
-	cursor[ foundlink ] = enabled
+	cursor[ SF.instance ] = enabled
 	gui.EnableScreenClicker( enabled )
 end
 
-hook.Add( "starfall_hud_disconnect", "starfall_disable_cursor", function( hud )
-	if cursor[ hud ] then
+hook.Add( "starfall_hud_disconnect", "starfall_disable_cursor", function( inst )
+	if cursor[ inst ] then
 		gui.EnableScreenClicker( false )
 	end
-	cursor[ hud ] = nil
+	cursor[ inst ] = nil
 end )
 
 function CheckButtonPerms(instance, ply, button)


### PR DESCRIPTION
I couldn't really split this up into multiple commits, as to change one thing I had to change it all.

Being checking HUD connections was used more than once, I made an instance function `Instance:isHUDConnected()` that checks if a HUD is connected. 
I changed `input.enableCursor( enable )` to use this method.

Added two hooks, `hudconnect` and `huddisconnect` as well as `render.isHUDConnected()` to check if a HUD component is connected to the processor.