### PR TITLE
Add swizzle support for vectors

### DIFF
--- a/lua/starfall/libs_sh/vectors.lua
+++ b/lua/starfall/libs_sh/vectors.lua
@@ -52,12 +52,26 @@ function vec_metamethods.__newindex (t, k, v)
 	end
 end
 
+local math_min = math.min
+
 --- __index metamethod
 function vec_metamethods.__index (t, k)
 	if xyz[k] then
 		return rawget(t, xyz[k])
-	else
+	elseif vec_methods[k] ~= nil then
 		return vec_methods[k]
+	else 
+		-- Swizzle support
+		local v = {0,0,0}
+		for i = 1, math_min(#k,3)do
+			local vk = xyz[k[i]]
+			if vk then
+				v[i] = rawget(t, vk)
+			else
+				return nil -- Not a swizzle
+			end
+		end
+		return wrap(v)
 	end
 end
 

--- a/lua/starfall/libs_sh/vectors.lua
+++ b/lua/starfall/libs_sh/vectors.lua
@@ -47,6 +47,18 @@ local xyz = { x = 1, y = 2, z = 3 }
 function vec_metamethods.__newindex (t, k, v)
 	if xyz[k] then
 		rawset(t, xyz[k], v)
+
+	elseif (#k == 2 and xyz[k[1]] and xyz[k[2]])  then
+		checktype(v, vec_metamethods)
+
+		rawset(t, xyz[k[1]], rawget(v, 1))
+		rawset(t, xyz[k[2]], rawget(v, 2))
+	elseif (#k == 3 and xyz[k[1]] and xyz[k[2]] and xyz[k[3]]) then
+		checktype(v, vec_metamethods)
+
+		rawset(t, xyz[k[1]], rawget(v, 1))
+		rawset(t, xyz[k[2]], rawget(v, 2))
+		rawset(t, xyz[k[3]], rawget(v, 3))
 	else
 		rawset(t, k, v)
 	end


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Swizzling_(computer_graphics)

Just something nice to have when you want to rearrange vectors. Shouldn't really affect performance as it's only used as last resort when a lookup fails.

Here's some demo code
```lua
local a, b, c

a = Vector(1,2,3)
b = Vector(0,0,0)

-- Reverses the vector
b.zyx = a

print(b)        -- output: 3 2 1
print(b.zyx)    -- output: 1 2 3

-- Another way to copy a vector
c = a.xyz
c.z = 4

print(a)        -- output: 1 2 3
print(c)        -- output: 1 2 4

print(a.xx)    -- outpuit: 1 1 0
```