### PR TITLE
Remove deprecated property AdminSpawnable

### DIFF
--- a/lua/entities/starfall_hologram/shared.lua
+++ b/lua/entities/starfall_hologram/shared.lua
@@ -5,7 +5,6 @@ ENT.PrintName       = "Starfall Hologram"
 ENT.Author          = "Starfall Organization"
 
 ENT.Spawnable       = false
-ENT.AdminSpawnable  = false
 
 function ENT:SetupDataTables()
 

--- a/lua/entities/starfall_hud/shared.lua
+++ b/lua/entities/starfall_hud/shared.lua
@@ -8,4 +8,3 @@ ENT.Purpose         = ""
 ENT.Instructions    = ""
 
 ENT.Spawnable       = false
-ENT.AdminSpawnable  = false

--- a/lua/entities/starfall_processor/shared.lua
+++ b/lua/entities/starfall_processor/shared.lua
@@ -8,7 +8,6 @@ ENT.Purpose         = ""
 ENT.Instructions    = ""
 
 ENT.Spawnable       = false
-ENT.AdminSpawnable  = false
 
 ENT.Starfall        = true
 ENT.States          = {

--- a/lua/entities/starfall_screen/shared.lua
+++ b/lua/entities/starfall_screen/shared.lua
@@ -8,4 +8,3 @@ ENT.Purpose         = ""
 ENT.Instructions    = ""
 
 ENT.Spawnable       = false
-ENT.AdminSpawnable  = false


### PR DESCRIPTION
'AdminSpawnable' has been renamed to 'AdminOnly' since GMod 13, the default value is 'false', it should simply be fine to remove those lines too.
Old docs say:
"If false, admins can't spawn that weapon (you can set to false for base weapons)."
See also:
https://wiki.garrysmod.com/page/Structures/ENT