### PR TITLE
Fixed error caused by permissionRequestSatisfied

### DIFF
--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -242,7 +242,7 @@ if CLIENT then
 	--@return Boolean of whether the client gave all permissions specified in last request or not.
 	--@client
 	function SF.DefaultEnvironment.permissionRequestSatisfied()
-		return SF.Permissions.permissionsRequestSatisfied( SF.instance )
+		return SF.Permissions.permissionRequestSatisfied( SF.instance )
 	end
 
 end


### PR DESCRIPTION
Fixed error caused by permissionRequestSatisfied
errored with: addons/starfallex/lua/starfall/libs_sh/builtins.lua:245: attempt to call field 'permissionsRequestSatisfied' (a nil value)