### PR TITLE
Removed unnecessary type check

### DIFF
--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -371,7 +371,6 @@ function render_library.clearBuffersObeyStencil(r, g, b, a, depth)
 	SF.CheckLuaType(g, TYPE_NUMBER)
 	SF.CheckLuaType(b, TYPE_NUMBER)
 	SF.CheckLuaType(a, TYPE_NUMBER)
-	SF.CheckLuaType(depth, TYPE_NUMBER)
 
 	local renderdata = SF.instance.data.render
 	if not renderdata.usingRT then  SF.Throw("Stencil operations are allowed only inside RenderTarget!") end


### PR DESCRIPTION
Depth argument of [render.ClearBuffersObeyStencil](http://wiki.garrysmod.com/page/render/ClearBuffersObeyStencil) is optional and uses a boolean value.