### PR TITLE
Added input.getCursorVisible()

### DIFF
--- a/lua/starfall/libs_sh/input.lua
+++ b/lua/starfall/libs_sh/input.lua
@@ -116,10 +116,6 @@ end
 function input_methods.getCursorVisible()
 	SF.Permissions.check(SF.instance, nil, "input")
 
-	if not SF.instance:isHUDActive() then
-		SF.Throw("No HUD component connected", 2)
-	end
-
 	return vgui.CursorVisible()
 end
 

--- a/lua/starfall/libs_sh/input.lua
+++ b/lua/starfall/libs_sh/input.lua
@@ -116,6 +116,10 @@ end
 function input_methods.getCursorVisible()
 	SF.Permissions.check(SF.instance, nil, "input")
 
+	if not SF.instance:isHUDActive() then
+		SF.Throw("No HUD component connected", 2)
+	end
+
 	return vgui.CursorVisible()
 end
 

--- a/lua/starfall/libs_sh/input.lua
+++ b/lua/starfall/libs_sh/input.lua
@@ -110,6 +110,15 @@ function input_methods.getCursorPos()
 	return input.GetCursorPos()
 end
 
+--- Gets whether the cursor is visible on the screen
+-- @client
+-- @return The cursor's visibility
+function input_methods.getCursorVisible()
+	SF.Permissions.check(SF.instance, nil, "input")
+
+	return vgui.CursorVisible()
+end
+
 ---Translates position on player's screen to aim vector
 -- @client
 -- @param x X coordinate on the screen


### PR DESCRIPTION
This will allow users to distinguish between in-game inputs, and inputs that are put into VGUI elements, such as the chat box, or Q menu.
I additionally made the function only work in the HUD, since `input.enableCursor()` also only works in HUD.