### PR TITLE
Fixed Ace highlighting

### DIFF
--- a/lua/starfall/editor/tabhandlers/tab_ace.lua
+++ b/lua/starfall/editor/tabhandlers/tab_ace.lua
@@ -97,6 +97,7 @@ end
 local function createLibraryMap ()
 
 	local libMap, libs = {}, {}
+	local libsLookup = {}
 
 	libMap[ "Environment" ] = {}
 	for name, val in pairs( SF.DefaultEnvironment ) do
@@ -114,14 +115,42 @@ local function createLibraryMap ()
 		end
 	end
 
+	for lib, tbl in pairs( SF.Libraries.libraries ) do --Constants/enums aren't present in docs ATM
+		table.insert( libs, lib ) -- Highlight library name
+		libsLookup[ lib ] = true
+		libMap[ lib ] = {}
+
+		for name, val in pairs( tbl ) do
+			local fullname = lib .. "\\." .. name
+
+			if libsLookup[ fullname ] then continue end
+			libsLookup[ fullname ] = true
+
+			table.insert( libMap[ lib ], name )
+			table.insert( libs, fullname )
+		end
+	end
+
 	--Gathering data from docs
 	for lib, tbl in pairs( SF.Docs.libraries ) do
 		if not isstring(lib) then continue end -- We gotta skip numberics
+
+		if not libsLookup[ lib ] then
+			table.insert( libs, lib )
+			libsLookup[ lib ] = true
+		end
+
 		libMap[ lib ] = {}
+
 		for name, val in pairs( tbl.functions ) do
 			if not isstring(name) then continue end -- We gotta skip numberics
+
+			local fullname = lib .. "\\." .. name
+			if libsLookup[ fullname ] then continue end
+			libsLookup[ fullname ] = true
+
 			table.insert( libMap[ lib ], name )
-			table.insert( libs, lib.."\\."..name )
+			table.insert( libs, fullname )
 		end
 	end
 


### PR DESCRIPTION
Now the Ace editor highlights built-in library functions (**math.cos** for example), libraries and enums

![sf_fix_highlight](https://user-images.githubusercontent.com/7669876/28888786-93ad4792-77ca-11e7-9641-97568ab3d5f7.png)