### PR TITLE
WireLink and Entity fixes, outputs breaking on code upload and dupe spawn.

### DIFF
--- a/lua/starfall/libs_sv/wire.lua
+++ b/lua/starfall/libs_sv/wire.lua
@@ -318,6 +318,16 @@ function wire_library.adjustOutputs (names, types)
 		types[i] = newtype
 	end
 	ent._outputs = { names, types }
+
+	-- Restore wirelink and entity output if present, because these outputs are created by the Wire ToolGun
+	-- and breaks on every code update.
+	for k,v in pairs( ent.Outputs ) do
+		if v.Name == "wirelink" or v.Name == "entity" then
+			table.insert(names, v.Name)
+			table.insert(types, v.Type)
+		end
+	end
+
 	WireLib.AdjustSpecialOutputs(ent, names, types)
 end
 
@@ -372,12 +382,12 @@ function wire_library.create (entI, entO, inputname, outputname, width, color, m
 	checkpermission(SF.instance, entO, "wire.createWire")
 
 	if not entI.Inputs then SF.Throw("Source has no valid inputs") end
-	if not entO.Outputs then
-		if outputname == "entity" then
-			WireLib.CreateEntityOutput( nil, entO, {true} )
-		else
-			SF.Throw("Target has no valid outputs")
-		end
+
+	-- Create wirelink or entity output on target if requested
+	if outputname == "entity" then
+		WireLib.CreateEntityOutput( nil, entO, {true} )
+	elseif outputname == "wirelink" then
+		WireLib.CreateWirelinkOutput( nil, entO, {true} )
 	end
 
 	if inputname == "" then SF.Throw("Invalid input name") end

--- a/lua/starfall/libs_sv/wire.lua
+++ b/lua/starfall/libs_sv/wire.lua
@@ -317,7 +317,6 @@ function wire_library.adjustOutputs (names, types)
 		names[i] = newname
 		types[i] = newtype
 	end
-	ent._outputs = { names, types }
 
 	-- Restore wirelink and entity output if present, because these outputs are created by the Wire ToolGun
 	-- and breaks on every code update.
@@ -327,6 +326,8 @@ function wire_library.adjustOutputs (names, types)
 			table.insert(types, v.Type)
 		end
 	end
+
+	ent._outputs = { names, types }
 
 	WireLib.AdjustSpecialOutputs(ent, names, types)
 end
@@ -383,7 +384,7 @@ function wire_library.create (entI, entO, inputname, outputname, width, color, m
 
 	if not entI.Inputs then SF.Throw("Source has no valid inputs") end
 
-	-- Create wirelink or entity output on target if requested
+	-- Initialize wirelink and entity outputs on target if present
 	if outputname == "entity" then
 		WireLib.CreateEntityOutput( nil, entO, {true} )
 	elseif outputname == "wirelink" then

--- a/lua/weapons/gmod_tool/stools/starfall_processor.lua
+++ b/lua/weapons/gmod_tool/stools/starfall_processor.lua
@@ -34,6 +34,15 @@ if SERVER then
 			sf.Inputs = WireLib.AdjustSpecialInputs(sf, inputs[1], inputs[2])
 		end
 		if WireLib and outputs and outputs[1] and outputs[2] then
+			-- Initialize wirelink and entity outputs if present
+			for _, iname in pairs(outputs[1]) do
+				if iname == "entity" then
+					WireLib.CreateEntityOutput( nil, sf, {true} )
+				elseif iname == "wirelink" then
+					WireLib.CreateWirelinkOutput( nil, sf, {true} )
+				end
+			end
+
 			sf.Outputs = WireLib.AdjustSpecialOutputs(sf, outputs[1], outputs[2])
 		end
 


### PR DESCRIPTION
- Fixed `wirelink` and `entity` outputs breaking on code upload.
```
Restore wirelink and entity output if present, because these outputs are created by the Wire ToolGun and breaks on every code update.
```
- Fixed creation of `wirelink` and `entity` wires with `wire.create(...)`
```
Create wirelink or entity output on target if requested, only entity was handled but with a check on "not entO.Outputs", this will not work because almost all wire devices have outputs, in addition only one wirelink and entity outputs are needed by device and these names are used by WireLib
```

- Fixed duped StarfallEx chips not correctly initializing `wirelink` and `entity` outputs on spawn.

Feel free to ask if you have any questions about my changes.

Regards,
F0x

