### PR TITLE
Fix starfall editor particle effect

### DIFF
--- a/lua/starfall/editor/editor.lua
+++ b/lua/starfall/editor/editor.lua
@@ -161,6 +161,7 @@ if CLIENT then
 
 	function SF.Editor.close ()
 		SF.Editor.editor:Close()
+		RunConsoleCommand( "starfall_event", "editor_close" )
 	end
 
 	function SF.Editor.getCode ()


### PR DESCRIPTION
When you close the starfall editor the particle effect above your head does not disappear. The bug was probably introduced in commit 955125e663cc3f443bcb2e7a6623e8d6f1ee84b3.