### PR TITLE
Added render.renderView

### DIFF
--- a/lua/starfall/examples/render_view.lua
+++ b/lua/starfall/examples/render_view.lua
@@ -1,0 +1,85 @@
+--@name render.renderView example
+--@author Szymekk
+--@client
+
+-- render.renderView allows to render the world into a render target
+-- Link the chip to a screen to see how it works
+
+setupPermissionRequest({ "render.offscreen", "render.renderView" }, "See an example of render.renderView.", true)
+local permissionSatisfied = hasPermission("render.renderView")
+
+local rtName = "rendertarget"
+render.createRenderTarget(rtName)
+
+local mat = material.create("gmodscreenspace")
+mat:setTextureRenderTarget("$basetexture", rtName)
+
+local scrW, scrH
+local screenEnt
+
+hook.add("renderoffscreen", "render_view", function()
+    if not permissionSatisfied then return end
+
+    if not render.isInRenderView() and screenEnt then
+        render.selectRenderTarget(rtName)
+
+        local origin = screenEnt:getPos()
+        local relativePos = (origin - eyePos())
+        
+        local m1 = Matrix()
+        m1:setAngles(screenEnt:getAngles())
+        
+        local m2 = Matrix()
+        m2:setAngles(eyeAngles())
+        
+        local m3 = Matrix()
+        m3:setTranslation(relativePos)
+        
+        local mRotation = m1:getInverseTR() * m2
+        local mTransform = m1:getInverseTR() * m3
+        
+        render.renderView({
+            origin = screenEnt:getPos() - mTransform:getTranslation() + Vector(0, 0, 200),
+            angles = mRotation:getAngles(),
+            aspectratio = scrW / scrH,
+            x = 0,
+            y = 0,
+            w = 1024,
+            h = 1024,
+            drawviewmodel = false,
+        })
+        
+        render.selectRenderTarget()
+    end
+end)
+
+hook.add("render", "render_screen", function()
+    if not permissionSatisfied then
+        render.setColor(Color(255, 255, 255))
+        render.setFont("DermaLarge")
+        render.drawText(256, 256 - 32, "Use me", 1)
+        return
+    end
+
+    if render.isInRenderView() then
+        render.setColor(Color(0, 0, 0))
+        render.drawRect(0, 0, 512, 512)
+        render.setColor(Color(255, 255, 0))
+        render.setFont("DermaLarge")
+        render.drawText(256, 256 - 32, "RenderView", 1)
+        return
+    end
+
+    scrW, scrH = render.getGameResolution()
+    screenEnt = screenEnt or render.getScreenEntity()
+
+    render.pushViewMatrix({ type = "2D" })
+    render.setMaterial(mat)
+    render.setColor(Color(255, 255, 255))
+    render.drawTexturedRect(0, 0, scrW, scrH)
+    render.popViewMatrix()
+end)
+
+hook.add("permissionrequest", "", function()
+    permissionSatisfied = hasPermission("render.renderView")
+end)


### PR DESCRIPTION
This branch adds [render.RenderView](http://wiki.garrysmod.com/page/render/RenderView) function to Starfall. This makes it possible to render the scene from another perspective to a render target. Such a technique can be used to render portals, render mirrors or make screens transparent.

Mirror example:
![Mirror](https://cdn.discordapp.com/attachments/280721310479417345/511174808151785484/unknown.png)

Since rendering the scene is an expensive operation, I added a ConVar limiting the use of render.renderView to 2 calls per frame by default. I also added a privilege.
I didn't encounter any exploits or serious bugs with it, but a few people should try it out before merging, possibly with other scripts using screens at the same time. I included an example script.