### PR TITLE
Allow getPhysicsObject to return PhysObj of the world entity

### DIFF
--- a/lua/starfall/libs_sh/entities.lua
+++ b/lua/starfall/libs_sh/entities.lua
@@ -315,7 +315,7 @@ end
 -- @return The number of physics objects on the entity
 function ents_methods:getPhysicsObjectCount()
 	local ent = eunwrap(self)
-	if not isValid(ent) then SF.Throw("Entity is not valid.", 2) end
+	if not isValid(ent) and ent ~= game.GetWorld() then SF.Throw("Entity is not valid.", 2) end
 	return ent:GetPhysicsObjectCount()
 end
 
@@ -323,7 +323,7 @@ end
 -- @return The main physics object of the entity
 function ents_methods:getPhysicsObject()
 	local ent = eunwrap(self)
-	if not isValid(ent) then SF.Throw("Entity is not valid.", 2) end
+	if not isValid(ent) and ent ~= game.GetWorld() then SF.Throw("Entity is not valid.", 2) end
 	return pwrap(ent:GetPhysicsObject())
 end
 
@@ -333,7 +333,7 @@ end
 function ents_methods:getPhysicsObjectNum(id)
 	SF.CheckLuaType(id, TYPE_NUMBER)
 	local ent = eunwrap(self)
-	if not isValid(ent) then SF.Throw("Entity is not valid.", 2) end
+	if not isValid(ent) and ent ~= game.GetWorld() then SF.Throw("Entity is not valid.", 2) end
 	return pwrap(ent:GetPhysicsObjectNum(id))
 end
 


### PR DESCRIPTION
IsValid returns **false** for the world entity, but it has valid physics object.