### PR TITLE
Run hooks for editor Open, Close, and CodeChanged

### DIFF
--- a/lua/starfall/editor/sfframe.lua
+++ b/lua/starfall/editor/sfframe.lua
@@ -1445,6 +1445,7 @@ function Editor:Open(Line, code, forcenewtab)
 		return
 	end
 	if Line then self:LoadFile(Line, forcenewtab) return end
+	hook.Run("StarfallEditorOpen")
 end
 
 function Editor:SaveFile(Line, close, SaveAs)
@@ -1554,6 +1555,7 @@ function Editor:Close()
 
 		RunConsoleCommand("starfall_processor_ScriptModel", model or "")
 	end 
+	hook.Run("StarfallEditorClose")
 end
 
 function Editor:Setup(nTitle, nLocation, nEditorType)

--- a/lua/starfall/editor/tabhandlers/tab_ace.lua
+++ b/lua/starfall/editor/tabhandlers/tab_ace.lua
@@ -334,6 +334,7 @@ function TabHandler:init() -- It's caled when editor is initalized, you can crea
 
 	html:AddFunction( "console", "copyCode", function( code )
 			currentSession.code = code
+			hook.Run( "StarfallEditorCodeChanged", code )
 		end)
 	html:AddFunction( "console", "copyClipboard", function( code )
 			timer.Simple(0, function() SetClipboardText( code ) end)


### PR DESCRIPTION
On our server we wanted to detect when you change text in the SF editor for a chat-over-head kind of thing.