### PR TITLE
Fixed ConVar not replicating to client.

### DIFF
--- a/lua/starfall/editor/editor.lua
+++ b/lua/starfall/editor/editor.lua
@@ -33,11 +33,10 @@ if CLIENT then
 
 	SF.Editor.CurrentTabHandler = CreateClientConVar("sf_editor_tabeditor", "ace", true, false)
 
-else
-
-	SF.Editor.HelperURL = CreateConVar("sf_editor_helperurl", "http://thegrb93.github.io/StarfallEx/", {FCVAR_ARCHIVE, FCVAR_REPLICATED}, "URL for website used by SF Helper, change to allow custom documentation.")
-
 end
+
+SF.Editor.HelperURL = CreateConVar("sf_editor_helperurl", "http://thegrb93.github.io/StarfallEx/", {FCVAR_ARCHIVE, FCVAR_REPLICATED}, "URL for website used by SF Helper, change to allow custom documentation.")
+
 ------------------
 -- Editor
 --

--- a/lua/starfall/editor/tabhandlers/tab_helper.lua
+++ b/lua/starfall/editor/tabhandlers/tab_helper.lua
@@ -60,7 +60,7 @@ function PANEL:Init() --That's init of VGUI like other PANEL:Methods(), separate
 	html:DockPadding(0, 0, 0, 0)
 	html:SetKeyboardInputEnabled(true)
 	html:SetMouseInputEnabled(true)
-	html:OpenURL(GetConVar("sf_editor_helperurl"):GetString())
+	html:OpenURL(SF.Editor.HelperURL:GetString())
 	timer.Simple(3,function()
 		if not html.loaded then
 			SF.AddNotify(LocalPlayer(), "Your connection seems to be slow or offline, you may try using legacy helper(available from settings).", "GENERIC" , 10, "DRIP2")

--- a/lua/weapons/gmod_tool/stools/starfall_processor.lua
+++ b/lua/weapons/gmod_tool/stools/starfall_processor.lua
@@ -180,7 +180,7 @@ if CLIENT then
 	local lastclick = CurTime()
 	
 	local function GotoDocs(button)
-		gui.OpenURL(GetConVar("sf_editor_helperurl"):GetString())
+		gui.OpenURL(SF.Editor.HelperURL:GetString())
 	end
 	
 	function TOOL.BuildCPanel(panel)


### PR DESCRIPTION
With Starfall installed locally, the convar was on my client, but a player who does not have it installed will be unable to open the editor, as the convar does not exist. Apparently FCVAR_REPLICATED does not create the convar on the client, it just updates it.