### PR TITLE
Fixed #169

### DIFF
--- a/lua/starfall/libs_sh/hook.lua
+++ b/lua/starfall/libs_sh/hook.lua
@@ -105,7 +105,7 @@ function hook_library.run ( hookname, ... )
 	if tbl[1] then
 		return unpack( tbl, 2 )
 	else
-		SF.throw("Hook errored",2)
+		return
 	end
 end
 


### PR DESCRIPTION
runScriptHook provides error checking itself, so there is no need for that + it prevents from hook.run("foo") when there is no hook named "foo"