### PR TITLE
Additions to collision listener

### DIFF
--- a/lua/entities/starfall_prop/cl_init.lua
+++ b/lua/entities/starfall_prop/cl_init.lua
@@ -44,6 +44,13 @@ function ENT:GetRenderMesh()
 	end
 end
 
+function ENT:OnRemove() 
+	if self.rendermesh then --prevent possible error
+		self.rendermesh:Destroy()
+		self.rendermesh = nil --garbage
+	end
+end
+
 net.Receive("starfall_custom_prop", function()
 	local index = net.ReadUInt(16)
 	local self, data

--- a/lua/entities/starfall_prop/cl_init.lua
+++ b/lua/entities/starfall_prop/cl_init.lua
@@ -44,10 +44,19 @@ function ENT:GetRenderMesh()
 	end
 end
 
-function ENT:OnRemove() 
+function ENT:OnRemove()
 	if self.rendermesh then --prevent possible error
 		self.rendermesh:Destroy()
-		self.rendermesh = nil --garbage
+	end
+
+	-- This is required because snapshots can cause OnRemove to run even if it wasn't removed.
+	local mesh = self.rendermesh
+	if mesh then
+		timer.Simple(0, function()
+			if not self:IsValid() then
+				self.rendermesh:Destroy()
+			end
+		end)
 	end
 end
 

--- a/lua/entities/starfall_prop/cl_init.lua
+++ b/lua/entities/starfall_prop/cl_init.lua
@@ -45,13 +45,8 @@ function ENT:GetRenderMesh()
 end
 
 function ENT:OnRemove()
-	if self.rendermesh then --prevent possible error
-		self.rendermesh:Destroy()
-	end
-
 	-- This is required because snapshots can cause OnRemove to run even if it wasn't removed.
-	local mesh = self.rendermesh
-	if mesh then
+	if self.rendermesh then
 		timer.Simple(0, function()
 			if not self:IsValid() then
 				self.rendermesh:Destroy()

--- a/lua/entities/starfall_prop/cl_init.lua
+++ b/lua/entities/starfall_prop/cl_init.lua
@@ -48,8 +48,9 @@ function ENT:OnRemove()
 	-- This is required because snapshots can cause OnRemove to run even if it wasn't removed.
 	if self.rendermesh then
 		timer.Simple(0, function()
-			if not self:IsValid() then
+			if self.rendermesh and not self:IsValid() then
 				self.rendermesh:Destroy()
+				self.rendermesh = nil
 			end
 		end)
 	end

--- a/lua/entities/starfall_prop/init.lua
+++ b/lua/entities/starfall_prop/init.lua
@@ -21,6 +21,12 @@ function ENT:TransmitData(recip)
 	return stream
 end
 
+function ENT:OnRemove() --cleanup potential collision listener
+    if self.PhysicsCollide then
+        self.PhysicsCollide = nil
+    end
+end
+
 hook.Add("PlayerInitialSpawn","SF_Initialize_Custom_Props",function(ply)
 	SF.WaitForPlayerInit(ply, function()
 		for k, v in ipairs(ents.FindByClass("starfall_prop")) do

--- a/lua/entities/starfall_prop/init.lua
+++ b/lua/entities/starfall_prop/init.lua
@@ -21,10 +21,6 @@ function ENT:TransmitData(recip)
 	return stream
 end
 
-function ENT:OnRemove() 
-	self.PhysicsCollide = nil --cleanup potential collision listener
-end
-
 hook.Add("PlayerInitialSpawn","SF_Initialize_Custom_Props",function(ply)
 	SF.WaitForPlayerInit(ply, function()
 		for k, v in ipairs(ents.FindByClass("starfall_prop")) do

--- a/lua/entities/starfall_prop/init.lua
+++ b/lua/entities/starfall_prop/init.lua
@@ -21,10 +21,8 @@ function ENT:TransmitData(recip)
 	return stream
 end
 
-function ENT:OnRemove() --cleanup potential collision listener
-    if self.PhysicsCollide then
-        self.PhysicsCollide = nil
-    end
+function ENT:OnRemove() 
+	self.PhysicsCollide = nil --cleanup potential collision listener
 end
 
 hook.Add("PlayerInitialSpawn","SF_Initialize_Custom_Props",function(ply)

--- a/lua/starfall/libs_sv/entities.lua
+++ b/lua/starfall/libs_sv/entities.lua
@@ -362,7 +362,7 @@ end
 function ents_methods:removeCollisionListener()
 	local ent = getent(self)
 	checkpermission(SF.instance, ent, "entities.canTool")
-	if not ent.SF_CollisionCallback or not ent.PhysicsCollide then SF.Throw("The entity isn't listening to collisions!", 2) end
+	if not ( ent.SF_CollisionCallback or ent.PhysicsCollide ) then SF.Throw("The entity isn't listening to collisions!", 2) end
 	if ent:GetClass() ~= "starfall_prop" then
 		ent:RemoveCallback("PhysicsCollide", ent.SF_CollisionCallback)
 		ent.SF_CollisionCallback = nil

--- a/lua/starfall/libs_sv/entities.lua
+++ b/lua/starfall/libs_sv/entities.lua
@@ -347,9 +347,16 @@ function ents_methods:addCollisionListener(func)
 	if ent.SF_CollisionCallback then SF.Throw("The entity is already listening to collisions!", 2) end
 
 	local instance = SF.instance
-	ent.SF_CollisionCallback = ent:AddCallback("PhysicsCollide", function(ent, data)
-		instance:runFunction(func, SF.StructWrapper(data))
-	end)
+	if ent:GetClass() == "prop_physics" then
+        ent.SF_CollisionCallback = ent:AddCallback("PhysicsCollide", function(ent, data)
+            instance:runFunction(func, SF.StructWrapper(data))
+        end)
+    else
+        function ent:PhysicsCollide( data, ent )
+            instance:runFunction(func, SF.StructWrapper(data))
+        end
+        ent.SF_CollisionCallback = ent.PhysicsCollide
+    end
 end
 
 --- Removes a collision listening hook from the entity so that a new one can be added
@@ -357,7 +364,11 @@ function ents_methods:removeCollisionListener()
 	local ent = getent(self)
 	checkpermission(SF.instance, ent, "entities.canTool")
 	if not ent.SF_CollisionCallback then SF.Throw("The entity isn't listening to collisions!", 2) end
-	ent:RemoveCallback("PhysicsCollide", ent.SF_CollisionCallback)
+	if ent:GetClass() == "prop_physics" then
+        ent:RemoveCallback("PhysicsCollide", ent.SF_CollisionCallback)
+    else
+        ent.PhysicsCollide = nil
+    end
 	ent.SF_CollisionCallback = nil
 end
 

--- a/lua/starfall/libs_sv/entities.lua
+++ b/lua/starfall/libs_sv/entities.lua
@@ -352,7 +352,7 @@ function ents_methods:addCollisionListener(func)
 			instance:runFunction(func, SF.StructWrapper(data))
 		end)
 	else
-		function ent:PhysicsCollide( data, ent )
+		function ent:PhysicsCollide( data, phys )
 			instance:runFunction(func, SF.StructWrapper(data))
 		end
 	end
@@ -362,11 +362,12 @@ end
 function ents_methods:removeCollisionListener()
 	local ent = getent(self)
 	checkpermission(SF.instance, ent, "entities.canTool")
-	if not ( ent.SF_CollisionCallback or ent.PhysicsCollide ) then SF.Throw("The entity isn't listening to collisions!", 2) end
 	if ent:GetClass() ~= "starfall_prop" then
+		if not ent.SF_CollisionCallback then SF.Throw("The entity isn't listening to collisions!", 2) end
 		ent:RemoveCallback("PhysicsCollide", ent.SF_CollisionCallback)
 		ent.SF_CollisionCallback = nil
 	else
+		if not ent.PhysicsCollide then SF.Throw("The entity isn't listening to collisions!", 2) end
 		ent.PhysicsCollide = nil
 	end
 end

--- a/lua/starfall/libs_sv/entities.lua
+++ b/lua/starfall/libs_sv/entities.lua
@@ -344,10 +344,10 @@ function ents_methods:addCollisionListener(func)
 	local ent = getent(self)
 	checkluatype(func, TYPE_FUNCTION)
 	checkpermission(SF.instance, ent, "entities.canTool")
-	if ent.SF_CollisionCallback then SF.Throw("The entity is already listening to collisions!", 2) end
-
+	
 	local instance = SF.instance
 	if ent:GetClass() ~= "starfall_prop" then
+		if ent.SF_CollisionCallback then SF.Throw("The entity is already listening to collisions!", 2) end
 		ent.SF_CollisionCallback = ent:AddCallback("PhysicsCollide", function(ent, data)
 			instance:runFunction(func, SF.StructWrapper(data))
 		end)
@@ -367,7 +367,6 @@ function ents_methods:removeCollisionListener()
 		ent:RemoveCallback("PhysicsCollide", ent.SF_CollisionCallback)
 		ent.SF_CollisionCallback = nil
 	else
-		if not ent.PhysicsCollide then SF.Throw("The entity isn't listening to collisions!", 2) end
 		ent.PhysicsCollide = nil
 	end
 end

--- a/lua/starfall/libs_sv/entities.lua
+++ b/lua/starfall/libs_sv/entities.lua
@@ -347,29 +347,28 @@ function ents_methods:addCollisionListener(func)
 	if ent.SF_CollisionCallback then SF.Throw("The entity is already listening to collisions!", 2) end
 
 	local instance = SF.instance
-	if ent:GetClass() == "prop_physics" then
-        ent.SF_CollisionCallback = ent:AddCallback("PhysicsCollide", function(ent, data)
-            instance:runFunction(func, SF.StructWrapper(data))
-        end)
-    else
-        function ent:PhysicsCollide( data, ent )
-            instance:runFunction(func, SF.StructWrapper(data))
-        end
-        ent.SF_CollisionCallback = ent.PhysicsCollide
-    end
+	if ent:GetClass() ~= "starfall_prop" then
+		ent.SF_CollisionCallback = ent:AddCallback("PhysicsCollide", function(ent, data)
+			instance:runFunction(func, SF.StructWrapper(data))
+		end)
+	else
+		function ent:PhysicsCollide( data, ent )
+			instance:runFunction(func, SF.StructWrapper(data))
+		end
+	end
 end
 
 --- Removes a collision listening hook from the entity so that a new one can be added
 function ents_methods:removeCollisionListener()
 	local ent = getent(self)
 	checkpermission(SF.instance, ent, "entities.canTool")
-	if not ent.SF_CollisionCallback then SF.Throw("The entity isn't listening to collisions!", 2) end
-	if ent:GetClass() == "prop_physics" then
-        ent:RemoveCallback("PhysicsCollide", ent.SF_CollisionCallback)
-    else
-        ent.PhysicsCollide = nil
-    end
-	ent.SF_CollisionCallback = nil
+	if not ent.SF_CollisionCallback or not ent.PhysicsCollide then SF.Throw("The entity isn't listening to collisions!", 2) end
+	if ent:GetClass() ~= "starfall_prop" then
+		ent:RemoveCallback("PhysicsCollide", ent.SF_CollisionCallback)
+		ent.SF_CollisionCallback = nil
+	else
+		ent.PhysicsCollide = nil
+	end
 end
 
 --- Set's the entity to collide with nothing but the world


### PR DESCRIPTION
Fix for collision listener for SENTS
SENTS have a different method from prop_physics to add a collision listener.
this is now set correctly.
Also an additional hook is added for starfall_prop to remove this collision listener if it was set.