### PR TITLE
Hud can now popup permission overwrite menu

### DIFF
--- a/lua/entities/starfall_hud/init.lua
+++ b/lua/entities/starfall_hud/init.lua
@@ -61,6 +61,15 @@ end
 
 function ENT:Use(ply)
 	self:SetHudEnabled(ply, -1)
+	
+	if not self.link then return end
+	
+	if ply:IsPlayer() then
+		net.Start("starfall_processor_used")
+			net.WriteEntity(self)
+			net.WriteEntity(ply)
+		net.Broadcast()
+	end
 end
 
 function ENT:LinkEnt (ent, ply)


### PR DESCRIPTION
Hud will now be able to popup permission overwrite menu when pressed use on same as with chip and screen.