### PR TITLE
Added vector.getRotated and entities.getClipping

### DIFF
--- a/lua/starfall/libs_sh/entities.lua
+++ b/lua/starfall/libs_sh/entities.lua
@@ -18,7 +18,7 @@ local checkpermission = SF.Permissions.check
 
 SF.Permissions.registerPrivilege("entities.setRenderProperty", "RenderProperty", "Allows the user to change the rendering of an entity", { client = (CLIENT and {} or nil), entities = {} })
 SF.Permissions.registerPrivilege("entities.emitSound", "Emitsound", "Allows the user to play sounds on entities", { client = (CLIENT and {} or nil), entities = {} })
-SF.Permissions.registerPrivilege("entities.getclip", "Emitsound", "Allows the user to get the clipping data of an entity", { client = (CLIENT and {} or nil), entities = {} })
+SF.Permissions.registerPrivilege("entities.getclip", "GetClipping", "Allows the user to get the clipping data of an entity", { client = (CLIENT and {} or nil), entities = {} })
 
 SF.AddHook("postload", function()
 	ang_meta = SF.Angles.Metatable
@@ -465,6 +465,7 @@ function ents_methods:getClipping()
 	local ent = eunwrap(self)
 	
 	if not (ent and ent:IsValid()) then SF.Throw("Entity is not valid.", 2) end
+	checkpermission(SF.instance, ent, "entities.getclip")
 	
 	local clips = {}
 	

--- a/lua/starfall/libs_sh/entities.lua
+++ b/lua/starfall/libs_sh/entities.lua
@@ -484,8 +484,16 @@ function ents_methods:getClipping()
 	if ent.clips then
 		for i, clip in pairs(ent.clips) do
 			if clip.enabled ~= false then
+				local local_ent = false
+				
+				if clip.localentid then
+					local_ent = ewrap(Entity(clip.localentid))
+				elseif clip.entity then
+					local_ent = ewrap(clip.entity)
+				end
+				
 				table.insert(clips, {
-					local_ent = clip.localentid and (clip.localentid ~= 0 and ewrap(Entity(clip.localentid)) or self) or (clip.entity and ewrap(clip.entity) or false),
+					local_ent = local_ent,
 					origin = vwrap(clip.origin),
 					normal = vwrap(clip.normal)
 				})

--- a/lua/starfall/libs_sh/entities.lua
+++ b/lua/starfall/libs_sh/entities.lua
@@ -18,7 +18,6 @@ local checkpermission = SF.Permissions.check
 
 SF.Permissions.registerPrivilege("entities.setRenderProperty", "RenderProperty", "Allows the user to change the rendering of an entity", { client = (CLIENT and {} or nil), entities = {} })
 SF.Permissions.registerPrivilege("entities.emitSound", "Emitsound", "Allows the user to play sounds on entities", { client = (CLIENT and {} or nil), entities = {} })
-SF.Permissions.registerPrivilege("entities.getclip", "GetClipping", "Allows the user to get the clipping data of an entity", { client = (CLIENT and {} or nil), entities = {} })
 
 SF.AddHook("postload", function()
 	ang_meta = SF.Angles.Metatable
@@ -465,7 +464,6 @@ function ents_methods:getClipping()
 	local ent = eunwrap(self)
 	
 	if not (ent and ent:IsValid()) then SF.Throw("Entity is not valid.", 2) end
-	checkpermission(SF.instance, ent, "entities.getclip")
 	
 	local clips = {}
 	

--- a/lua/starfall/libs_sh/vectors.lua
+++ b/lua/starfall/libs_sh/vectors.lua
@@ -348,6 +348,18 @@ function vec_methods:rotate (b)
 	self[3] = vec.z
 end
 
+--- Returns Rotated vector by Angle b
+-- @param b Angle to rotate by.
+-- @return Rotated Vector
+function vec_methods:getRotated (b)
+	SF.CheckType(b, SF.Types["Angle"])
+
+	local vec = unwrap(self)
+	vec:Rotate(SF.UnwrapObject(b))
+
+	return wrap({ vec.x, vec.y, vec.z })
+end
+
 --- Return rotated vector by an axis
 -- @param axis Axis the rotate around
 -- @param degrees Angle to rotate by in degrees or nil if radians.


### PR DESCRIPTION
Added 2 methods:
 - vector.getRotated(ang) Returns the rotated vector
 - entities.getClipping() Returns a table containing all clips

![Clipping preview](https://i.imgur.com/S9sjX9k.png)