### PR TITLE
Only send code that has changed

### DIFF
--- a/lua/entities/starfall_processor/cl_init.lua
+++ b/lua/entities/starfall_processor/cl_init.lua
@@ -117,6 +117,11 @@ net.Receive("starfall_processor_download", function (len)
 		I = I + 1
 	end
 
+	if I == 0 then
+		dlProc:Compile(dlOwner, dlFiles, dlMain)
+		dlProc.restarting = false
+	end
+
 	dlNumFiles.Completed = 0
 	dlNumFiles.NumFiles = I
 end)

--- a/lua/entities/starfall_processor/cl_init.lua
+++ b/lua/entities/starfall_processor/cl_init.lua
@@ -98,6 +98,7 @@ net.Receive("starfall_processor_download", function (len)
 
 	if not dlProc:IsValid() or not dlOwner:IsValid() then return end
 	dlProc.owner = dlOwner
+	dlProc.files = dlProc.files or {}
 
 	local I = 0
 	while I < 256 do
@@ -113,8 +114,9 @@ net.Receive("starfall_processor_download", function (len)
 		net.ReadStream(nil, function(data)
 			dlNumFiles.Completed = dlNumFiles.Completed + 1
 			dlFiles[filename] = data or ""
+			dlProc.files[filename] = data or ""
 			if dlProc:IsValid() and dlOwner:IsValid() and dlNumFiles.Completed == dlNumFiles.NumFiles then
-				dlProc:Compile(dlOwner, dlFiles, dlMain)
+				dlProc:Compile(dlOwner, dlProc.files, dlMain)
 				dlProc.restarting = false
 			end
 		end)

--- a/lua/entities/starfall_processor/cl_init.lua
+++ b/lua/entities/starfall_processor/cl_init.lua
@@ -101,7 +101,12 @@ net.Receive("starfall_processor_download", function (len)
 
 	local I = 0
 	while I < 256 do
-		if net.ReadBit() ~= 0 then break end
+		if net.ReadBit() ~= 0 then
+			if I == 0 then
+				dlProc:Compile(dlOwner, dlProc.files, dlMain)
+			end
+			break
+		end
 
 		local filename = net.ReadString()
 

--- a/lua/entities/starfall_processor/cl_init.lua
+++ b/lua/entities/starfall_processor/cl_init.lua
@@ -114,7 +114,7 @@ net.Receive("starfall_processor_download", function (len)
 		net.ReadStream(nil, function(data)
 			dlNumFiles.Completed = dlNumFiles.Completed + 1
 			dlFiles[filename] = data or ""
-			dlProc.files[filename] = data or ""
+			if dlProc:IsValid() then dlProc.files[filename] = data or "" end
 			if dlProc:IsValid() and dlOwner:IsValid() and dlNumFiles.Completed == dlNumFiles.NumFiles then
 				dlProc:Compile(dlOwner, dlProc.files, dlMain)
 				dlProc.restarting = false

--- a/lua/entities/starfall_processor/cl_init.lua
+++ b/lua/entities/starfall_processor/cl_init.lua
@@ -98,25 +98,18 @@ net.Receive("starfall_processor_download", function (len)
 
 	if not dlProc:IsValid() or not dlOwner:IsValid() then return end
 	dlProc.owner = dlOwner
-	dlProc.files = dlProc.files or {}
 
 	local I = 0
 	while I < 256 do
-		if net.ReadBit() ~= 0 then
-			if I == 0 then
-				dlProc:Compile(dlOwner, dlProc.files, dlMain)
-			end
-			break
-		end
+		if net.ReadBit() ~= 0 then break end
 
 		local filename = net.ReadString()
 
 		net.ReadStream(nil, function(data)
 			dlNumFiles.Completed = dlNumFiles.Completed + 1
 			dlFiles[filename] = data or ""
-			if dlProc:IsValid() then dlProc.files[filename] = data or "" end
 			if dlProc:IsValid() and dlOwner:IsValid() and dlNumFiles.Completed == dlNumFiles.NumFiles then
-				dlProc:Compile(dlOwner, dlProc.files, dlMain)
+				dlProc:Compile(dlOwner, dlFiles, dlMain)
 				dlProc.restarting = false
 			end
 		end)

--- a/lua/entities/starfall_processor/init.lua
+++ b/lua/entities/starfall_processor/init.lua
@@ -27,24 +27,18 @@ util.AddNetworkString("starfall_processor_update_links")
 util.AddNetworkString("starfall_processor_used")
 util.AddNetworkString("starfall_processor_link")
 
-function ENT:SendCode (recipient, filesToSend)
+function ENT:SendCode (recipient)
 	net.Start("starfall_processor_download")
 	net.WriteEntity(self)
 	net.WriteEntity(self.owner)
 	net.WriteString(self.mainfile)
 
-	if not filesToSend then
-		for name, code in pairs(self.files) do
-			net.WriteBit(false)
-			net.WriteString(name)
-			net.WriteStream(code)
-		end
-	else
-		for i, name in ipairs(filesToSend) do
-			net.WriteBit(false)
-			net.WriteString(name)
-			net.WriteStream(self.files[name] or ".")
-		end
+	for name, data in pairs(self.files) do
+
+		net.WriteBit(false)
+		net.WriteString(name)
+		net.WriteStream(data)
+
 	end
 
 	net.WriteBit(true)

--- a/lua/entities/starfall_processor/init.lua
+++ b/lua/entities/starfall_processor/init.lua
@@ -34,7 +34,7 @@ function ENT:SendCode (recipient, allFiles)
 	net.WriteString(self.mainfile)
 
 	if not allFiles then
-		for i, name in ipairs(self.newlyUploadedFiles) do
+		for i, name in ipairs(self.filesToSend) do
 			net.WriteBit(false)
 			net.WriteString(name)
 			net.WriteStream(self.files[name])

--- a/lua/entities/starfall_processor/init.lua
+++ b/lua/entities/starfall_processor/init.lua
@@ -27,23 +27,23 @@ util.AddNetworkString("starfall_processor_update_links")
 util.AddNetworkString("starfall_processor_used")
 util.AddNetworkString("starfall_processor_link")
 
-function ENT:SendCode (recipient, allFiles)
+function ENT:SendCode (recipient, filesToSend)
 	net.Start("starfall_processor_download")
 	net.WriteEntity(self)
 	net.WriteEntity(self.owner)
 	net.WriteString(self.mainfile)
 
-	if not allFiles then
-		for i, name in ipairs(self.filesToSend) do
-			net.WriteBit(false)
-			net.WriteString(name)
-			net.WriteStream(self.files[name])
-		end
-	else
+	if not filesToSend then
 		for name, code in pairs(self.files) do
 			net.WriteBit(false)
 			net.WriteString(name)
 			net.WriteStream(code)
+		end
+	else
+		for i, name in ipairs(filesToSend) do
+			net.WriteBit(false)
+			net.WriteString(name)
+			net.WriteStream(self.files[name])
 		end
 	end
 
@@ -68,7 +68,7 @@ net.Receive("starfall_processor_download", function(len, ply)
 	local proc = net.ReadEntity()
 	if ply:IsValid() and proc:IsValid() then
 		if proc.mainfile and proc.files then
-			proc:SendCode(ply, true)
+			proc:SendCode(ply)
 		else
 			proc.SendQueue = proc.SendQueue or {}
 			proc.SendQueue[#proc.SendQueue + 1] = ply

--- a/lua/entities/starfall_processor/init.lua
+++ b/lua/entities/starfall_processor/init.lua
@@ -27,13 +27,13 @@ util.AddNetworkString("starfall_processor_update_links")
 util.AddNetworkString("starfall_processor_used")
 util.AddNetworkString("starfall_processor_link")
 
-function ENT:SendCode (recipient)
+function ENT:SendCode (updatefiles, recipient)
 	net.Start("starfall_processor_download")
 	net.WriteEntity(self)
 	net.WriteEntity(self.owner)
 	net.WriteString(self.mainfile)
 
-	for name, data in pairs(self.files) do
+	for name, data in pairs(updatefiles) do
 
 		net.WriteBit(false)
 		net.WriteString(name)

--- a/lua/entities/starfall_processor/init.lua
+++ b/lua/entities/starfall_processor/init.lua
@@ -43,7 +43,7 @@ function ENT:SendCode (recipient, filesToSend)
 		for i, name in ipairs(filesToSend) do
 			net.WriteBit(false)
 			net.WriteString(name)
-			net.WriteStream(self.files[name])
+			net.WriteStream(self.files[name] or ".")
 		end
 	end
 

--- a/lua/entities/starfall_processor/shared.lua
+++ b/lua/entities/starfall_processor/shared.lua
@@ -24,13 +24,14 @@ function ENT:Compile(owner, files, mainfile)
 		self.instance = nil
 	end
 
-	self.files = self.files or {}
-	self.filesToSend = {}
+	local filesToSend = {}
+	if SERVER then
+		self.files = self.files or {}
 
-	-- Determine which files have changed and is to be sent to other players
-	for filename, code in pairs(files) do
-		if code ~= (self.files[filename] or "_DOES_NOT_EXIST_") then
-			table.insert(self.filesToSend, filename)
+		for filename, code in pairs(files) do
+			if code ~= (self.files[filename] or "_DOES_NOT_EXIST_") then
+				table.insert(filesToSend, filename)
+			end
 		end
 	end
 
@@ -42,7 +43,7 @@ function ENT:Compile(owner, files, mainfile)
 
 	if SERVER then
 		if update then
-			self:SendCode()
+			self:SendCode(nil, filesToSend)
 		elseif self.SendQueue then
 			self:SendCode(self.SendQueue)
 			self.SendQueue = nil

--- a/lua/entities/starfall_processor/shared.lua
+++ b/lua/entities/starfall_processor/shared.lua
@@ -29,7 +29,7 @@ function ENT:Compile(owner, files, mainfile)
 
 	-- Determine which files have changed and is to be sent to other players
 	for filename, code in pairs(files) do
-		if util.CRC(code) ~= util.CRC(self.files[filename] or "_DOES_NOT_EXIST_") then
+		if code ~= (self.files[filename] or "_DOES_NOT_EXIST_") then
 			table.insert(self.filesToSend, filename)
 		end
 	end

--- a/lua/entities/starfall_processor/shared.lua
+++ b/lua/entities/starfall_processor/shared.lua
@@ -24,8 +24,12 @@ function ENT:Compile(owner, files, mainfile)
 		self.instance = nil
 	end
 
-	-- Remove unused files
+	local update = self.mainfile ~= nil
+	self.error = nil
+	self.mainfile = mainfile
 	self.files = self.files or {}
+	self.owner = owner
+
 	for filename, code in pairs(files) do
 		if code == "-removed-" then
 			self.files[filename] = nil
@@ -34,21 +38,16 @@ function ENT:Compile(owner, files, mainfile)
 		end
 	end
 
-	local update = self.mainfile ~= nil
-	self.error = nil
-	self.mainfile = mainfile
-	self.owner = owner
-
 	if SERVER then
 		if update then
-			self:SendCode()
+			self:SendCode(files)
 		elseif self.SendQueue then
-			self:SendCode(self.SendQueue)
+			self:SendCode(files, self.SendQueue)
 			self.SendQueue = nil
 		end
 	end
 
-	local ok, instance = SF.Instance.Compile(files, mainfile, owner, { entity = self })
+	local ok, instance = SF.Instance.Compile(self.files, mainfile, owner, { entity = self })
 	if not ok then self:Error(instance) return end
 
 	if instance.ppdata.scriptnames and instance.mainfile and instance.ppdata.scriptnames[instance.mainfile] then

--- a/lua/entities/starfall_processor/shared.lua
+++ b/lua/entities/starfall_processor/shared.lua
@@ -17,22 +17,11 @@ ENT.States          = {
 	None = 3,
 }
 
-function ENT:Compile(owner, files, mainfile)
+function ENT:Compile(owner, files, mainfile, filesToSend)
 	if self.instance then
 		self.instance:runScriptHook("removed")
 		self.instance:deinitialize()
 		self.instance = nil
-	end
-
-	local filesToSend = {}
-	if SERVER then
-		self.files = self.files or {}
-
-		for filename, code in pairs(files) do
-			if code ~= (self.files[filename] or "_DOES_NOT_EXIST_") then
-				table.insert(filesToSend, filename)
-			end
-		end
 	end
 
 	local update = self.mainfile ~= nil

--- a/lua/entities/starfall_processor/shared.lua
+++ b/lua/entities/starfall_processor/shared.lua
@@ -25,12 +25,12 @@ function ENT:Compile(owner, files, mainfile)
 	end
 
 	self.files = self.files or {}
-	self.newlyUploadedFiles = {}
+	self.filesToSend = {}
 
 	-- Determine which files have changed and is to be sent to other players
 	for filename, code in pairs(files) do
 		if util.CRC(code) ~= util.CRC(self.files[filename] or "_DOES_NOT_EXIST_") then
-			table.insert(self.newlyUploadedFiles, filename)
+			table.insert(self.filesToSend, filename)
 		end
 	end
 

--- a/lua/entities/starfall_processor/shared.lua
+++ b/lua/entities/starfall_processor/shared.lua
@@ -24,6 +24,14 @@ function ENT:Compile(owner, files, mainfile, filesToSend)
 		self.instance = nil
 	end
 
+	-- Remove unused files
+	for filename, code in pairs(files) do
+		if filename[1] == "-" then
+			files[filename] = nil
+			files[filename:sub(2)] = nil
+		end
+	end
+
 	local update = self.mainfile ~= nil
 	self.error = nil
 	self.files = files
@@ -39,7 +47,7 @@ function ENT:Compile(owner, files, mainfile, filesToSend)
 		end
 	end
 
-	local ok, instance = SF.Instance.Compile(files, mainfile, owner, { entity = self })
+	local ok, instance = SF.Instance.Compile(self.files, mainfile, owner, { entity = self })
 	if not ok then self:Error(instance) return end
 
 	if instance.ppdata.scriptnames and instance.mainfile and instance.ppdata.scriptnames[instance.mainfile] then

--- a/lua/entities/starfall_processor/shared.lua
+++ b/lua/entities/starfall_processor/shared.lua
@@ -24,6 +24,16 @@ function ENT:Compile(owner, files, mainfile)
 		self.instance = nil
 	end
 
+	self.files = self.files or {}
+	self.newlyUploadedFiles = {}
+
+	-- Determine which files have changed and is to be sent to other players
+	for filename, code in pairs(files) do
+		if util.CRC(code) ~= util.CRC(self.files[filename] or "_DOES_NOT_EXIST_") then
+			table.insert(self.newlyUploadedFiles, filename)
+		end
+	end
+
 	local update = self.mainfile ~= nil
 	self.error = nil
 	self.files = files

--- a/lua/entities/starfall_processor/shared.lua
+++ b/lua/entities/starfall_processor/shared.lua
@@ -17,7 +17,7 @@ ENT.States          = {
 	None = 3,
 }
 
-function ENT:Compile(owner, files, mainfile, filesToSend)
+function ENT:Compile(owner, files, mainfile)
 	if self.instance then
 		self.instance:runScriptHook("removed")
 		self.instance:deinitialize()
@@ -25,29 +25,30 @@ function ENT:Compile(owner, files, mainfile, filesToSend)
 	end
 
 	-- Remove unused files
+	self.files = self.files or {}
 	for filename, code in pairs(files) do
-		if filename[1] == "-" then
-			files[filename] = nil
-			files[filename:sub(2)] = nil
+		if code == "-removed-" then
+			self.files[filename] = nil
+		else
+			self.files[filename] = code
 		end
 	end
 
 	local update = self.mainfile ~= nil
 	self.error = nil
-	self.files = files
 	self.mainfile = mainfile
 	self.owner = owner
 
 	if SERVER then
 		if update then
-			self:SendCode(nil, filesToSend)
+			self:SendCode()
 		elseif self.SendQueue then
 			self:SendCode(self.SendQueue)
 			self.SendQueue = nil
 		end
 	end
 
-	local ok, instance = SF.Instance.Compile(self.files, mainfile, owner, { entity = self })
+	local ok, instance = SF.Instance.Compile(files, mainfile, owner, { entity = self })
 	if not ok then self:Error(instance) return end
 
 	if instance.ppdata.scriptnames and instance.mainfile and instance.ppdata.scriptnames[instance.mainfile] then

--- a/lua/starfall/sflib.lua
+++ b/lua/starfall/sflib.lua
@@ -596,17 +596,6 @@ if SERVER then
 			return
 		end
 
-		local function combine(a, b)
-			local out = {}
-			for key, value in pairs(a) do
-				out[key] = value
-			end
-			for key, value in pairs(b) do
-				out[key] = value
-			end
-			return out
-		end
-
 		updata.mainfile = net.ReadString()
 		local sf = net.ReadEntity()
 
@@ -614,7 +603,7 @@ if SERVER then
 		while I < 256 do
 			if net.ReadBit() ~= 0 then
 				if I == 0 then
-					updata.callback(updata.mainfile, sf.files)
+					updata.callback(updata.mainfile, sf.files, {})
 				end
 				break
 			end
@@ -630,8 +619,8 @@ if SERVER then
 				updata.files[filename] = data
 
 				if updata.Completed == updata.NumFiles then
-					local filesToCompile = (sf:IsValid() and sf.instance) and combine(sf.files or {}, updata.files) or updata.files
-					updata.callback(updata.mainfile, filesToCompile)
+					local filesToCompile = (sf:IsValid() and sf.instance) and table.Merge(sf.files or {}, updata.files) or updata.files
+					updata.callback(updata.mainfile, filesToCompile, table.GetKeys(updata.files))
 					uploaddata[ply] = nil
 				end
 			end)

--- a/lua/starfall/sflib.lua
+++ b/lua/starfall/sflib.lua
@@ -626,7 +626,7 @@ if SERVER then
 		updata.NumFiles = I
 
 		if I == 0 then
-			updata.callback(updata.mainfile, sf.files, {})
+			updata.callback(updata.mainfile, updata.files)
 			uploaddata[ply] = nil
 		end
 	end)

--- a/lua/starfall/sflib.lua
+++ b/lua/starfall/sflib.lua
@@ -596,12 +596,19 @@ if SERVER then
 			return
 		end
 
+		local function combine(a, b)
+			local out = {}
+			for key, value in pairs(a) do
+				out[key] = value
+			end
+			for key, value in pairs(b) do
+				out[key] = value
+			end
+			return out
+		end
+
 		updata.mainfile = net.ReadString()
 		local sf = net.ReadEntity()
-
-		if sf:IsValid() then
-			sf.files = sf.files or {}
-		end
 
 		local I = 0
 		while I < 256 do
@@ -622,9 +629,9 @@ if SERVER then
 				updata.Completed = updata.Completed + 1
 				updata.files[filename] = data
 
-				if sf:IsValid() then sf.files[filename] = data end
 				if updata.Completed == updata.NumFiles then
-					updata.callback(updata.mainfile, sf:IsValid() and sf.files or updata.files)
+					local filesToCompile = (sf:IsValid() and sf.instance) and combine(sf.files or {}, updata.files) or updata.files
+					updata.callback(updata.mainfile, filesToCompile)
 					uploaddata[ply] = nil
 				end
 			end)
@@ -701,8 +708,6 @@ else
 				if code ~= (sf.files[filename] or "_DOES_NOT_EXIST_") then
 					table.insert(updatedFiles, filename)
 				end
-
-				sf.files[filename] = code
 			end
 		else
 			for filename, code in pairs(list.files) do

--- a/lua/starfall/sflib.lua
+++ b/lua/starfall/sflib.lua
@@ -694,7 +694,7 @@ else
 			sf.files = sf.files or {}
 
 			for filename, code in pairs(list.files) do
-				if util.CRC(code) ~= util.CRC(sf.files[filename] or "_DOES_NOT_EXIST_") then
+				if code ~= (sf.files[filename] or "_DOES_NOT_EXIST_") then
 					table.insert(updatedFiles, filename)
 				end
 

--- a/lua/starfall/sflib.lua
+++ b/lua/starfall/sflib.lua
@@ -691,10 +691,10 @@ else
 	net.Receive("starfall_requpload", function(len)
 		local sf = net.ReadEntity()
 		local ok, list = SF.Editor.BuildIncludesTable()
-		local newlySpawnedSF = not sf:IsValid()
+		local sfJustSpawned = not sf:IsValid()
 		local updatedFiles = {}
 
-		if (sf and sf.intance) or not newlySpawnedSF then
+		if not sfJustSpawned and sf.instance then
 			sf.files = sf.files or {}
 
 			for filename, code in pairs(list.files) do

--- a/lua/starfall/sflib.lua
+++ b/lua/starfall/sflib.lua
@@ -689,6 +689,15 @@ else
 		local ok, list = SF.Editor.BuildIncludesTable()
 		local sfJustSpawned = not sf:IsValid()
 		local updatedFiles = {}
+		local removedFiles = {}
+
+		local function hasKey(t, key)
+			for k, value in pairs(t) do
+				if k == key then return true end
+			end
+
+			return false
+		end
 
 		if not sfJustSpawned and sf.instance then
 			sf.files = sf.files or {}
@@ -698,10 +707,14 @@ else
 					table.insert(updatedFiles, filename)
 				end
 			end
-		else
-			for filename, code in pairs(list.files) do
-				table.insert(updatedFiles, filename)
+
+			for filename, code in pairs(sf.files) do
+				if not hasKey(list.files, filename) then
+					table.insert(removedFiles, "-" .. filename)
+				end
 			end
+		else
+			updatedFiles = table.GetKeys(list.files)
 		end
 
 		if ok then
@@ -710,10 +723,10 @@ else
 			net.WriteString(list.mainfile)
 			net.WriteEntity(sf)
 
-			for i, filename in ipairs(updatedFiles) do
+			for i, filename in ipairs(table.Add(updatedFiles, removedFiles)) do
 				net.WriteBit(false)
 				net.WriteString(filename)
-				net.WriteStream(list.files[filename])
+				net.WriteStream(list.files[filename] or ".")
 			end
 
 			net.WriteBit(true)

--- a/lua/starfall/sflib.lua
+++ b/lua/starfall/sflib.lua
@@ -689,23 +689,24 @@ else
 
 			if sf:IsValid() and sf.instance then
 				for filename, code in pairs(list.files) do
-					if sf.files[filename] == code then
-						list.files[filename] = nil
+					if sf.files[filename] ~= code then
+						updatedFiles[filename] = code
 					end
 				end
-
 				for filename, code in pairs(sf.files) do
 					if not list.files[filename] then
-						list.files[filename] = "-removed-"
+						updatedFiles[filename] = "-removed-"
 					end
 				end
+			else
+				updatedFiles = list.files
 			end
 
 			--print("Uploading SF code")
 			net.Start("starfall_upload")
 			net.WriteString(list.mainfile)
 
-			for filename, code in pairs(list.files) do
+			for filename, code in pairs(updatedFiles) do
 				net.WriteBit(false)
 				net.WriteString(filename)
 				net.WriteStream(code)

--- a/lua/starfall/sflib.lua
+++ b/lua/starfall/sflib.lua
@@ -598,7 +598,10 @@ if SERVER then
 
 		updata.mainfile = net.ReadString()
 		local sf = net.ReadEntity()
-		sf.files = sf.files or {}
+
+		if sf:IsValid() then
+			sf.files = sf.files or {}
+		end
 
 		local I = 0
 		while I < 256 do
@@ -618,9 +621,10 @@ if SERVER then
 				end
 				updata.Completed = updata.Completed + 1
 				updata.files[filename] = data
-				sf.files[filename] = data
+
+				if sf:IsValid() then sf.files[filename] = data end
 				if updata.Completed == updata.NumFiles then
-					updata.callback(updata.mainfile, sf.files)
+					updata.callback(updata.mainfile, sf:IsValid() and sf.files or updata.files)
 					uploaddata[ply] = nil
 				end
 			end)
@@ -690,7 +694,7 @@ else
 		local newlySpawnedSF = not sf:IsValid()
 		local updatedFiles = {}
 
-		if not newlySpawnedSF then
+		if (sf and sf.intance) or not newlySpawnedSF then
 			sf.files = sf.files or {}
 
 			for filename, code in pairs(list.files) do
@@ -724,6 +728,7 @@ else
 		else
 			net.Start("starfall_upload")
 			net.WriteString("")
+			net.WriteEntity(sf)
 			net.WriteBit(true)
 			net.SendToServer()
 			if list then

--- a/lua/weapons/gmod_tool/stools/starfall_processor.lua
+++ b/lua/weapons/gmod_tool/stools/starfall_processor.lua
@@ -95,10 +95,10 @@ function TOOL:LeftClick(trace)
 		undo.Finish()
 	end
 
-	if not SF.RequestCode(ply, sf, function(mainfile, files)
+	if not SF.RequestCode(ply, sf, function(mainfile, files, filesToSend)
 		if not mainfile then return end
 		if not IsValid(sf) then return end -- Probably removed during transfer
-		sf:Compile(ply, files, mainfile)
+		sf:Compile(ply, files, mainfile, filesToSend)
 		if sf.instance and sf.instance.ppdata.models and sf.instance.mainfile then
 			local model = sf.instance.ppdata.models[sf.instance.mainfile]
 			if util.IsValidModel(model) and util.IsValidProp(model) then

--- a/lua/weapons/gmod_tool/stools/starfall_processor.lua
+++ b/lua/weapons/gmod_tool/stools/starfall_processor.lua
@@ -95,7 +95,7 @@ function TOOL:LeftClick(trace)
 		undo.Finish()
 	end
 
-	if not SF.RequestCode(ply, function(mainfile, files)
+	if not SF.RequestCode(ply, sf, function(mainfile, files)
 		if not mainfile then return end
 		if not IsValid(sf) then return end -- Probably removed during transfer
 		sf:Compile(ply, files, mainfile)

--- a/lua/weapons/gmod_tool/stools/starfall_processor.lua
+++ b/lua/weapons/gmod_tool/stools/starfall_processor.lua
@@ -95,10 +95,10 @@ function TOOL:LeftClick(trace)
 		undo.Finish()
 	end
 
-	if not SF.RequestCode(ply, sf, function(mainfile, files, filesToSend)
+	if not SF.RequestCode(ply, sf, function(mainfile, files)
 		if not mainfile then return end
 		if not IsValid(sf) then return end -- Probably removed during transfer
-		sf:Compile(ply, files, mainfile, filesToSend)
+		sf:Compile(ply, files, mainfile)
 		if sf.instance and sf.instance.ppdata.models and sf.instance.mainfile then
 			local model = sf.instance.ppdata.models[sf.instance.mainfile]
 			if util.IsValidModel(model) and util.IsValidProp(model) then


### PR DESCRIPTION
Player will only send files that have changed (via checksum).
All uploaded code is stored in the already existing `self.files`

### Implementation

1. When a new player joins, player will request all files from the chip
2. (Client/Owner) When a player creates a new chip, upload all current code
3. (Client/Owner) When a chip is updated, determine which files have changed and and send said files to server
    3.1. Files no longer included will be have a `-` prepended to their name declaring it to be removed from `self.files` on compile (This is also sent to the server and in turn to all clients).
4. (Server) `ENT:Compile()` all downloaded code + files stored, pass the uploaded files from client to all clients (`self:SendCode(nil, filesToSend)`)
    4.1. If no files were uploaded, compile with the stored files and `self:SendCode(nil, {})`
5. (Client) Once the client downloads the files then `ENT:Compile()` all downloaded code + files stored
    5.1. If no files were downloaded then call `ENT:Compile()` using the code already stored