### PR TITLE
fix table.Copy-ing SF.EntityTable failing due to string indexes.

### DIFF
--- a/lua/starfall/sflib.lua
+++ b/lua/starfall/sflib.lua
@@ -36,13 +36,9 @@ end
 -- Declare Basic Starfall Types
 -------------------------------------------------------------------------------
 
--- Returns a class that manages a table of entity keys
-SF.EntityTable = {
+local EntityTable = {
 	__newindex = function(t, e, v)
 		rawset(t, e, v)
-		if !IsEntity(e) then
-			return
-		end
 		if t.wait then
 			e:CallOnRemove("SF_" .. t.key, function()
 				timer.Simple(0, function()
@@ -60,17 +56,17 @@ SF.EntityTable = {
 				end
 			end)
 		end
-	end,
-	__call = function(p, key, destructor, dontwait)
-		local t = {
-			key = key,
-			destructor = destructor,
-			wait = CLIENT and not dontwait
-		}
-		return setmetatable(t, p)
 	end
 }
-setmetatable(SF.EntityTable, SF.EntityTable)
+-- Returns a class that manages a table of entity keys
+function SF.EntityTable(key, destructor, dontwait)
+	local t = {
+		key = key,
+		destructor = destructor,
+		wait = CLIENT and not dontwait
+	}
+	return setmetatable(t, EntityTable)
+end
 
 --- Returns a class that wraps a structure and caches indexes
 SF.StructWrapper = {

--- a/lua/starfall/sflib.lua
+++ b/lua/starfall/sflib.lua
@@ -40,6 +40,9 @@ end
 SF.EntityTable = {
 	__newindex = function(t, e, v)
 		rawset(t, e, v)
+		if !IsEntity(e) then
+			return
+		end
 		if t.wait then
 			e:CallOnRemove("SF_" .. t.key, function()
 				timer.Simple(0, function()


### PR DESCRIPTION
when table.Copy is called on SF.EntityTable (or anything including a reference to it), it first copies the __newindex and then the __call.
since the __newindex tries to add a CallOnRemove function to the index, it errors on entering "__call".
this is an issue with table.Copy moreso than starfall, but it breaks things that copy _G, which are relatively common.