### PR TITLE
Change wiremod forums link to discord server

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,8 +1,5 @@
 Starfall Scripting Environment
 ----------
 
-- Development Thread: [`http://www.wiremod.com/forum/developers-showcase/22739-starfall-processor.html`](http://www.wiremod.com/forum/developers-showcase/22739-starfall-processor.html?goto=newpost).
-- Documentation: [`http://thegrb93.github.io/Starfall/`](http://thegrb93.github.io/StarfallEx/).
-
-----------
-
+- Development Thread: [`https://discord.gg/QTPgtk2`](https://discord.gg/QTPgtk2)
+- Documentation: [`http://thegrb93.github.io/Starfall/`](http://thegrb93.github.io/StarfallEx/)


### PR DESCRIPTION
The wiremod forums got shutdown and the link doesn't lead to the
thread anymore.
Community stuff happens now on the discord server.