### PR TITLE
Add getPhysMaterial

### DIFF
--- a/lua/starfall/libs_sv/entities.lua
+++ b/lua/starfall/libs_sv/entities.lua
@@ -837,8 +837,6 @@ function ents_methods:getPhysMaterial()
 	local phys = getPhysObject(ent)
 	if not phys then SF.Throw("Entity has no physics object or is not valid", 2) end
 	
-	SF.Permissions.check(SF.instance.player, ent, "entities.setMass")
-	
 	return phys:GetMaterial()
 end
 

--- a/lua/starfall/libs_sv/entities.lua
+++ b/lua/starfall/libs_sv/entities.lua
@@ -828,6 +828,20 @@ function ents_methods:setPhysMaterial(mat)
 	construct.SetPhysProp(nil, ent, 0, phys, { Material = mat })
 end
 
+--- Get the physical material of the entity
+-- @return the physical material
+function ents_methods:getPhysMaterial()
+	SF.CheckType(self, ents_metatable)
+	local ent = unwrap(self)
+
+	local phys = getPhysObject(ent)
+	if not phys then SF.Throw("Entity has no physics object or is not valid", 2) end
+	
+	SF.Permissions.check(SF.instance.player, ent, "entities.setMass")
+	
+	return phys:GetMaterial()
+end
+
 --- Checks whether entity has physics
 -- @return True if entity has physics
 function ents_methods:isValidPhys()


### PR DESCRIPTION
Since we are able to set the physical material from an entity directly, why can't we get it ? 