### PR TITLE
Skip default textentry handler in wire editor

### DIFF
--- a/lua/starfall/editor/tabhandlers/tab_wire.lua
+++ b/lua/starfall/editor/tabhandlers/tab_wire.lua
@@ -268,7 +268,7 @@ function PANEL:Init()
 
 	self.TextEntry.OnLoseFocus = function (self) self.Parent:_OnLoseFocus() end
 	self.TextEntry.OnTextChanged = function (self) self.Parent:_OnTextChanged() end
-	self.TextEntry.OnKeyCodeTyped = function (self, code) self.Parent:_OnKeyCodeTyped(code) end
+	self.TextEntry.OnKeyCodeTyped = function (self, code) return self.Parent:_OnKeyCodeTyped(code) end
 
 	self.TextEntry.Parent = self
 
@@ -1988,6 +1988,7 @@ function PANEL:DuplicateLine()
 end
 
 function PANEL:_OnKeyCodeTyped(code)
+	local handled = true
 	self.Blink = RealTime()
 
 	local alt = input.IsKeyDown(KEY_LALT) or input.IsKeyDown(KEY_RALT)
@@ -2061,6 +2062,8 @@ function PANEL:_OnKeyCodeTyped(code)
 			self:SetCaret({ #self.Rows, 1 })
 		elseif code == KEY_D then
 			self:DuplicateLine()
+		else
+			handled = false
 		end
 
 	else
@@ -2149,6 +2152,8 @@ function PANEL:_OnKeyCodeTyped(code)
 			end
 		elseif code == KEY_F1 then
 			self:ContextHelp()
+		else
+			handled = false
 		end
 	end
 
@@ -2157,7 +2162,7 @@ function PANEL:_OnKeyCodeTyped(code)
 		if mode == 0 or mode == 4 then
 			self.AC_Panel:RequestFocus()
 			if mode == 4 and self.AC_Panel.Selected == 0 then self.AC_Panel.Selected = 1 end
-			return
+			return true
 		end
 	end
 
@@ -2185,14 +2190,17 @@ function PANEL:_OnKeyCodeTyped(code)
 		end
 		-- signal that we want our focus back after (since TAB normally switches focus)
 		if code == KEY_TAB then self.TabFocus = true end
+		handled = true
 	end
 
-	if control then
-		self:OnShortcut(code)
+	if control and not handled then
+		handled = self:OnShortcut(code)
 	end
 	SF.Editor.editor:Validate(false)
 
 	self:AC_Check()
+
+	return handled
 end
 
 ---------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This mirrors wiremod/wire@97166285e04d2747ce4202f3e8426490184d5636 and fixes race conditions between custom and default shortcuts, such as in wiremod/wire#1512, and as starfall uses the wire editor, the issue affects it as well.

Bug reproduction steps:

* Use Linux
* Select code in wire tab using shift+arrowkeys
* Ctrl-C
* Clipboard is now containing invalid data