### PR TITLE
Save/Reload fixes

### DIFF
--- a/lua/starfall/editor/editor.lua
+++ b/lua/starfall/editor/editor.lua
@@ -811,6 +811,7 @@ if CLIENT then
 		end )
 	concommand.Add( "sf_editor_reload", function()
 		if not SF.Editor.initialized then return end
+		SF.Editor.editor:Close()
 		for k, v in pairs(SF.Editor.TabHandlers) do
 			if v.cleanup then v:cleanup() end
 		end

--- a/lua/starfall/editor/tabhandlers/tab_wire.lua
+++ b/lua/starfall/editor/tabhandlers/tab_wire.lua
@@ -270,8 +270,8 @@ function TabHandler:registerSettings()
 	local FontSizeSelect = vgui.Create("DComboBox", temp)
 	FontSizeSelect.OnSelect = function(panel, index, value)
 		value = value:gsub(" %b()", "")
-		self:ChangeFont(self.FontConVar:GetString(), tonumber(value))
-		RunConsoleCommand("wire_expression2_editor_font_size", value)
+		RunConsoleCommand("sf_editor_wire_fontsize", value)
+		RunConsoleCommand("sf_editor_reload")
 	end
 	for i = 11, 26 do
 		FontSizeSelect:AddChoice(i .. (i == 16 and " (Default)" or ""))


### PR DESCRIPTION
- Tabs wont be saved unless they were previously loaded
- Font changing works again
- sf_reload_editor saves tabs now, so you wont lose changes after changing settings
- Autosave doesnt use autosave.txt, instead it just saves all tabs
- TL;DR, settings work, you wont lose your progress even if game crashes