### PR TITLE
Added render.setCullMode

### DIFF
--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -128,10 +128,11 @@ local MATRIX_STACK_LIMIT = 8
 local matrix_stack = {}
 local view_matrix_stack = {}
 
-local globalRTs = {}
-local globalRTcount = 0
 local plyRTcount = {}
 local plyURLTexcount = {}
+local globalRTcount = 0
+local globalRTs = {}
+for i = 0, 10 do globalRTs[2^i] = {} end -- from 1 to 1024
 
 local renderhooks = {
 	render = true,
@@ -171,6 +172,7 @@ SF.Libraries.AddHook("cleanup", function (instance, hook)
 	if renderhooks[hook] then
 		render.OverrideDepthEnable(false, false)
 		render.SetScissorRect(0, 0, 0, 0, false)
+		render.CullMode(MATERIAL_CULLMODE_CCW)
 		for i = #matrix_stack, 1, -1 do
 			cam.PopModelMatrix()
 			matrix_stack[i] = nil
@@ -209,7 +211,7 @@ end)
 
 SF.Libraries.AddHook("deinitialize", function (instance)
 	for k, v in pairs(instance.data.render.rendertargets) do
-		globalRTs[v][2] = true -- mark as available
+		globalRTs[v.size][v.rtname][2] = true -- mark as available
 	end
 	for k, v in pairs(instance.data.render.textures) do
 		instance.data.render.textures[k] = nil
@@ -744,10 +746,24 @@ function render_library.setTexture (id)
 end
 
 --- Creates a new render target to draw onto.
--- The dimensions will always be 1024x1024
+-- Default dimensions is 1024x1024
 -- @param name The name of the render target
-function render_library.createRenderTarget (name)
+-- @param size Optional rendertarget size, up to 1024. Must be a power of 2
+function render_library.createRenderTarget (name, size)
 	SF.CheckLuaType(name, TYPE_STRING)
+
+	if size == nil then
+		size = 1024
+	else
+		SF.CheckLuaType(size, TYPE_NUMBER)
+
+		if size >= 1 then
+			local nearestPower = math.Round(math.log(math.min(size, 1024), 2))
+			size = 2^nearestPower
+		else
+			SF.Throw("Invalid rendertarget size.", 2)
+		end
+	end
 
 	local instance = SF.instance
 	local data = instance.data.render
@@ -765,21 +781,21 @@ function render_library.createRenderTarget (name)
 	data.rendertargetcount = data.rendertargetcount + 1
 
 	local rtname, rt
-	for k, v in pairs(globalRTs) do
+	for k, v in pairs(globalRTs[size]) do
 		if v[2] then rtname, rt = k, v break end
 	end
 	if rt then
 		rt[2] = false
 	else
 		globalRTcount = globalRTcount + 1
-		rtname = "Starfall_CustomRT_" .. globalRTcount
-		rt = { GetRenderTarget(rtname, 1024, 1024), false }
+		rtname = "Starfall_CustomRT_" .. globalRTcount .. "_" .. size
+		rt = { GetRenderTarget(rtname, size, size), false }
 		rt[3] = CreateMaterial("StarfallCustomModel_"..globalRTcount, "VertexLitGeneric", { ["$model"] = 1 })
 		rt[3]:SetTexture("$basetexture", rt[1])
-		globalRTs[rtname] = rt
+		globalRTs[size][rtname] = rt
 	end
 
-	data.rendertargets[name] = rtname
+	data.rendertargets[name] = {rtname = rtname, size = size}
 end
 
 --- Releases the rendertarget. Required if you reach the maximum rendertargets.
@@ -787,9 +803,9 @@ end
 function render_library.destroyRenderTarget(name)
 	local instance = SF.instance
 	local data = instance.data.render
-	local rtname = data.rendertargets[name]
-	if rtname then
-		globalRTs[rtname][2] = true
+	local rtinfo = data.rendertargets[name]
+	if rtinfo then
+		globalRTs[rtinfo.size][rtinfo.rtname][2] = true
 		data.rendertargets[name] = nil
 	else
 		SF.Throw("Cannot destroy an invalid rendertarget.", 2)
@@ -805,16 +821,16 @@ function render_library.selectRenderTarget (name)
 	if name then
 		SF.CheckLuaType(name, TYPE_STRING)
 
-		local rtname = data.rendertargets[name]
-		if not rtname then SF.Throw("Invalid Rendertarget", 2) end
-		local rttbl = globalRTs[rtname]
+		local rtinfo = data.rendertargets[name]
+		if not rtinfo then SF.Throw("Invalid Rendertarget", 2) end
+		local rttbl = globalRTs[rtinfo.size][rtinfo.rtname]
 		if not rttbl then SF.Throw("Invalid Rendertarget", 2) end
 		local rt = rttbl[1]
 		if not rt then SF.Throw("Invalid Rendertarget", 2) end
 
 		if not data.usingRT then
 			data.oldViewPort = { 0, 0, ScrW(), ScrH() }
-			render.SetViewPort(0, 0, 1024, 1024)
+			render.SetViewPort(0, 0, rtinfo.size, rtinfo.size)
 			cam.Start2D()
 			view_matrix_stack[#view_matrix_stack + 1] = "End2D"
 			render.SetStencilEnable(false)
@@ -854,9 +870,9 @@ function render_library.setRenderTargetTexture (name)
 	if not data.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	SF.CheckLuaType(name, TYPE_STRING)
 
-	local rtname = data.rendertargets[name]
-	if rtname and globalRTs[rtname] then
-		RT_Material:SetTexture("$basetexture", globalRTs[rtname][1])
+	local rtinfo = data.rendertargets[name]
+	if rtinfo and globalRTs[rtinfo.size][rtinfo.rtname] then
+		RT_Material:SetTexture("$basetexture", globalRTs[rtinfo.size][rtinfo.rtname][1])
 		surface.SetMaterial(RT_Material)
 		render.SetMaterial(RT_Material)
 	else
@@ -871,9 +887,9 @@ function render_library.getRenderTargetMaterial(name)
 	local data = SF.instance.data.render
 	SF.CheckLuaType(name, TYPE_STRING)
 
-	local rtname = data.rendertargets[name]
-	if rtname and globalRTs[rtname] then
-		return "!"..globalRTs[rtname][3]:GetName()
+	local rtinfo = data.rendertargets[name]
+	if rtinfo and globalRTs[rtinfo.size][rtinfo.rtname] then
+		return "!"..globalRTs[rtinfo.size][rtinfo.rtname][3]:GetName()
 	end
 end
 
@@ -912,6 +928,19 @@ function render_library.setFilterMin(val)
 	end
 	SF.instance.data.render.changedFilterMin = true
 	render.PushFilterMin(val)
+end
+
+--- Changes the cull mode
+-- @param mode Cull mode. 0 for counter clock wise, 1 for clock wise
+function render_library.setCullMode(mode)
+	if not SF.instance.data.render.isRendering then SF.Throw("Not in a rendering hook.", 2) end
+	SF.CheckLuaType(mode, TYPE_NUMBER)
+
+	if mode >= 0 and mode <= 1 then
+		render.CullMode(mode)
+	else
+		render.CullMode(MATERIAL_CULLMODE_CCW)
+	end
 end
 
 --- Clears the active render target

--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -934,13 +934,8 @@ end
 -- @param mode Cull mode. 0 for counter clock wise, 1 for clock wise
 function render_library.setCullMode(mode)
 	if not SF.instance.data.render.isRendering then SF.Throw("Not in a rendering hook.", 2) end
-	SF.CheckLuaType(mode, TYPE_NUMBER)
 
-	if mode >= 0 and mode <= 1 then
-		render.CullMode(mode)
-	else
-		render.CullMode(MATERIAL_CULLMODE_CCW)
-	end
+	render.CullMode(mode == 1 and 1 or 0)
 end
 
 --- Clears the active render target

--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -896,6 +896,8 @@ end
 -- @param ang The angles that should be translated from the current to the new system
 -- @param newSystemOrigin The origin of the system to translate to
 -- @param newSystemAngles The angles of the system to translate to
+-- @return localPos
+-- @return localAngles
 function SF.DefaultEnvironment.worldToLocal(pos, ang, newSystemOrigin, newSystemAngles)
 	SF.CheckType(pos, SF.Types["Vector"])
 	SF.CheckType(ang, SF.Types["Angle"])
@@ -917,6 +919,8 @@ end
 -- @param localAng The angle that should be converted to a world angle
 -- @param originPos The origin point of the source coordinate system, in world coordinates
 -- @param originAngle The angles of the source coordinate system, as a world angle
+-- @return worldPos
+-- @return worldAngles
 function SF.DefaultEnvironment.localToWorld(localPos, localAng, originPos, originAngle)
 	SF.CheckType(localPos, SF.Types["Vector"])
 	SF.CheckType(localAng, SF.Types["Angle"])


### PR DESCRIPTION
Added **render.setCullMode**. Cull mode is reset to _MATERIAL_CULLMODE_CCW_ in cleanup hook, so render can not be broken.