### PR TITLE
Added local player drawing and fixed clipping in render.renderView

### DIFF
--- a/lua/starfall/examples/render_view.lua
+++ b/lua/starfall/examples/render_view.lua
@@ -8,7 +8,7 @@
 setupPermissionRequest({ "render.offscreen", "render.renderView" }, "See an example of render.renderView.", true)
 local permissionSatisfied = hasPermission("render.renderView")
 
-local rtName = "rendertarget"
+local rtName = "mirror_rt"
 render.createRenderTarget(rtName)
 
 local mat = material.create("gmodscreenspace")
@@ -22,32 +22,31 @@ hook.add("renderoffscreen", "render_view", function()
 
     if not render.isInRenderView() and screenEnt then
         render.selectRenderTarget(rtName)
-
-        local origin = screenEnt:getPos()
-        local relativePos = (origin - eyePos())
         
-        local m1 = Matrix()
-        m1:setAngles(screenEnt:getAngles())
+        render.enableClipping(true)
         
-        local m2 = Matrix()
-        m2:setAngles(eyeAngles())
+        local clipNormal = screenEnt:getUp()
+        render.pushCustomClipPlane(clipNormal, (screenEnt:getPos() + clipNormal):dot(clipNormal))
         
-        local m3 = Matrix()
-        m3:setTranslation(relativePos)
+        local localOrigin = screenEnt:worldToLocal(eyePos())
+        local reflectedOrigin = screenEnt:localToWorld(localOrigin * Vector(1, 1, -1))  
         
-        local mRotation = m1:getInverseTR() * m2
-        local mTransform = m1:getInverseTR() * m3
+        local localAng = screenEnt:worldToLocalAngles(eyeAngles())
+        local reflectedAngle = screenEnt:localToWorldAngles(Angle(-localAng.p, localAng.y, -localAng.r + 180))
         
         render.renderView({
-            origin = screenEnt:getPos() - mTransform:getTranslation() + Vector(0, 0, 200),
-            angles = mRotation:getAngles(),
+            origin = reflectedOrigin,
+            angles = reflectedAngle,
             aspectratio = scrW / scrH,
             x = 0,
             y = 0,
             w = 1024,
             h = 1024,
             drawviewmodel = false,
+            drawviewer = true,
         })
+        
+        render.popCustomClipPlane()
         
         render.selectRenderTarget()
     end
@@ -76,7 +75,7 @@ hook.add("render", "render_screen", function()
     render.pushViewMatrix({ type = "2D" })
     render.setMaterial(mat)
     render.setColor(Color(255, 255, 255))
-    render.drawTexturedRect(0, 0, scrW, scrH)
+    render.drawTexturedRect(scrW, 0, -scrW, scrH)
     render.popViewMatrix()
 end)
 


### PR DESCRIPTION
Drawing HUD in render.renderView is now disallowed. It was too glitchy and I couldn't get it to work. The example has been replaced with a mirror example - clipping planes don't produce black triangles anymore.