### PR TITLE
Fixed casing and removed unused code

### DIFF
--- a/lua/starfall/editor/editor.lua
+++ b/lua/starfall/editor/editor.lua
@@ -196,13 +196,13 @@ if CLIENT then
 		SF.Editor.editor = editor
 
 		for k, v in pairs(SF.Editor.TabHandlers) do
-			if v.init then v:init() end
+			if v.Init then v:Init() end
 		end
 
 		editor:Setup("Starfall Editor", "starfall", "Starfall")
 
 		for k, v in pairs(SF.Editor.TabHandlers) do -- We let TabHandlers register their settings but only if they are current editor or arent editor at all
-			if v.registerSettings and (not v.IsEditor or (v.IsEditor and SF.Editor.CurrentTabHandler:GetString() == k)) then v:registerSettings() end
+			if v.RegisterSettings and (not v.IsEditor or (v.IsEditor and SF.Editor.CurrentTabHandler:GetString() == k)) then v:RegisterSettings() end
 		end
 
 	end
@@ -470,7 +470,7 @@ if CLIENT then
 		if not SF.Editor.initialized then return end
 		SF.Editor.editor:Close()
 		for k, v in pairs(SF.Editor.TabHandlers) do
-			if v.cleanup then v:cleanup() end
+			if v.Cleanup then v:Cleanup() end
 		end
 		SF.Editor.initialized = false
 		SF.Editor.editor:Remove()

--- a/lua/starfall/editor/sfderma.lua
+++ b/lua/starfall/editor/sfderma.lua
@@ -202,202 +202,6 @@ end
 vgui.Register("StarfallPanel", PANEL, "DPanel")
 -- End Starfall Panel
 
---------------------------------------------------------------
---------------------------------------------------------------
-
--- Tab Holder
-PANEL = {}
-
-function PANEL:Init ()
-self:SetTall(22)
-self.offsetTabs = 0
-self.tabs = {}
-
-local parent = self
-
-self.offsetRight = vgui.Create("StarfallButton", self)
-self.offsetRight:SetVisible(false)
-self.offsetRight:SetSize(22, 22)
-self.offsetRight:SetIcon("arrowr")
-function self.offsetRight:PerformLayout ()
-local wide = 0
-if parent.offsetLeft:IsVisible() then
-	wide = parent.offsetLeft:GetWide() + 2
-end
-for i = parent.offsetTabs + 1, #parent.tabs do
-	if wide + parent.tabs[i]:GetWide() > parent:GetWide() - self:GetWide() - 2 then
-		break
-	else
-		wide = wide + parent.tabs[i]:GetWide() + 2
-	end
-end
-self:SetPos(wide, 0)
-end
-function self.offsetRight:DoClick ()
-parent.offsetTabs = parent.offsetTabs + 1
-if parent.offsetTabs > #parent.tabs - 1 then
-	parent.offsetTabs = #parent.tabs - 1
-end
-parent:InvalidateLayout()
-end
-
-self.offsetLeft = vgui.Create("StarfallButton", self)
-self.offsetLeft:SetVisible(false)
-self.offsetLeft:SetSize(22, 22)
-self.offsetLeft:SetIcon("arrowl")
-function self.offsetLeft:DoClick ()
-parent.offsetTabs = parent.offsetTabs - 1
-if parent.offsetTabs < 0 then
-	parent.offsetTabs = 0
-end
-parent:InvalidateLayout()
-end
-
-self.menuoptions = {}
-
-self.menuoptions[#self.menuoptions + 1] = { "Close", function ()
-	if not self.targetTab then return end
-	self:removeTab(self.targetTab)
-	self.targetTab = nil
-	end }
-self.menuoptions[#self.menuoptions + 1] = { "Close Other Tabs", function ()
-		if not self.targetTab then return end
-		local n = 1
-		while #self.tabs ~= 1 do
-			v = self.tabs[n]
-			if v ~= self.targetTab then
-				self:removeTab(v)
-			else
-				n = 2
-			end
-		end
-		self.targetTab = nil
-		end }
-end
-PANEL.Paint = function () end
-function PANEL:PerformLayout ()
-	local parent = self:GetParent()
-	self:SetWide(parent:GetWide() - 10)
-	self.offsetRight:PerformLayout()
-	self.offsetLeft:PerformLayout()
-
-	local offset = 0
-	if self.offsetLeft:IsVisible() then
-		offset = self.offsetLeft:GetWide() + 2
-	end
-	for i = 1, self.offsetTabs do
-		offset = offset - self.tabs[i]:GetWide() - 2
-	end
-	local bool = false
-	for k, v in pairs(self.tabs) do
-		v:SetPos(offset, 0)
-		if offset < 0 then
-			v:SetVisible(false)
-		elseif offset + v:GetWide() > self:GetWide() - self.offsetRight:GetWide() - 2 then
-			v:SetVisible(false)
-			bool = true
-		else
-			v:SetVisible(true)
-		end
-		offset = offset + v:GetWide() + 2
-	end
-
-	if bool then
-		self.offsetRight:SetVisible(true)
-	else
-		self.offsetRight:SetVisible(false)
-	end
-	if self.offsetTabs > 0 then
-		self.offsetLeft:SetVisible(true)
-	else
-		self.offsetLeft:SetVisible(false)
-	end
-end
-function PANEL:addTab (text)
-	local panel = self
-	local tab = vgui.Create("StarfallButton", self)
-	tab:SetText(text)
-	tab.isTab = true
-
-	function tab:DoClick ()
-		panel:selectTab(self)
-	end
-
-	function tab:DoRightClick ()
-		panel.targetTab = self
-		local menu = vgui.Create("DMenu", panel:GetParent())
-		for k, v in pairs(panel.menuoptions) do
-			local option, func = v[1], v[2]
-			if func == "SPACER" then
-				menu:AddSpacer()
-			else
-				menu:AddOption(option, func)
-			end
-		end
-		menu:Open()
-	end
-
-	function tab:DoMiddleClick ()
-		panel:removeTab(self)
-	end
-
-	self.tabs[#self.tabs + 1] = tab
-
-	return tab
-end
-function PANEL:removeTab (tab)
-	local tabIndex
-	if type(tab) == "number" then
-		tabIndex = tab
-		tab = self.tabs[tab]
-	else
-		tabIndex = self:getTabIndex(tab)
-	end
-
-	table.remove(self.tabs, tabIndex)
-	tab:Remove()
-
-	self:OnRemoveTab(tabIndex)
-end
-function PANEL:getActiveTab ()
-	for k, v in pairs(self.tabs) do
-		if v.active then return v end
-	end
-end
-function PANEL:getTabIndex (tab)
-	return table.KeyFromValue(self.tabs, tab)
-end
-function PANEL:selectTab (tab)
-	if type(tab) == "number" then
-		tab = self.tabs[tab]
-	end
-	if tab == nil then return end
-
-	if self:getActiveTab() == tab then return end
-
-	for k, v in pairs(self.tabs) do
-		v.active = false
-	end
-	tab.active = true
-
-	if self:getTabIndex(tab) <= self.offsetTabs then
-		self.offsetTabs = self:getTabIndex(tab) - 1
-	elseif not tab:IsVisible() then
-		while not tab:IsVisible() do
-			self.offsetTabs = self.offsetTabs + 1
-			self:PerformLayout()
-		end
-	end
-end
-function PANEL:OnRemoveTab (tabIndex)
-
-end
-vgui.Register("StarfallTabHolder", PANEL, "DPanel")
--- End Tab Holder
-
---------------------------------------------------------------
---------------------------------------------------------------
-
 -- File Tree
 local invalid_filename_chars = {
 	["*"] = "",
@@ -414,7 +218,7 @@ PANEL = {}
 function PANEL:Init ()
 
 end
-function PANEL:setup (folder)
+function PANEL:Setup (folder)
 	self.folder = folder
 	self.Root = self.RootNode:AddFolder(folder, folder, "DATA", true)
 	--[[Waiting for examples, 10 tries each 1 second]]
@@ -438,7 +242,7 @@ function PANEL:setup (folder)
 	end
 	self.Root:SetExpanded(true)
 end
-function PANEL:reloadTree ()
+function PANEL:ReloadTree ()
 	self.Root:Remove()
 	if self.Examples then
 		self.Examples:Remove()
@@ -446,7 +250,7 @@ function PANEL:reloadTree ()
 	if self.DataFiles then
 		self.DataFiles:Remove()
 	end
-	self:setup(self.folder)
+	self:Setup(self.folder)
 end
 function PANEL:DoRightClick (node)
 	self:openMenu(node)
@@ -648,7 +452,7 @@ function PANEL:Init ()
 		searchBox:SetValue("Search...")
 	end
 end
-function PANEL:getComponents ()
+function PANEL:GetComponents ()
 	return self.searchBox, self.tree
 end
 
@@ -659,7 +463,7 @@ derma.DefineControl("StarfallFileBrowser", "", PANEL, "DPanel")
 
 PANEL = {}
 
-local function createpermissionsPanel ( parent )
+local function CreatePermissionsPanel ( parent )
 	local chip = parent.chip
 	local panel = vgui.Create( 'DPanel', parent )
 	panel:Dock( FILL )
@@ -805,7 +609,7 @@ function PANEL:OpenForChip( chip, showOverrides )
 	self.satisfied = SF.Permissions.permissionRequestSatisfied( chip.instance )
 	self.area = ( showOverrides or self.satisfied ) and 2 or 1
 
-	local permissions = createpermissionsPanel( self )
+	local permissions = CreatePermissionsPanel( self )
 	permissions:SetParent( self )
 	permissions:Dock( FILL )
 	self.permissionsPanel = permissions

--- a/lua/starfall/editor/sfframe.lua
+++ b/lua/starfall/editor/sfframe.lua
@@ -30,7 +30,7 @@ end
 
 local Editor = {}
 
-local function getTabHandler(name)
+local function GetTabHandler(name)
 	return SF.Editor.TabHandlers[name or SF.Editor.CurrentTabHandler:GetString()]
 end
 -- ----------------------------------------------------------------------
@@ -221,10 +221,10 @@ function Editor:OnMousePressed(mousecode)
 		self.p_w, self.p_h = self:GetSize()
 		self.p_mx = gui.MouseX()
 		self.p_my = gui.MouseY()
-		self.p_mode = self:getMode()
+		self.p_mode = self:GetMode()
 		if self.p_mode == "drag" then
 			if self.GuiClick > CurTime() - 0.2 then
-				self:fullscreen()
+				self:Fullscreen()
 				self.pressed = false
 				self.GuiClick = 0
 			else
@@ -278,7 +278,7 @@ function Editor:Think()
 	end
 	if not self.pressed then
 		local cursor = "arrow"
-		local mode = self:getMode()
+		local mode = self:GetMode()
 		if (mode == "sizeBR") then cursor = "sizenwse"
 		elseif (mode == "sizeR") then cursor = "sizewe"
 		elseif (mode == "sizeB") then cursor = "sizens"
@@ -309,7 +309,7 @@ end
 
 -- special functions
 
-function Editor:fullscreen()
+function Editor:Fullscreen()
 	if self.fs then
 		self:SetPos(self.preX, self.preY)
 		self:SetSize(self.preW, self.preH)
@@ -323,7 +323,7 @@ function Editor:fullscreen()
 	end
 end
 
-function Editor:getMode()
+function Editor:GetMode()
 	local x, y = self:GetPos()
 	local w, h = self:GetSize()
 	local ix = gui.MouseX() - x
@@ -343,7 +343,7 @@ function Editor:getMode()
 	end
 end
 
-function Editor:addComponent(panel, x, y, w, h)
+function Editor:AddComponent(panel, x, y, w, h)
 	assert(not panel.Bounds)
 	panel.Bounds = { x = x, y = y, w = w, h = h }
 	self.Components[#self.Components + 1] = panel
@@ -387,11 +387,11 @@ function Editor:GetNumTabs() return #self.C.TabHolder.Items end
 function Editor:UpdateTabText(tab, title)
 	-- Editor subtitle and tab text
 	local ed = tab.content
-	local _, text = getPreferredTitles(ed.chosenfile, ed:getCode())
+	local _, text = getPreferredTitles(ed.chosenfile, ed:GetCode())
 	tabtext = title or text
 	tab:SetToolTip(ed.chosenfile)
 	tabtext = tabtext or "Generic"
-	if not ed:isSaved() then
+	if not ed:IsSaved() then
 		tabtext = tabtext.." *"
 	end
 	if tab:GetText() ~= tabtext then
@@ -458,11 +458,11 @@ function Editor:FixTabFadeTime()
 end
 
 function Editor:CreateTab(chosenfile, forcedTabHandler)
-	local th = getTabHandler(forcedTabHandler)
+	local th = GetTabHandler(forcedTabHandler)
 	local content = vgui.Create(th.ControlName)
 	content.parentpanel = self -- That's going to be Deprecated
-	content.getTabHandler = function() return th end -- add :getTabHandler()
-	content.isSaved = function(self) return (not th.IsEditor) or self:getCode() == self.savedCode or self:getCode() == defaultCode or self:getCode() == "" end
+	content.GetTabHandler = function() return th end -- add :GetTabHandler()
+	content.IsSaved = function(self) return (not th.IsEditor) or self:GetCode() == self.savedCode or self:GetCode() == defaultCode or self:GetCode() == "" end
 	local sheet = self.C.TabHolder:AddSheet(extractNameFromFilePath(chosenfile), content)
 	content.chosenfile = chosenfile
 	sheet.Tab.content = content -- For easy access
@@ -547,15 +547,15 @@ function Editor:CreateTab(chosenfile, forcedTabHandler)
 			end
 			menu:Open()
 			menu:AddSpacer()
-			if th.registerTabMenu then
-				th:registerTabMenu(menu, content)
+			if th.RegisterTabMenu then
+				th:RegisterTabMenu(menu, content)
 			end
 			return
 		end
 
 		self:SetActiveTab(pnl)
 	end
-	if content.getTabHandler().IsEditor then
+	if content.GetTabHandler().IsEditor then
 		content.OnTextChanged = function(panel)
 			self:UpdateTabText(self:GetActiveTab())
 			timer.Create("sfautosave", 5, 1, function()
@@ -627,7 +627,7 @@ function Editor:CloseTab(_tab,dontask)
 		end
 	end
 	local ed = activetab:GetPanel()
-	if not ed:isSaved() and not dontask and not ed.IsOnline then
+	if not ed:IsSaved() and not dontask and not ed.IsOnline then
 		local question = string.format("Do you want to close %q ?", activetab:GetText())
 		Derma_Query(question, "Are you sure?", "Close", function() self:CloseTab(_tab, true) end, "Cancel", function() end)
 		return
@@ -723,13 +723,13 @@ function Editor:InitComponents()
 			end
 		}, "DButton")
 
-	self.C.ButtonHolder = self:addComponent(vgui.Create("DPanel", self), -430-4, 4, 430, 22) -- Upper menu
+	self.C.ButtonHolder = self:AddComponent(vgui.Create("DPanel", self), -430-4, 4, 430, 22) -- Upper menu
 	self.C.ButtonHolder.Paint = function() end
-	-- addComponent( panel, x, y, w, h )
+	-- AddComponent( panel, x, y, w, h )
 	-- if x, y, w, h is minus, it will stay relative to right or buttom border
 	self.C.Close = vgui.Create("StarfallButton", self.C.ButtonHolder) -- Close button
-	-- self.C.Inf = self:addComponent(vgui.CreateFromTable(DMenuButton, self), -45-4-26, 0, 24, 22) -- Info button
-	-- self.C.ConBut = self:addComponent(vgui.CreateFromTable(DMenuButton, self), -45-4-24-26, 0, 24, 22) -- Control panel open/close
+	-- self.C.Inf = self:AddComponent(vgui.CreateFromTable(DMenuButton, self), -45-4-26, 0, 24, 22) -- Info button
+	-- self.C.ConBut = self:AddComponent(vgui.CreateFromTable(DMenuButton, self), -45-4-24-26, 0, 24, 22) -- Control panel open/close
 
 	self.C.Divider = vgui.Create("DHorizontalDivider", self)
 
@@ -751,8 +751,8 @@ function Editor:InitComponents()
 	self.C.Inf = vgui.CreateFromTable(DMenuButton, self.C.Menu) -- Info button
 	self.C.ConBut = vgui.CreateFromTable(DMenuButton, self.C.Menu) -- Control panel button
 
-	self.C.Control = self:addComponent(vgui.Create("Panel", self), -462, 72, 462, -30) -- Control Panel
-	self.C.Credit = self:addComponent(vgui.Create("DTextEntry", self), -160, 52, 150, 200) -- Credit box
+	self.C.Control = self:AddComponent(vgui.Create("Panel", self), -462, 72, 462, -30) -- Control Panel
+	self.C.Credit = self:AddComponent(vgui.Create("DTextEntry", self), -160, 52, 150, 200) -- Credit box
 
 	-- extra component options
 	if Editor.LayoutVar:GetInt() == 1 then -- Browser on right
@@ -1297,7 +1297,7 @@ function Editor:NewScript(incurrent)
 		self.C.TabHolder:InvalidateLayout()
 
 		self:SetCode(defaultCode)
-		self:GetCurrentTabContent().savedCode = self:GetCurrentTabContent():getCode() -- It may return different line endings etc
+		self:GetCurrentTabContent().savedCode = self:GetCurrentTabContent():GetCode() -- It may return different line endings etc
 	end
 end
 
@@ -1316,7 +1316,7 @@ function Editor:SaveTabs()
 	local activeTab = self:GetActiveTabIndex()
 	tabs.selectedTab = activeTab
 	for i = 1, self:GetNumTabs() do
-		if not self:GetTabContent(i):getTabHandler().IsEditor then
+		if not self:GetTabContent(i):GetTabHandler().IsEditor then
 			if tabs.selectedTab == i then
 				tabs.selectedTab = 1
 			end
@@ -1333,7 +1333,7 @@ function Editor:SaveTabs()
 			end
 		end
 		tabs[i].filename = filename
-		tabs[i].code = self:GetTabContent(i):getCode()
+		tabs[i].code = self:GetTabContent(i):GetCode()
 	end
 
 	file.Write("sf_tabs.txt", util.TableToJSON(tabs))
@@ -1371,7 +1371,7 @@ function Editor:OpenOldTabs()
 end
 
 function Editor:Validate(gotoerror)
-	if not self:GetCurrentTabContent():getTabHandler().IsEditor then --Dont validate for non-editors
+	if not self:GetCurrentTabContent():GetTabHandler().IsEditor then --Dont validate for non-editors
 		self:SetValidatorStatus("")
 		return
 	end
@@ -1391,8 +1391,8 @@ function Editor:Validate(gotoerror)
 		self.C.Val:SetText(" " .. message)
 	end
 
-	if self:GetCurrentTabContent().onValidate then
-		self:GetCurrentTabContent():onValidate(success, row, message, gotoerror)
+	if self:GetCurrentTabContent().OnValidate then
+		self:GetCurrentTabContent():OnValidate(success, row, message, gotoerror)
 	end
 	return true
 end
@@ -1453,7 +1453,7 @@ function Editor:ExtractName()
 end
 
 function Editor:SetCode(code)
-	self:GetCurrentTabContent():setCode(code)
+	self:GetCurrentTabContent():SetCode(code)
 	self.savebuffer = self:GetCode()
 	self:Validate()
 	self:ExtractName()
@@ -1461,8 +1461,8 @@ end
 
 function Editor:PasteCode(code)
 	local content = self:GetCurrentTabContent()
-	if not content:getTabHandler().IsEditor or not content.pasteCode then return end
-	content:pasteCode(code)
+	if not content:GetTabHandler().IsEditor or not content.PasteCode then return end
+	content:PasteCode(code)
 end
 
 function Editor:GetTabContent(n)
@@ -1476,7 +1476,7 @@ function Editor:GetCurrentTabContent()
 end
 
 function Editor:GetCode()
-	return self:GetCurrentTabContent():getCode()
+	return self:GetCurrentTabContent():GetCode()
 end
 
 function Editor:Open(Line, code, forcenewtab)
@@ -1489,7 +1489,7 @@ function Editor:Open(Line, code, forcenewtab)
 					self:SetActiveTab(i)
 					self:SetCode(code)
 					return
-				elseif self:GetTabContent(i):getCode() == code then
+				elseif self:GetTabContent(i):GetCode() == code then
 					self:SetActiveTab(i)
 					return
 				end
@@ -1581,7 +1581,7 @@ function Editor:LoadFile(Line, forcenewtab)
 					self:SetActiveTab(i)
 					if forcenewtab ~= nil then self:SetCode(str) end
 					return
-				elseif self:GetTabContent(i):getCode() == str then
+				elseif self:GetTabContent(i):GetCode() == str then
 					self:SetActiveTab(i)
 					return
 				end
@@ -1632,7 +1632,7 @@ function Editor:Setup(nTitle, nLocation, nEditorType)
 	self.Title = nTitle
 	self.Location = nLocation
 	self.EditorType = nEditorType
-	self.C.Browser.tree:setup(nLocation)
+	self.C.Browser.tree:Setup(nLocation)
 
 	local SFHelp = vgui.Create("StarfallButton", self.C.ButtonHolder)
 	SFHelp:SetSize(58, 20)

--- a/lua/starfall/editor/tabhandlers/tab_ace.lua
+++ b/lua/starfall/editor/tabhandlers/tab_ace.lua
@@ -276,7 +276,7 @@ local function fixKeys(key, notfirst)
 
 end
 
-function TabHandler:registerSettings()
+function TabHandler:RegisterSettings()
 
 	--Adding settings
 	local sheet = SF.Editor.editor:AddControlPanelTab("Ace", "icon16/cog.png", "ACE options.")
@@ -335,7 +335,7 @@ function TabHandler:registerSettings()
 
 end
 
-function TabHandler:init() -- It's caled when editor is initalized, you can create library map there etc
+function TabHandler:Init() -- It's caled when editor is initalized, you can create library map there etc
 
 	local html = vgui.Create("DHTML")
 	html:Dock(FILL)
@@ -407,7 +407,7 @@ function TabHandler:init() -- It's caled when editor is initalized, you can crea
 	TabHandler.html:SetVisible(false)
 end
 
-function TabHandler:cleanup() -- It's caled when editor is marked for disposal
+function TabHandler:Cleanup() -- It's caled when editor is marked for disposal
 	print("Cleanup called!")
 	TabHandler.html:Remove()
 	TabHandler.html = nil -- Getting rid of old dhtml
@@ -425,16 +425,16 @@ function PANEL:Init() --That's init of VGUI like other PANEL:Methods(), separate
 	self:SetBackgroundColor(Color(39, 40, 34))
 end
 
-function PANEL:getCode() -- Return name of hanlder or code if it's editor
+function PANEL:GetCode() -- Return name of hanlder or code if it's editor
 	return self.code or ""
 end
 
-function PANEL:pasteCode(code)
+function PANEL:PasteCode(code)
 	if not TabHandler.Loaded then return end
 	runJS("editor.insert(\"" .. code:JavascriptSafe() .. "\")")
 end
 
-function PANEL:setCode(code)
+function PANEL:SetCode(code)
 	self.code = code
 	if TabHandler.Loaded then
 		setSessionValue(self, code)

--- a/lua/starfall/editor/tabhandlers/tab_helper.lua
+++ b/lua/starfall/editor/tabhandlers/tab_helper.lua
@@ -8,10 +8,10 @@ local PANEL = {} -- It's our VGUI
 -- Handler part (Tab Handler)
 -------------------------------
 
-function TabHandler:init() -- It's caled when editor is initalized, you can create library map there etc
+function TabHandler:Init() -- It's caled when editor is initalized, you can create library map there etc
 end
 
-function TabHandler:registerSettings() -- Setting panels should be registered there
+function TabHandler:RegisterSettings() -- Setting panels should be registered there
 
 end
 
@@ -38,7 +38,7 @@ local function htmlSetup(old, new)
 	end
 end
 
-function TabHandler:registerTabMenu(menu, content)
+function TabHandler:RegisterTabMenu(menu, content)
 	menu:AddOption("Undock",function()
 
 
@@ -46,7 +46,7 @@ function TabHandler:registerTabMenu(menu, content)
 	end)
 end
 
-function TabHandler:cleanup() -- Called when editor is reloaded/removed
+function TabHandler:Cleanup() -- Called when editor is reloaded/removed
 end
 
 
@@ -99,11 +99,11 @@ function PANEL:Undock()
 	self:CloseTab()
 end
 
-function PANEL:getCode() -- Return name of hanlder or code if it's editor
+function PANEL:GetCode() -- Return name of hanlder or code if it's editor
 	return "@name "..(self.title or "StarfallEx Reference")
 end
 
-function PANEL:setCode()
+function PANEL:SetCode()
 
 end
 
@@ -111,7 +111,7 @@ function PANEL:OnFocusChanged(gained) -- When this tab is opened
 
 end
 
-function PANEL:validate(movecarret) -- Validate request, has to return success,message
+function PANEL:Validate(movecarret) -- Validate request, has to return success,message
 
 end
 --------------

--- a/lua/weapons/gmod_tool/stools/starfall_processor.lua
+++ b/lua/weapons/gmod_tool/stools/starfall_processor.lua
@@ -211,7 +211,7 @@ if CLIENT then
 
 		local filebrowser = vgui.Create("StarfallFileBrowser")
 		panel:AddPanel(filebrowser)
-		filebrowser.tree:setup("starfall")
+		filebrowser.tree:Setup("starfall")
 		filebrowser:SetSize(235, 400)
 		
 		local lastClick = 0


### PR DESCRIPTION
It needs more testing to see if old casings are still used in some places.

Why?
Editor was big mess when it came to casing, most of it(parts of wire and derma) used functions starting uppercase meanwhile some parts were using lowercase.

Why not lowercase like rest of starfall?
Because it's derma, gmod uses uppercase functions for derma so I think all derma-related stuff should also do it that way.