### PR TITLE
Added local capabilities to includedir/requiredir

### DIFF
--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -656,12 +656,19 @@ function SF.DefaultEnvironment.requiredir(dir, loadpriority)
 	SF.CheckLuaType(dir, TYPE_STRING)
 	if loadpriority then SF.CheckLuaType(loadpriority, TYPE_TABLE) end
 	
+	local path
+	if string.sub(dir, 1, 1)=="/" then
+		path = SF.NormalizePath(dir)
+	else
+		path = SF.NormalizePath(string.GetPathFromFilename(string.sub(debug.getinfo(2, "S").source, 5)) .. dir)
+	end
+
 	local returns = {}
 
 	if loadpriority then
 		for i = 1, #loadpriority do
 			for file, _ in pairs(SF.instance.scripts) do
-				if string.find(file, dir .. "/" .. loadpriority[i] , 1) == 1 then
+				if string.find(file, path .. "/" .. loadpriority[i] , 1) == 1 then
 					returns[file] = SF.DefaultEnvironment.require(file)
 				end
 			end
@@ -669,7 +676,7 @@ function SF.DefaultEnvironment.requiredir(dir, loadpriority)
 	end
 
 	for file, _ in pairs(SF.instance.scripts) do
-		if string.find(file, dir, 1) == 1 and not returns[file] then
+		if string.find(file, path, 1) == 1 and not returns[file] then
 			returns[file] = SF.DefaultEnvironment.require(file)
 		end
 	end

--- a/lua/starfall/preprocessor.lua
+++ b/lua/starfall/preprocessor.lua
@@ -139,7 +139,8 @@ local function directive_includedir(args, filename, data)
 
 	local incl = data.includes[filename]
 	args = string.Trim(args)
-	local files = file.Find("starfall/" ..args.. "/*", "DATA")
+	local path = string.GetPathFromFilename(filename)
+	local files = file.Find("starfall/"..path..args.. "/*", "DATA")
 	if files then
 		for _, v in pairs(files) do
 			incl[#incl + 1] = args .. "/" .. v


### PR DESCRIPTION
Fix might be required for support for original behavior without a preceding '/'

For example, `requiredir "test"` would've originally searched for `starfall/test/*`, whereas now it will search for `<running directory>/test/*`