### PR TITLE
Remove useless CRC checks

### DIFF
--- a/lua/starfall/libs_cl/joystick.lua
+++ b/lua/starfall/libs_cl/joystick.lua
@@ -1,11 +1,6 @@
 
 if file.Exists("lua/bin/gmcl_joystick_win32.dll", "GAME") then
-	if util.CRC(file.Read("bin/gmcl_joystick_win32.dll", "LUA"))=="2665158387" then
-		require("joystick")
-	else
-		ErrorNoHalt("CRC check for gmcl_joystick_win32.dll failed.")
-		return
-	end
+	require("joystick")
 else
 	return
 end


### PR DESCRIPTION
DLLs compiled with GCC, mingw, etc wont work with Starfall otherwise.
If youre up to stopping clients from injecting cheats with Starfall, its useless, due to easy bypassers avalibility.