### PR TITLE
Option to enable font antialiasing

### DIFF
--- a/lua/starfall/editor/sfframe.lua
+++ b/lua/starfall/editor/sfframe.lua
@@ -89,13 +89,13 @@ cvars.AddChangeCallback("sf_editor_layout", function()
 end)
 
 Editor.CreatedFonts = {}
-function createFont(name, FontName, Size)
+function createFont(name, FontName, Size, Antialiasing)
 	local fontTable =
 	{
 		font = FontName,
 		size = Size,
 		weight = 400,
-		antialias = true,
+		antialias = Antialiasing,
 		additive = false,
 		italic = false,
 	}
@@ -107,15 +107,15 @@ function createFont(name, FontName, Size)
 	surface.CreateFont(name.."_Italic", fontTable)
 
 end
-function Editor:GetFont(FontName, Size)
+function Editor:GetFont(FontName, Size, Antialiasing)
 	if not FontName or FontName == "" or not Size then return end
-	local name = "sf_" .. FontName .. "_" .. Size
+	local name = "sf_" .. FontName .. "_" .. Size .. "_" .. (Antialiasing and 1 or 0)
 
 	-- If font is not already created, create it.
 	if not self.CreatedFonts[name] then
 		self.CreatedFonts[name] = true
-		createFont(name, FontName, Size)
-		timer.Simple(0, function() createFont(name, FontName, Size) end) --Fix for bug explained there http://wiki.garrysmod.com/page/surface/CreateFont
+		createFont(name, FontName, Size, Antialiasing)
+		timer.Simple(0, function() createFont(name, FontName, Size, Antialiasing) end) --Fix for bug explained there http://wiki.garrysmod.com/page/surface/CreateFont
 	end
 
 	surface.SetFont(name)

--- a/lua/starfall/editor/tabhandlers/tab_wire.lua
+++ b/lua/starfall/editor/tabhandlers/tab_wire.lua
@@ -72,6 +72,7 @@ TabHandler.EnlightenColorsConVar = CreateClientConVar("sf_editor_wire_enlightenc
 TabHandler.HighlightOnDoubleClickConVar = CreateClientConVar("sf_editor_wire_highlight_on_double_click", "1", true, false)
 TabHandler.DisplayCaretPosConVar = CreateClientConVar("sf_editor_wire_display_caret_pos", "0", true, false)
 TabHandler.AutoIndentConVar = CreateClientConVar("sf_editor_wire_auto_indent", "1", true, false)
+TabHandler.EnableAntialiasing = CreateClientConVar("sf_editor_wire_enable_antialiasing", "1", true, false)
 TabHandler.ScrollSpeedConVar = CreateClientConVar("sf_editor_wire_scrollmultiplier", 1, true, false)
 TabHandler.LinesHiddenFormatConVar = CreateClientConVar("sf_editor_wire_lines_hidden_format", "< %d lines hidden >", true, false)
 TabHandler.AutoValidateConVar = CreateClientConVar("sf_editor_wire_validateontextchange", "0", true, false)
@@ -235,7 +236,7 @@ function TabHandler:RegisterSettings()
 	end
 	FontSelect:AddChoice("Custom...")
 	FontSelect:SetValue(TabHandler.FontConVar:GetString())
-	FontSelect:SetFontInternal(SF.Editor.editor:GetFont(TabHandler.FontConVar:GetString(), 16))
+	FontSelect:SetFontInternal(SF.Editor.editor:GetFont(TabHandler.FontConVar:GetString(), 16, TabHandler.EnableAntialiasing:GetBool()))
 
 
 
@@ -275,6 +276,9 @@ function TabHandler:RegisterSettings()
 
 	local enlightenColors = form:CheckBox( "Use brighter colors", "sf_editor_wire_enlightencolors" )
 	local displayCaret = form:CheckBox( "Display caret position", "sf_editor_wire_display_caret_pos" )
+
+	local enableAntialiasing = form:CheckBox( "Enable font antialiasing", "sf_editor_wire_enable_antialiasing" )
+
 	local scrollSpeed = form:NumSlider("Scroll Speed","sf_editor_wire_scrollmultiplier", 0.01, 4, 4)
 	scrollSpeed:SetPaintBackgroundEnabled( true )
 	scrollSpeed.TextArea.m_colText = Color(255,255,255)
@@ -361,8 +365,8 @@ function PANEL:Init()
 	self:SetMode("Starfall")
 	self.CurrentMode:LoadSyntaxColors()
 
-	self.CurrentFont, self.FontWidth, self.FontHeight = SF.Editor.editor:GetFont(TabHandler.FontConVar:GetString(), TabHandler.FontSizeConVar:GetInt())
-	self.CurrentFontSmall, self.FontSmallWidth, self.FontSmallHeight = SF.Editor.editor:GetFont(TabHandler.FontConVar:GetString(), math_floor(TabHandler.FontSizeConVar:GetInt()*0.9))
+	self.CurrentFont, self.FontWidth, self.FontHeight = SF.Editor.editor:GetFont(TabHandler.FontConVar:GetString(), TabHandler.FontSizeConVar:GetInt(), TabHandler.EnableAntialiasing:GetBool())
+	self.CurrentFontSmall, self.FontSmallWidth, self.FontSmallHeight = SF.Editor.editor:GetFont(TabHandler.FontConVar:GetString(), math_floor(TabHandler.FontSizeConVar:GetInt()*0.9), TabHandler.EnableAntialiasing:GetBool())
 	table.insert(TabHandler.Tabs, self)
 
 end
@@ -471,8 +475,8 @@ function PANEL:OnThemeChange()
 	for k,v in ipairs(self.Rows) do
 		v[2] = false
 	end
-	self.CurrentFont, self.FontWidth, self.FontHeight = SF.Editor.editor:GetFont(TabHandler.FontConVar:GetString(), TabHandler.FontSizeConVar:GetInt())
-	self.CurrentFontSmall, self.FontSmallWidth, self.FontSmallHeight = SF.Editor.editor:GetFont(TabHandler.FontConVar:GetString(), TabHandler.FontSizeConVar:GetInt()*0.7)
+	self.CurrentFont, self.FontWidth, self.FontHeight = SF.Editor.editor:GetFont(TabHandler.FontConVar:GetString(), TabHandler.FontSizeConVar:GetInt(), TabHandler.EnableAntialiasing:GetBool())
+	self.CurrentFontSmall, self.FontSmallWidth, self.FontSmallHeight = SF.Editor.editor:GetFont(TabHandler.FontConVar:GetString(), TabHandler.FontSizeConVar:GetInt()*0.7, TabHandler.EnableAntialiasing:GetBool())
 
 end
 


### PR DESCRIPTION
Added option to enable font antialiasing in wire editor. This option is enabled by default.