### PR TITLE
Fixed client entity permissions not working correctly on clientside

### DIFF
--- a/lua/starfall/libs_sh/entities.lua
+++ b/lua/starfall/libs_sh/entities.lua
@@ -16,10 +16,10 @@ local checktype = SF.CheckType
 local checkluatype = SF.CheckLuaType
 local checkpermission = SF.Permissions.check
 
-SF.Permissions.registerPrivilege("entities.setRenderProperty", "RenderProperty", "Allows the user to change the rendering of an entity", { entities = {} })
-SF.Permissions.registerPrivilege("entities.emitSound", "Emitsound", "Allows the user to play sounds on entities", { entities = {} })
-SF.Permissions.registerPrivilege("entities.getAngles", "GetAngles", "Allows the user to get angles of an entity", { entities = {} })
-SF.Permissions.registerPrivilege("entities.getPos", "GetPos", "Allows the user to get position of an entity", { entities = {} })
+SF.Permissions.registerPrivilege("entities.setRenderProperty", "RenderProperty", "Allows the user to change the rendering of an entity", CLIENT and { client = {} } or { entities = {} })
+SF.Permissions.registerPrivilege("entities.emitSound", "Emitsound", "Allows the user to play sounds on entities", CLIENT and { client = {} } or { entities = {} })
+SF.Permissions.registerPrivilege("entities.getAngles", "GetAngles", "Allows the user to get angles of an entity", CLIENT and { client = {} } or { entities = {} })
+SF.Permissions.registerPrivilege("entities.getPos", "GetPos", "Allows the user to get position of an entity", CLIENT and { client = {} } or { entities = {} })
 
 SF.AddHook("postload", function()
 	ang_meta = SF.Angles.Metatable

--- a/lua/starfall/libs_sh/entities.lua
+++ b/lua/starfall/libs_sh/entities.lua
@@ -16,10 +16,10 @@ local checktype = SF.CheckType
 local checkluatype = SF.CheckLuaType
 local checkpermission = SF.Permissions.check
 
-SF.Permissions.registerPrivilege("entities.setRenderProperty", "RenderProperty", "Allows the user to change the rendering of an entity", CLIENT and { client = {} } or { entities = {} })
-SF.Permissions.registerPrivilege("entities.emitSound", "Emitsound", "Allows the user to play sounds on entities", CLIENT and { client = {} } or { entities = {} })
-SF.Permissions.registerPrivilege("entities.getAngles", "GetAngles", "Allows the user to get angles of an entity", CLIENT and { client = {} } or { entities = {} })
-SF.Permissions.registerPrivilege("entities.getPos", "GetPos", "Allows the user to get position of an entity", CLIENT and { client = {} } or { entities = {} })
+SF.Permissions.registerPrivilege("entities.setRenderProperty", "RenderProperty", "Allows the user to change the rendering of an entity", { client = (CLIENT and {} or nil), entities = {} })
+SF.Permissions.registerPrivilege("entities.emitSound", "Emitsound", "Allows the user to play sounds on entities", { client = (CLIENT and {} or nil), entities = {} })
+SF.Permissions.registerPrivilege("entities.getAngles", "GetAngles", "Allows the user to get angles of an entity", { client = (CLIENT and {} or nil), entities = {} })
+SF.Permissions.registerPrivilege("entities.getPos", "GetPos", "Allows the user to get position of an entity", { client = (CLIENT and {} or nil), entities = {} })
 
 SF.AddHook("postload", function()
 	ang_meta = SF.Angles.Metatable


### PR DESCRIPTION
Fixed client entity permissions on the clientside ignoring the user setting and being owner only.

Thanks @https://github.com/adamnejm for finding the source of the issue