### PR TITLE
Added clientside hologram parenting

### DIFF
--- a/lua/starfall/libs_sh/holograms.lua
+++ b/lua/starfall/libs_sh/holograms.lua
@@ -461,6 +461,9 @@ else
 	
 	local holoChildrenMeta = { __mode = "k" }
 	
+	--- Parents a hologram
+	-- @param ent Entity parent (nil to unparent)
+	-- @param attachment Optional attachment ID
 	function hologram_methods:setParent (ent, attachment)
 		
 		checktype(self, hologram_metamethods)

--- a/lua/starfall/libs_sh/holograms.lua
+++ b/lua/starfall/libs_sh/holograms.lua
@@ -500,6 +500,7 @@ else
 				holo.sf_parent.sf_children[holo] = nil
 			end
 			
+			holo.sf_parent = nil
 			holo:SetParent()
 			
 		end


### PR DESCRIPTION
Tested briefly, garbage collection works, changing parents, unparenting, hierarchy recursion works.
Code check and more testing probably required.

Added CL privilege hologram.setParent.
Engine flag on the parent - [EFL_FORCE_CHECK_TRANSMIT](https://wiki.garrysmod.com/page/Enums/EFL) might be required for some entities, but I'm not adding that since I can't test that on anything.
