### PR TITLE
Fix javascriptSafe exploit

### DIFF
--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -218,7 +218,12 @@ string_methods.gfind = string.gfind
 string_methods.gmatch = string.gmatch
 string_methods.gsub = string.gsub
 string_methods.implode = string.Implode string_methods.Implode = string.Implode
-string_methods.javascriptSafe = string.JavascriptSafe string_methods.JavascriptSafe = string.JavascriptSafe
+local function javascriptSafe(str)
+	SF.CheckLuaType(str, TYPE_STRING)
+
+	return string.JavascriptSafe(str)
+end
+string_methods.javascriptSafe = javascriptSafe string_methods.JavascriptSafe = javascriptSafe
 string_methods.left = string.Left string_methods.Left = string.Left
 string_methods.len = string.len
 string_methods.lower = string.lower


### PR DESCRIPTION
Since there is no typechecking in `string.javascriptSafe` it's possible to pass a table instead of a string. This allows you to get a reference to [`javascript_escape_replacements`](https://github.com/Facepunch/garrysmod/blob/master/garrysmod/lua/includes/extensions/string.lua#L22) by having a a custom gsub function in the passed table. Then its possible to load any javascript in the ace editor when a file is loaded (or other places) by escaping the replacements.