### PR TITLE
Fixed clipboard pasting on linux

### DIFF
--- a/lua/starfall/editor.lua
+++ b/lua/starfall/editor.lua
@@ -480,7 +480,12 @@ if CLIENT then
 		html:AddFunction( "console", "copyClipboard", function( code )
 			timer.Simple(0, function() SetClipboardText( code ) end)
 		end)
-		
+
+		html:AddFunction( "console", "doValidation", SF.Editor.doValidation)
+
+		html:AddFunction( "console", "fixConsole",function() if system.IsWindows() and tobool( GetConVarNumber( "sf_editor_fixconsolebug" ) ) then gui.ActivateGameUI() end end)
+
+				
 		local tabs = util.JSONToTable( file.Read( "sf_tabs.txt" ) or "" )
 			
 		local function FinishedLoadingEditor()

--- a/lua/starfall/editor.lua
+++ b/lua/starfall/editor.lua
@@ -469,7 +469,9 @@ if CLIENT then
 		html:DockMargin( 5, 59, 5, 5 )
 		html:SetKeyboardInputEnabled( true )
 		html:SetMouseInputEnabled( true )
-		html:SetAllowLua( true )
+		if not system.IsLinux() then --Editor isnt running any code on linux through RUNLUA, but it causes errors while pasting from clipboard set outside of editor. (Temporary fix)
+			html:SetAllowLua( true )
+		end
 		html:OpenURL( editorUrl )
 		html:AddFunction( "console", "copyCode", function( code )
 			SF.Editor.getActiveTab().code = code


### PR DESCRIPTION
Fix works only on linux, tested it a bit and I didnt see any bugs caused by disabling RUNLUA: feature, also editor runs lua only on windows and mac anyway.
Fixes #159 