### PR TITLE
Added StarfallError hook that reports script errors

### DIFF
--- a/lua/entities/starfall_processor/shared.lua
+++ b/lua/entities/starfall_processor/shared.lua
@@ -147,6 +147,10 @@ function ENT:Error(err)
 			net.SendToServer()
 		end
 	end
+	
+	for inst, _ in pairs(SF.allInstances) do
+		inst:runScriptHook("starfallerror", inst.Types.Entity.Wrap(self), inst.Types.Player.Wrap(SERVER and self.owner or LocalPlayer()), msg)
+	end
 end
 
 local function MenuOpen( ContextMenu, Option, Entity, Trace )

--- a/lua/starfall/libs_sh/hook.lua
+++ b/lua/starfall/libs_sh/hook.lua
@@ -501,7 +501,6 @@ end
 -- @param team Whether the message was team only
 -- @param isdead Whether the message was send from a dead player
 
-
 --- Called when starfall chip errors
 -- @name StarfallError
 -- @class hook

--- a/lua/starfall/libs_sh/hook.lua
+++ b/lua/starfall/libs_sh/hook.lua
@@ -500,3 +500,12 @@ end
 -- @param text The message
 -- @param team Whether the message was team only
 -- @param isdead Whether the message was send from a dead player
+
+
+--- Called when starfall chip errors
+-- @name StarfallError
+-- @class hook
+-- @shared
+-- @param ent Starfall chip that errored
+-- @param ply Owner of the chip on server or player that script errored for on client
+-- @param err Error message


### PR DESCRIPTION
Shared hook that will be fired when other instances error.
Provides chip entity, chip owner (or localplayer when on client) and a short message.

Example code:
```lua
hook.add("StarfallError", "", function(ent, ply, msg)
    print(ent, ply, msg)
    -- Entity [81][starfall_processor], Player [1][Name], SF:main:9: attempt to index local 'b' (a boolean value)
end)
```
