### PR TITLE
Re-enabled JSON Generation, because it is used in search.

### DIFF
--- a/docgen/build_all.lua
+++ b/docgen/build_all.lua
@@ -1,3 +1,3 @@
 require "build_docs"
---require "build_docs_json"
+require "build_docs_json"
 require "build_docs_lua"


### PR DESCRIPTION
While generating my own docs website for our custom SF functions, I noticed that they don't show up in search, after some digging I found that the search javascript still uses the json file, yet it had been removed from the docgen. 

This change re-enables the build_docs_json.lua docgen file, as it is needed for the search to work properly. 