### PR TITLE
Editor cleanup, server and client permissions have separate tabs now

### DIFF
--- a/lua/starfall/editor/sfderma.lua
+++ b/lua/starfall/editor/sfderma.lua
@@ -8,7 +8,6 @@ PANEL.windows = {}
 SF.Editor.ShowExamplesVar = CreateClientConVar("sf_editor_showexamples", "1", true, false)
 SF.Editor.ShowDataFilesVar = CreateClientConVar("sf_editor_showdatafiles", "0", true, false)
 
-
 --[[ Loading SF Examples ]]
 
 if SF.Editor.ShowExamplesVar:GetBool() then
@@ -923,3 +922,82 @@ function PANEL:Paint( w, h )
 	draw.RoundedBox( 0, 0, 0, w, h, SF.Editor.colors.dark )
 end
 vgui.Register( "SFChipPermissions", PANEL, "DFrame" )
+
+-- End Instance Permissions
+
+--------------------------------------------------------------
+--------------------------------------------------------------
+
+-- Starfall Permissions (Global)
+
+PANEL  = {}
+function PANEL:AddProviders(providers, server)
+	for _, p in pairs(providers) do
+		local header = vgui.Create("DLabel", header)
+		header:SetFont("DermaLarge")
+		header:SetColor(Color(255, 255, 255))
+		header:SetText((server and "[Server] " or "[Client] ")..p.name)
+		header:SetSize(0, 40)
+		header:Dock(TOP)
+		self.scrollPanel:AddItem(header)
+
+		for id, setting in SortedPairs(p.settings) do
+
+			local header = vgui.Create("StarfallPanel")
+			header:DockMargin(0, 5, 0, 0)
+			header:SetSize(0, 20)
+			header:Dock(TOP)
+			header:SetToolTip(id)
+			header:SetBackgroundColor(Color(0,0,0,20))
+
+			local settingtext = vgui.Create("DLabel", header)
+			settingtext:SetFont("DermaDefault")
+			settingtext:SetColor(Color(255, 255, 255))
+			settingtext:SetText(id)
+			settingtext:DockMargin(5, 0, 0, 0)
+			settingtext:Dock(LEFT)
+			settingtext:SizeToContents()
+
+			local description = vgui.Create("DLabel", header)
+			description:SetFont("DermaDefault")
+			description:SetColor(Color(128, 128, 128))
+			description:SetText(" - "..setting[2])
+			description:DockMargin(5, 0, 0, 0)
+			description:Dock(FILL)
+
+			local buttons = {}
+			for i,option in pairs(p.settingsoptions) do
+				local button = vgui.Create("StarfallButton", header)
+				button:SetText(option)
+				button:DockMargin(0, 0, 3, 0)
+				button:Dock(RIGHT)
+				button.active = setting[3]==i
+
+				button.DoClick = function(self)
+					RunConsoleCommand(server and "sf_permission" or "sf_permission_cl", id, p.id, i)
+					for _, b in ipairs(buttons) do
+						b.active = false
+					end
+					self.active = true
+				end
+				buttons[i] = button
+			end
+
+			self.scrollPanel:AddItem(header)
+
+		end
+	end
+end
+function PANEL:Clear()
+	self.scrollPanel:Clear()
+end
+function PANEL:Init()
+
+	self.scrollPanel = vgui.Create("DScrollPanel", self)
+	self.scrollPanel:Dock(FILL)
+	self.scrollPanel:SetPaintBackgroundEnabled(false)
+end
+function PANEL:Paint(w,h)
+
+end
+vgui.Register( "StarfallPermissions", PANEL, "DPanel" )

--- a/lua/starfall/editor/sfframe.lua
+++ b/lua/starfall/editor/sfframe.lua
@@ -1037,12 +1037,15 @@ function Editor:GetSettings()
 
 	AddCategory(dlist, "Editor", "icon16/application_side_tree.png", "Options for the editor itself.")
 
-	------ Permissions panel
-	local perms = SF.Editor.createpermissionsPanel ()
-	perms:Refresh()
+	------ Client Permissions panel
+	local perms = SF.Editor.createGlobalPermissionsPanel(true, false)
+	AddCategory(perms, "Permissions [Client]", "icon16/tick.png", "Permission settings.")
 
-	AddCategory(perms, "Permissions", "icon16/tick.png", "Permission settings.")
-
+	------ Server Permissions panel
+	if LocalPlayer():IsSuperAdmin() then
+		local perms = SF.Editor.createGlobalPermissionsPanel(false, true)
+		AddCategory(perms, "Permissions [Server]", "icon16/tick.png", "Permission settings.")
+	end
 	------ Themes panel
 	local themesPanel = self:CreateThemesPanel()
 	themesPanel:Refresh()

--- a/lua/starfall/editor/tabhandlers/tab_ace.lua
+++ b/lua/starfall/editor/tabhandlers/tab_ace.lua
@@ -13,6 +13,23 @@ local PANEL = {} -- It's our VGUI
 ----------------
 -- Handler part
 ----------------
+
+CreateClientConVar("sf_editor_ace_wordwrap", 1, true, false)
+CreateClientConVar("sf_editor_ace_widgets", 1, true, false)
+CreateClientConVar("sf_editor_ace_linenumbers", 1, true, false)
+CreateClientConVar("sf_editor_ace_gutter", 1, true, false)
+CreateClientConVar("sf_editor_ace_invisiblecharacters", 0, true, false)
+CreateClientConVar("sf_editor_ace_indentguides", 1, true, false)
+CreateClientConVar("sf_editor_ace_activeline", 1, true, false)
+CreateClientConVar("sf_editor_ace_autocompletion", 1, true, false)
+CreateClientConVar("sf_editor_ace_liveautocompletion", 0, true, false)
+CreateClientConVar("sf_editor_ace_fixkeys", system.IsLinux() and 1 or 0, true, false) --maybe osx too? need someone to check
+CreateClientConVar("sf_editor_ace_fixconsolebug", 0, true, false)
+CreateClientConVar("sf_editor_ace_disablelinefolding", 0, true, false)
+CreateClientConVar("sf_editor_ace_keybindings", "ace", true, false)
+CreateClientConVar("sf_editor_ace_fontsize", 13, true, false)
+
+
 TabHandler.SessionTabs = {}
 TabHandler.DisableThemeSupport = CreateClientConVar("sf_editor_ace_disablethemesupport", "0", true, false)
 

--- a/lua/starfall/editor/tabhandlers/tab_settings.lua
+++ b/lua/starfall/editor/tabhandlers/tab_settings.lua
@@ -56,7 +56,9 @@ function PANEL:Init() --That's init of VGUI like other PANEL:Methods(), separate
 		end
 		categories[cat].panel:SetVisible(true)
 	end
-	for name, data in pairs(categories) do
+
+	for name, data in SortedPairs(categories) do
+		local data = categories[name] -- SortedPairs uses copy of the table
 		local button = vgui.Create("StarfallButton")
 		button.PerformLayout = EMPTY_FUNC
 		button:SetSize(200,40)


### PR DESCRIPTION
Dunno if that change to permissions(cache) is fine.
In general I started cleaning up editor lately because it has a lot of messy code and whole permission thing was like that before. 
Now permissions have their separate derma panel that can be filled with providers with pre-cached settings(because otherwise provider contains no information what privilages it manages and privilages can be modified by other addons by changing their providers etc).