### PR TITLE
Overriding Permissions at a glance

### DIFF
--- a/lua/entities/starfall_processor/cl_init.lua
+++ b/lua/entities/starfall_processor/cl_init.lua
@@ -128,3 +128,23 @@ net.Receive("starfall_processor_link", function()
 		component:LinkEnt(proc)
 	end
 end)
+
+net.Receive( 'starfall_processor_used', function ( len )
+	local chip = net.ReadEntity()
+	local activator = net.ReadEntity()
+	if not IsValid( chip ) then return end
+	if chip.link then chip = chip.link end
+
+	if IsValid( chip ) then
+
+		if not chip.instance then return end
+		chip.instance:runScriptHook( 'starfallused', SF.Entities.Wrap( activator ) )
+
+		if activator == LocalPlayer() then
+			if chip.instance.permissionRequest and chip.instance.permissionRequest.showOnUse and not SF.Permissions.permissionRequestSatisfied( chip.instance ) then
+				local pnl = vgui.Create( 'SFChipPermissions' )
+				if pnl then pnl:OpenForChip( chip ) end
+			end
+		end
+	end
+end )

--- a/lua/entities/starfall_processor/shared.lua
+++ b/lua/entities/starfall_processor/shared.lua
@@ -133,7 +133,7 @@ properties.Add( "starfall", {
 	Filter = function( self, ent, ply )
 		if not IsValid( ent ) then return false end
 		if not gamemode.Call( "CanProperty", ply, "starfall", ent ) then return false end
-		return ent.Starfall or ent.link and ent.link.GetClass() == 'starfall_screen'
+		return ent.Starfall or ent.link and ent.link.Starfall
 	end,
 	MenuOpen = MenuOpen,
 	Action = function ( self, ent ) end

--- a/lua/entities/starfall_processor/shared.lua
+++ b/lua/entities/starfall_processor/shared.lua
@@ -17,9 +17,9 @@ ENT.States          = {
 	None = 3,
 }
 
-function ENT:Compile( owner, files, mainfile )
+function ENT:Compile(owner, files, mainfile)
 	if self.instance then
-		self.instance:runScriptHook( "removed" )
+		self.instance:runScriptHook("removed")
 		self.instance:deinitialize()
 		self.instance = nil
 	end
@@ -34,18 +34,18 @@ function ENT:Compile( owner, files, mainfile )
 		self:SendCode()
 	end
 
-	local ok, instance = SF.Instance.Compile( files, mainfile, owner, { entity = self } )
-	if not ok then self:Error( instance ) return end
+	local ok, instance = SF.Instance.Compile(files, mainfile, owner, { entity = self })
+	if not ok then self:Error(instance) return end
 
-	if instance.ppdata.scriptnames and instance.mainfile and instance.ppdata.scriptnames[ instance.mainfile ] then
-		self.name = tostring( instance.ppdata.scriptnames[instance.mainfile] )
+	if instance.ppdata.scriptnames and instance.mainfile and instance.ppdata.scriptnames[instance.mainfile] then
+		self.name = tostring(instance.ppdata.scriptnames[instance.mainfile])
 	end
 
 	self.instance = instance
-	instance.runOnError = function( inst, ... )
+	instance.runOnError = function(inst, ...)
 		-- Have to make sure it's valid because the chip can be deleted before deinitialization and trigger errors
 		if self:IsValid() then
-			self:Error( ... )
+			self:Error(...)
 		end
 	end
 	instance.data.userdata = self.starfalluserdata
@@ -56,39 +56,39 @@ function ENT:Compile( owner, files, mainfile )
 
 	if SERVER then
 		local clr = self:GetColor()
-		self:SetColor( Color( 255, 255, 255, clr.a ) )
-		self:SetNWInt( "State", self.States.Normal )
+		self:SetColor(Color(255, 255, 255, clr.a))
+		self:SetNWInt("State", self.States.Normal)
 
 		if self.Inputs then
-			for k, v in pairs( self.Inputs ) do
-				self:TriggerInput( k, v.Value )
+			for k, v in pairs(self.Inputs) do
+				self:TriggerInput(k, v.Value)
 			end
 		end
 	end
 
 	--TriggerInput can cause self.instance to become nil
 	if self.instance then
-		self.instance:runScriptHook( "initialize" )
+		self.instance:runScriptHook("initialize")
 	end
 end
 
-function ENT:Error( err )
+function ENT:Error(err)
 	self.error = err
 
 	local msg = err.message
 	local traceback = err.traceback
 
 	if SERVER then
-		self:SetNWInt( "State", self.States.Error )
-		self:SetColor( Color(255, 0, 0, 255) )
-		self:SetDTString( 0, traceback or msg )
+		self:SetNWInt("State", self.States.Error)
+		self:SetColor(Color(255, 0, 0, 255))
+		self:SetDTString(0, traceback or msg)
 	end
 
-	local newline = string.find( msg, "\n" )
+	local newline = string.find(msg, "\n")
 	if newline then
-		msg = string.sub( msg, 1, newline - 1 )
+		msg = string.sub(msg, 1, newline - 1)
 	end
-	SF.AddNotify( self.owner, msg, "ERROR", 7, "ERROR1" )
+	SF.AddNotify(self.owner, msg, "ERROR", 7, "ERROR1")
 
 	if self.instance then
 		self.instance:deinitialize()
@@ -96,10 +96,10 @@ function ENT:Error( err )
 	end
 
 	if SERVER then
-		SF.Print( self.owner, traceback )
+		SF.Print(self.owner, traceback)
 	else
-		print( msg )
-		print( traceback )
+		print(msg)
+		print(traceback)
 	end
 end
 
@@ -107,21 +107,21 @@ local function MenuOpen( ContextMenu, Option, Entity, Trace )
 	local ent = Entity
 	if Entity:GetClass() == 'starfall_screen' then ent = ent.link end
 	local SubMenu = Option:AddSubMenu()
-	SubMenu:AddOption( "Restart Clientside", function ()
+	SubMenu:AddOption("Restart Clientside", function ()
 		ent:Restart()
-	end )
-	SubMenu:AddOption( "Terminate Clientside", function ()
+	end)
+	SubMenu:AddOption("Terminate Clientside", function ()
 		ent:Terminate()
-	end )
-	SubMenu:AddOption( "Open Global Permissions", function ()
+	end)
+	SubMenu:AddOption("Open Global Permissions", function ()
 		SF.Editor.openPermissionsPopup()
-	end )
+	end)
 	if ent.instance then
-		if ent.instance.permissionRequest and table.Count( ent.instance.permissionRequest.overrides ) or table.Count( ent.instance.permissionOverrides ) then
-			SubMenu:AddOption( "Overriding Permissions", function ()
-				local pnl = vgui.Create( "SFChipPermissions" )
-				if pnl then pnl:OpenForChip( ent ) end
-			end )
+		if ent.instance.permissionRequest and table.Count(ent.instance.permissionRequest.overrides) or table.Count(ent.instance.permissionOverrides) then
+			SubMenu:AddOption("Overriding Permissions", function ()
+				local pnl = vgui.Create("SFChipPermissions")
+				if pnl then pnl:OpenForChip(ent) end
+			end)
 		end
 	end
 end

--- a/lua/entities/starfall_screen/cl_init.lua
+++ b/lua/entities/starfall_screen/cl_init.lua
@@ -10,35 +10,6 @@ surface.CreateFont("Starfall_ErrorFont", {
 	weight = 200
 })
 
-net.Receive("starfall_processor_used", function (len) --This should probbably be in starfall_chip instead of starfall_screen file
-	local chip = net.ReadEntity()
-	local activator = net.ReadEntity()
-	if not IsValid(chip) then return end
-	if chip.link then chip = chip.link end
-
-	if IsValid(chip) then
-
-		if chip.instance then
-			chip.instance:runScriptHook("starfallused", SF.Entities.Wrap(activator))
-		end
-
-		-- Error message copying
-		if activator == LocalPlayer() then
-			if chip.instance and chip.instance.permissionRequest and chip.instance.permissionRequest.showOnUse then
-				local pnl = vgui.Create("SFChipPermissions")
-				if pnl then
-					pnl:OpenForChip(chip)
-				end
-			end
-			if chip.error and chip.error.message then
-				SetClipboardText(string.format("%q", chip.error.message))
-			elseif chip:GetDTString(0) then
-				SetClipboardText(chip:GetDTString(0))
-			end
-		end
-	end
-end)
-
 function ENT:Initialize ()
 	self.BaseClass.Initialize(self)
 

--- a/lua/starfall/editor/sfderma.lua
+++ b/lua/starfall/editor/sfderma.lua
@@ -787,9 +787,9 @@ function PANEL:OpenForChip( chip )
 	self.chip = chip
 	self.entIcon:SetModel( chip:GetModel(), chip:GetSkin() )
 	local rad = chip:GetModelRadius()
-	self.entIcon:SetCamPos( Vector( rad * math.sqrt( 2 ), rad * math.sqrt( 2 ), rad * 2 ) )
+	self.entIcon:SetCamPos( Vector( rad * 1.4, rad * 1.4, rad * 2 ) )
 	self.entIcon:SetLookAng( Angle( 135, 45, 180 ) )
-	self.entIcon:SetTooltip( tostring( chip ) )
+	self.entIcon:SetTooltip( tostring( chip ) .. '\nOwner: ' .. chip.owner:GetName() )
 	self.entName:SetText( #chip.name > 0 and chip.name or 'Starfall Processor' )
 	local desc = chip.instance.permissionRequest.description
 	self.description:SetText( #desc > 0 and desc or 'Please press "Grant" couple times. Then press "Apply Permissions", so this way we can provide you with interesting features.' )
@@ -798,7 +798,6 @@ function PANEL:OpenForChip( chip )
 	self:MakePopup()
 	self:ParentToHUD()
 	self:Center()
-	--self:MoveBy( 200, 0, 1 )
 
 	self.overrides = {}
 	if chip.instance.permissionOverrides then

--- a/lua/starfall/editor/sfderma.lua
+++ b/lua/starfall/editor/sfderma.lua
@@ -789,11 +789,11 @@ function PANEL:OpenForChip( chip )
 	local rad = chip:GetModelRadius()
 	self.entIcon:SetCamPos( Vector( rad * 1.4, rad * 1.4, rad * 2 ) )
 	self.entIcon:SetLookAng( Angle( 135, 45, 180 ) )
-	self.entIcon:SetTooltip( tostring( chip ) .. '\nOwner: ' .. chip.owner:GetName() )
+	self.entIcon:SetTooltip( 'Entity ID: ' .. chip:EntIndex() .. '\n\nOwner:\n' .. chip.owner:GetName() .. ' [ ' .. chip.owner:SteamID() .. ' ]' )
 	self.entName:SetText( #chip.name > 0 and chip.name or 'Starfall Processor' )
 	local desc = chip.instance.permissionRequest.description
-	self.description:SetText( #desc > 0 and desc or 'Please press "Grant" couple times. Then press "Apply Permissions", so this way we can provide you with interesting features.' )
-	self.description:SetTooltip( string.format( 'Description provided by owner.\nName: %s\nSteamID: %s', chip.owner:GetName(), chip.owner:SteamID() ) )
+	self.description:SetText( #desc > 0 and desc or 'Please press "Grant" a couple of times. Then press "Apply Permissions", so this way we can provide you with interesting features.' )
+	self.description:SetTooltip( 'Description attached to permission request from\n' .. chip.owner:GetName() .. ' [ ' .. chip.owner:SteamID() .. ' ]' )
 	self.ownerAvatar:SetPlayer( chip.owner, self.ownerPanel:GetTall() )
 	self:MakePopup()
 	self:ParentToHUD()
@@ -862,7 +862,7 @@ function PANEL:Init ()
 	notice:SetFont( 'SF_PermissionsWarning' )
 	notice:SetWrap( true )
 	notice:SetDark( true )
-	notice.prefixes = { 'requests additional permissions.', 'may still require some permissions.' }
+	notice.prefixes = { 'requires additional permissions.', 'may still require some permissions.' }
 	notice.update = function ()
 		notice:SetText( notice.prefixes[ self.area ] .. ' They might be useful to touch advanced technologies. There is place for any influence rendered by their features.' )
 	end
@@ -956,7 +956,6 @@ function PANEL:Init ()
 		end
 		grant:SetText( grant.states[ grant.state ].label )
 		grant:SetTooltip( grant.states[ grant.state ].hint )
-		ChangeTooltip( grant )
 		grant:SetColor( grant.states[ grant.state ].color or SF.Editor.colors.meddark )
 		grant:SetHoverColor( grant.states[ grant.state ].hoverColor or SF.Editor.colors.med )
 		grant:SetTextColor( grant.states[ grant.state ].textColor or SF.Editor.colors.light )
@@ -986,6 +985,7 @@ function PANEL:Init ()
 			if grant.state ~= 3 then self.changeOverrides() end
 			self:Close()
 		end
+		ChangeTooltip()
 	end
 
 	local decline = vgui.Create( 'StarfallButton', buttons )

--- a/lua/starfall/editor/sfderma.lua
+++ b/lua/starfall/editor/sfderma.lua
@@ -693,7 +693,7 @@ local function createpermissionsPanel ( parent )
 	for area, set in ipairs( listedPerms ) do
 		local scrollPanel = vgui.Create( 'DScrollPanel', panel )
 		scrollPanel:Dock( FILL )
-		scrollPanel:SetPaintBackgroundEnabled( false )
+		--scrollPanel.Paint = function () end
 		scrollPanel:Clear()
 		for id, _ in SortedPairs( set ) do
 			local permission = SF.Permissions.privileges[ id ]
@@ -778,12 +778,11 @@ local function createpermissionsPanel ( parent )
 			local prev = table.maxn( panel.index[ area ] ) or 0
 			panel.index[ area ][ prev + 1 ] = perm
 		end
-		if area ~= parent.area then scrollPanel:SetVisible( false ) end
 	end
 	return panel
 end
 
-function PANEL:OpenForChip( chip )
+function PANEL:OpenForChip( chip, showOverrides )
 	self.chip = chip
 	self.entIcon:SetModel( chip:GetModel(), chip:GetSkin() )
 	local rad = chip:GetModelRadius()
@@ -803,14 +802,14 @@ function PANEL:OpenForChip( chip )
 	if chip.instance.permissionOverrides then
 		self.overrides = table.Copy( chip.instance.permissionOverrides )
 	end
+	self.satisfied = SF.Permissions.permissionRequestSatisfied( chip.instance )
+	self.area = ( showOverrides or self.satisfied ) and 2 or 1
 
 	local permissions = createpermissionsPanel( self )
 	permissions:SetParent( self )
 	permissions:Dock( FILL )
 	self.permissionsPanel = permissions
 
-	self.satisfied = SF.Permissions.permissionRequestSatisfied( chip.instance )
-	self.area = self.satisfied and 2 or 1
 	self.update()
 	self.changeOverrides = function ()
 		if chip and chip.instance then
@@ -1066,7 +1065,7 @@ function PANEL:Init ()
 		grant.update()
 		decline.update()
 		local sp1 = self.permissionsPanel:GetChild( 0 )
-		local sp2 = self.permissionsPanel:GetChild( 0 )
+		local sp2 = self.permissionsPanel:GetChild( 1 )
 		sp1:SetVisible( self.area == 1 )
 		sp2:SetVisible( self.area == 2 )
 		sp1:GetCanvas():InvalidateLayout( true )

--- a/lua/starfall/editor/sfderma.lua
+++ b/lua/starfall/editor/sfderma.lua
@@ -962,14 +962,14 @@ function PANEL:Init ()
 	end
 	grant.DoClick = function ()
 		if grant.state == 1 then
-			local scrollPanel = self.permissionsPanel:GetChild( 0 )
-			local VBar = scrollPanel:GetVBar()
+			local sp1 = self.permissionsPanel:GetChild( 0 )
+			local VBar = sp1:GetVBar()
 			for i = 1, 2 do
 				for id, perm in ipairs( self.permissionsPanel.index[ 1 ] ) do
 					local x, y = perm:GetPos()
 					if i == 1 then
 						local h = perm:GetTall()
-						if VBar:GetScroll() < y + h * 0.2 and VBar:GetScroll() + scrollPanel:GetTall() > y + 0.8 * h then
+						if VBar:GetScroll() < y + h * 0.2 and VBar:GetScroll() + sp1:GetTall() > y + 0.8 * h then
 							if not perm:GetToggle() then
 								perm:SetToggle( true )
 								perm:OnToggled()
@@ -1065,11 +1065,12 @@ function PANEL:Init ()
 		owner.update()
 		grant.update()
 		decline.update()
-		for n = 0, 3 do
-			local scrollPanel = self.permissionsPanel:GetChild( n % 2 )
-			if n < 2 then scrollPanel:SetVisible( self.area == n + 1 )
-			else scrollPanel:GetCanvas():InvalidateLayout( true ) end
-		end
+		local sp1 = self.permissionsPanel:GetChild( 0 )
+		local sp2 = self.permissionsPanel:GetChild( 0 )
+		sp1:SetVisible( self.area == 1 )
+		sp2:SetVisible( self.area == 2 )
+		sp1:GetCanvas():InvalidateLayout( true )
+		sp2:GetCanvas():InvalidateLayout( true )
 		self:InvalidateLayout( true )
 	end
 end
@@ -1077,9 +1078,7 @@ function PANEL:PerformLayout()
 	if not self.tallAnimation and self.permissionsPanel then
 		-- handle tall change when it's not animated
 		local tall = self:GetTall() - self.permissionsPanel:GetTall()
-		if not self.reservedTall then
-			self:SetTall( tall )
-		end
+		if not self.reservedTall then self:SetTall( tall ) end
 		self.reservedTall = tall
 	end
 end

--- a/lua/starfall/editor/sfderma.lua
+++ b/lua/starfall/editor/sfderma.lua
@@ -786,8 +786,11 @@ end
 function PANEL:OpenForChip( chip )
 	self.chip = chip
 	self.entIcon:SetModel( chip:GetModel(), chip:GetSkin() )
+	local rad = chip:GetModelRadius()
+	self.entIcon:SetCamPos( Vector( rad * math.sqrt( 2 ), rad * math.sqrt( 2 ), rad * 2 ) )
+	self.entIcon:SetLookAng( Angle( 135, 45, 180 ) )
 	self.entIcon:SetTooltip( tostring( chip ) )
-	self.entName:SetText( chip.name )
+	self.entName:SetText( #chip.name > 0 and chip.name or 'Starfall Processor' )
 	local desc = chip.instance.permissionRequest.description
 	self.description:SetText( #desc > 0 and desc or 'Please press "Grant" couple times. Then press "Apply Permissions", so this way we can provide you with interesting features.' )
 	self.description:SetTooltip( string.format( 'Description provided by owner.\nName: %s\nSteamID: %s', chip.owner:GetName(), chip.owner:SteamID() ) )
@@ -795,6 +798,7 @@ function PANEL:OpenForChip( chip )
 	self:MakePopup()
 	self:ParentToHUD()
 	self:Center()
+	--self:MoveBy( 200, 0, 1 )
 
 	self.overrides = {}
 	if chip.instance.permissionOverrides then
@@ -839,10 +843,12 @@ function PANEL:Init ()
 		draw.RoundedBox( 0, 0, 0, w, h, Color( 255, 255, 255 ) )
 	end
 
-	local icon = vgui.Create( 'SpawnIcon', entity )
+	local icon = vgui.Create( 'DModelPanel', entity )
 	icon:Dock( LEFT )
 	icon:DockMargin( 0, 0, 5, 0 )
 	icon:SetSize( 118, 118 )
+	icon:SetFOV( 60 )
+	function icon:LayoutEntity( ent ) end
 	self.entIcon = icon
 
 	local name = vgui.Create( 'DLabel', entity )

--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -205,39 +205,46 @@ if CLIENT then
 	-- @class hook
 	-- @client
 
-	--- Setups permission override request
-	--@param perms Table of permission names to override
-	--@param desc Description attached to request
-	--@param showOnUse If true request will popup when user uses chip
+	--- Setups request for overriding permissions.
+	--@param perms Table of overridable permissions' names.
+	--@param desc Description attached to request.
+	--@param showOnUse Whether request will popup when player uses chip or linked screen.
 	--@client
-	function SF.DefaultEnvironment.setupPermissionRequest(perms, desc, showOnUse)
-		SF.CheckLuaType(desc, TYPE_STRING)
-		SF.CheckLuaType(perms, TYPE_TABLE)
-		showOnUse = showOnUse == true
+	function SF.DefaultEnvironment.setupPermissionRequest( perms, desc, showOnUse )
+		SF.CheckLuaType( desc, TYPE_STRING )
+		SF.CheckLuaType( perms, TYPE_TABLE )
 		local c = #perms
-		local overrides = {}
-		if #desc > 1000 then
-			SF.throw("Description too long!")
+		if #desc > 400 then
+			SF.Throw( "Description too long." )
 		end
-		local P = SF.Permissions
+		local privileges = SF.Permissions.privileges
+		local overrides = {}
 		for I = 1, c do
-			local v = perms[I]
-			if type(v) == "string" then
-				if not P.privileges[v] then
-					SF.Throw("Invalid permission name: "..v)
+			local v = perms[ I ]
+			if type( v ) == "string" then
+				if not privileges[ v ] then
+					SF.Throw( "Invalid permission name: " .. v )
 				end
-				if not P.privileges[v][3].client then
-					SF.Throw("Permission isn't requestable: "..v)
+				if not privileges[ v ][ 3 ].client then
+					SF.Throw( "Permission isn't requestable: " .. v )
 				end
-				overrides[v] = true
+				overrides[ v ] = true
 			end
 		end
 		SF.instance.permissionRequest = {}
 		SF.instance.permissionRequest.overrides = overrides
-		SF.instance.permissionRequest.description = desc
-		SF.instance.permissionRequest.showOnUse = showOnUse
+		SF.instance.permissionRequest.description = string.gsub( desc, '%s+$', '' )
+		SF.instance.permissionRequest.showOnUse = showOnUse == true
 
 	end
+
+	--- Is permission request fully satisfied.
+	--@return Boolean of whether the client gave all permissions specified in last request or not.
+	--@client
+	function SF.DefaultEnvironment.permissionRequestSatisfied()
+		return SF.Permissions.permissionsRequestSatisfied( SF.instance )
+	end
+
 end
 
 -- String library

--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -220,15 +220,15 @@ if CLIENT then
 		local privileges = SF.Permissions.privileges
 		local overrides = {}
 		for I = 1, c do
-			local v = perms[ I ]
-			if type( v ) == "string" then
-				if not privileges[ v ] then
-					SF.Throw( "Invalid permission name: " .. v )
+			local v = perms[I]
+			if type(v) == "string" then
+				if not privileges[v] then
+					SF.Throw("Invalid permission name: "..v)
 				end
-				if not privileges[ v ][ 3 ].client then
-					SF.Throw( "Permission isn't requestable: " .. v )
+				if not privileges[v][3].client then
+					SF.Throw("Permission isn't requestable: "..v)
 				end
-				overrides[ v ] = true
+				overrides[v] = true
 			end
 		end
 		SF.instance.permissionRequest = {}

--- a/lua/starfall/permissions/core.lua
+++ b/lua/starfall/permissions/core.lua
@@ -221,6 +221,17 @@ else
 			net.SendToServer()
 		end
 	end
+	function P.permissionRequestSatisfied( instance )
+		if not instance.permissionRequest then
+			SF.Throw( 'There is no permission request' )
+		end
+		if instance.permissionOverrides then
+			for id, _ in pairs( instance.permissionRequest.overrides ) do
+				if not instance.permissionOverrides[ id ] then return false end
+			end
+			return true
+		else return table.Count( instance.permissionRequest.overrides ) == 0 end
+	end
 	net.Receive("sf_permissionsettings", function()
 		if reqCallback then
 			local providers = {}


### PR DESCRIPTION
Three days of nearly ceaseless coding. Extreme part is usability of **Overring Permissions** panel (a.k.a. "Permissions Override").
But we are also able to:
* see shared context menu between linked processor and screen,
* revoke past overrides,
* open OP panel through context menu and also when the player uses processor/screen and permission request is not satisfied (not all overrides are given).

- [x] [Provide with screenshots.](https://github.com/thegrb93/StarfallEx/pull/345#issuecomment-352715963)
