### PR TITLE
Print to server console when a player's chip exceeds the serverside CPU quota

### DIFF
--- a/lua/starfall/instance.lua
+++ b/lua/starfall/instance.lua
@@ -124,6 +124,7 @@ function SF.Instance:runWithOps(func, ...)
 		end
 
 		if usedRatio>1 then
+			if SERVER then MsgC(Color(255,0,0),"[Starfall] CPU Quota exceeded by " .. self.player:Nick() .. " (" .. self.player:SteamID() .. ")\n") end
 			safeThrow("CPU Quota exceeded.", true)
 		elseif usedRatio > self.cpu_softquota then
 			safeThrow("CPU Quota warning.")

--- a/lua/starfall/instance.lua
+++ b/lua/starfall/instance.lua
@@ -119,12 +119,17 @@ function SF.Instance:runWithOps(func, ...)
 		local function safeThrow(msg, nocatch)
 			local source = debug.getinfo(3, "S").short_src
 			if string.find(source, "SF:", 1, true) or string.find(source, "starfall", 1, true) then
+				if nocatch then
+					if SERVER then
+						SF.Print(nil, "[Starfall] CPU Quota exceeded by " .. self.player:Nick() .. " (" .. self.player:SteamID() .. ")\n")
+						MsgC(Color(255,0,0), "[Starfall] CPU Quota exceeded by " .. self.player:Nick() .. " (" .. self.player:SteamID() .. ")\n")
+					end
+				end
 				SF.Throw(msg, 3, nocatch)
 			end
 		end
 
 		if usedRatio>1 then
-			if SERVER then MsgC(Color(255,0,0),"[Starfall] CPU Quota exceeded by " .. self.player:Nick() .. " (" .. self.player:SteamID() .. ")\n") end
 			safeThrow("CPU Quota exceeded.", true)
 		elseif usedRatio > self.cpu_softquota then
 			safeThrow("CPU Quota warning.")

--- a/lua/starfall/instance.lua
+++ b/lua/starfall/instance.lua
@@ -119,11 +119,13 @@ function SF.Instance:runWithOps(func, ...)
 		local function safeThrow(msg, nocatch)
 			local source = debug.getinfo(3, "S").short_src
 			if string.find(source, "SF:", 1, true) or string.find(source, "starfall", 1, true) then
-				if nocatch then
-					if SERVER then
-						SF.Print(nil, "[Starfall] CPU Quota exceeded by " .. self.player:Nick() .. " (" .. self.player:SteamID() .. ")\n")
-						MsgC(Color(255,0,0), "[Starfall] CPU Quota exceeded by " .. self.player:Nick() .. " (" .. self.player:SteamID() .. ")\n")
+				if SERVER and nocatch then
+					local consolemsg = "[Starfall] CPU Quota exceeded"
+					if self.player:IsValid() then
+						consolemsg = consolemsg .. " by " .. self.player:Nick() .. " (" .. self.player:SteamID() .. ")"
 					end
+					SF.Print(nil, consolemsg .. "\n")
+					MsgC(Color(255,0,0), consolemsg .. "\n")
 				end
 				SF.Throw(msg, 3, nocatch)
 			end

--- a/lua/starfall/sflib.lua
+++ b/lua/starfall/sflib.lua
@@ -820,7 +820,7 @@ if SERVER then
 	function SF.Print (ply, msg)
 		net.Start("starfall_console_print")
 			net.WriteString(msg)
-		net.Send(ply)
+		if ply then net.Send(ply) else net.Broadcast() end
 	end
 
 	function SF.ChatPrint(ply, ...)


### PR DESCRIPTION
As suggested by TheWizardLizard in #534, this can help server administrators see if players are intentionally causing servers to "hiccup" by hitting the CPU quota.