### PR TITLE
Registers a new SurfaceInfo type, add getBrushSurfaces() to entity methods

### DIFF
--- a/lua/starfall/libs_sh/entities.lua
+++ b/lua/starfall/libs_sh/entities.lua
@@ -1290,15 +1290,14 @@ end
 --- Returns a table of brushes surfaces for brush model entities.
 -- @shared
 -- @class function
--- @return Table of SurfaceInfos if the entity has a brush model, or an empty table otherwise.
+-- @return Table of SurfaceInfos if the entity has a brush model, or no value otherwise.
 function ents_methods:getBrushSurfaces()
 	local ent = getent(self)
 	local t = ent:GetBrushSurfaces()
+	if not t then return end
 	local out = {}
-	if t then
-		for k,surface in ipairs(t) do
-			out[k] = swrap(surface)
-		end
+	for k,surface in ipairs(t) do
+		out[k] = swrap(surface)
 	end
 	return out
 end

--- a/lua/starfall/libs_sh/entities.lua
+++ b/lua/starfall/libs_sh/entities.lua
@@ -1286,4 +1286,20 @@ function ents_methods:getHitBoxHitGroup(hitbox, hitboxset)
 	return getent(self):GetHitBoxHitGroup(hitbox, hitboxset)
 end
 
+--- Returns a table of brushes surfaces for brush model entities.
+-- @shared
+-- @class function
+-- @return Table of SurfaceInfos if the entity has a brush model, or no value otherwise.
+function ents_methods:getBrushSurfaces()
+	local ent = getent(self)
+	local t = ent:GetBrushSurfaces()
+	out = {}
+	if t then
+		for K,Surface in ipairs(t) do
+			out[K] = swrap(Surface)
+		end
+	end
+	return out
+end
+
 end

--- a/lua/starfall/libs_sh/entities.lua
+++ b/lua/starfall/libs_sh/entities.lua
@@ -28,6 +28,7 @@ local col_meta, cwrap, cunwrap = instance.Types.Color, instance.Types.Color.Wrap
 local phys_meta, pwrap, punwrap = instance.Types.PhysObj, instance.Types.PhysObj.Wrap, instance.Types.PhysObj.Unwrap
 local mtx_meta, mwrap, munwrap = instance.Types.VMatrix, instance.Types.VMatrix.Wrap, instance.Types.VMatrix.Unwrap
 local plywrap = instance.Types.Player.Wrap
+local swrap, sunwrap = instance.Types.SurfaceInfo.Wrap, instance.Types.SurfaceInfo.Unwrap
 
 local function getent(self)
 	local ent = eunwrap(self)
@@ -1289,14 +1290,14 @@ end
 --- Returns a table of brushes surfaces for brush model entities.
 -- @shared
 -- @class function
--- @return Table of SurfaceInfos if the entity has a brush model, or no value otherwise.
+-- @return Table of SurfaceInfos if the entity has a brush model, or an empty table otherwise.
 function ents_methods:getBrushSurfaces()
 	local ent = getent(self)
 	local t = ent:GetBrushSurfaces()
-	out = {}
+	local out = {}
 	if t then
-		for K,Surface in ipairs(t) do
-			out[K] = swrap(Surface)
+		for k,surface in ipairs(t) do
+			out[K] = swrap(surface)
 		end
 	end
 	return out

--- a/lua/starfall/libs_sh/entities.lua
+++ b/lua/starfall/libs_sh/entities.lua
@@ -1297,7 +1297,7 @@ function ents_methods:getBrushSurfaces()
 	local out = {}
 	if t then
 		for k,surface in ipairs(t) do
-			out[K] = swrap(surface)
+			out[k] = swrap(surface)
 		end
 	end
 	return out

--- a/lua/starfall/libs_sh/surfaceinfo.lua
+++ b/lua/starfall/libs_sh/surfaceinfo.lua
@@ -1,8 +1,4 @@
--- Globals
-local checkluatype = SF.CheckLuaType
-local checkpermission = SF.Permissions.check
-local registerprivilege = SF.Permissions.registerPrivilege
-
+-- Globals unneeded for now
 
 --- SurfaceInfo type
 -- @name SurfaceInfo
@@ -26,13 +22,14 @@ end
 ----------- Methods -----------
 
 local vec_meta, vwrap, vunwrap = instance.Types.Vector, instance.Types.Vector.Wrap, instance.Types.Vector.Unwrap
+local lwrap, lunwrap = instance.Types.LockedMaterial.Wrap, instance.Types.LockedMaterial.Unwrap
 
 --- Returns the brush surface's material.
--- @shared
+-- @client
 -- @return Material of one portion of a brush model.
 function surfaceinfo_methods:getMaterial()
     local surface = sunwrap(self)
-    return surface:GetMaterial()
+    return lwrap(surface:GetMaterial())
 end
 
 --- Returns a list of vertices the brush surface is built from.

--- a/lua/starfall/libs_sh/surfaceinfo.lua
+++ b/lua/starfall/libs_sh/surfaceinfo.lua
@@ -13,9 +13,7 @@ return function(instance)
 local surfaceinfo_methods, surfaceinfo_meta, swrap, sunwrap = instance.Types.SurfaceInfo.Methods, instance.Types.SurfaceInfo, instance.Types.SurfaceInfo.Wrap, instance.Types.SurfaceInfo.Unwrap
 
 function surfaceinfo_meta:__tostring()
-	local surfInfo = sunwrap(self)
-	if not surfInfo then return "(null SurfaceInfo)"
-	else return tostring(surfInfo) end
+	return "SurfaceInfo"
 end
 
 

--- a/lua/starfall/libs_sh/surfaceinfo.lua
+++ b/lua/starfall/libs_sh/surfaceinfo.lua
@@ -13,9 +13,9 @@ return function(instance)
 local surfaceinfo_methods, surfaceinfo_meta, swrap, sunwrap = instance.Types.SurfaceInfo.Methods, instance.Types.SurfaceInfo, instance.Types.SurfaceInfo.Wrap, instance.Types.SurfaceInfo.Unwrap
 
 function surfaceinfo_meta:__tostring()
-	local surfinf = sunwrap(self)
-	if not surfinf then return "(null SurfaceInfo)"
-	else return tostring(surfinf) end
+	local surfInfo = sunwrap(self)
+	if not surfInfo then return "(null SurfaceInfo)"
+	else return tostring(surfInfo) end
 end
 
 
@@ -28,20 +28,18 @@ local lwrap, lunwrap = instance.Types.LockedMaterial.Wrap, instance.Types.Locked
 -- @client
 -- @return Material of one portion of a brush model.
 function surfaceinfo_methods:getMaterial()
-    local surface = sunwrap(self)
-    return lwrap(surface:GetMaterial())
+    return lwrap(sunwrap(self):GetMaterial())
 end
 
 --- Returns a list of vertices the brush surface is built from.
 -- @shared
 -- @return A list of Vector points. This will usually be 4 corners of a quadrilateral in counter-clockwise order.
 function surfaceinfo_methods:getVertices()
-    local surface = sunwrap(self)
-    local t = surface:GetVertices()
+    local t = sunwrap(self):GetVertices()
     local out = {}
     if not t then return out end
-    for K,Vec in ipairs(t) do
-        out[K] = vwrap(Vec)
+    for k,vec in ipairs(t) do
+        out[k] = vwrap(vec)
     end
     return out
 end
@@ -51,8 +49,7 @@ end
 -- @shared
 -- @return Returns true if this surface won't be drawn.
 function surfaceinfo_methods:isNoDraw()
-    local surface = sunwrap(self)
-    return surface:IsNoDraw()
+    return sunwrap(self):IsNoDraw()
 end
 
 --- Checks if the brush surface is displaying the skybox.
@@ -60,8 +57,7 @@ end
 -- @shared
 -- @return Returns true if the surface is the sky.
 function surfaceinfo_methods:isSky()
-    local surface = sunwrap(self)
-    return surface:IsSky()
+    return sunwrap(self):IsSky()
 end
 
 --- Checks if the brush surface is water.
@@ -69,8 +65,7 @@ end
 -- @shared
 -- @return Returns true if the surface is water.
 function surfaceinfo_methods:isWater()
-    local surface = sunwrap(self)
-    return surface:IsWater()
+    return sunwrap(self):IsWater()
 end
 
 end

--- a/lua/starfall/libs_sh/surfaceinfo.lua
+++ b/lua/starfall/libs_sh/surfaceinfo.lua
@@ -1,0 +1,79 @@
+-- Globals
+local checkluatype = SF.CheckLuaType
+local checkpermission = SF.Permissions.check
+local registerprivilege = SF.Permissions.registerPrivilege
+
+
+--- SurfaceInfo type
+-- @name SurfaceInfo
+-- @class type
+-- @libtbl surfaceinfo_methods
+-- @libtbl surfaceinfo_meta
+
+SF.RegisterType("SurfaceInfo",false,true,debug.getregistry().SurfaceInfo)
+
+return function(instance) 
+
+local surfaceinfo_methods, surfaceinfo_meta, swrap, sunwrap = instance.Types.SurfaceInfo.Methods, instance.Types.SurfaceInfo, instance.Types.SurfaceInfo.Wrap, instance.Types.SurfaceInfo.Unwrap
+
+function surfaceinfo_meta:__tostring()
+	local surfinf = sunwrap(self)
+	if not surfinf then return "(null SurfaceInfo)"
+	else return tostring(surfinf) end
+end
+
+
+----------- Methods -----------
+
+local vec_meta, vwrap, vunwrap = instance.Types.Vector, instance.Types.Vector.Wrap, instance.Types.Vector.Unwrap
+
+--- Returns the brush surface's material.
+-- @shared
+-- @return Material of one portion of a brush model.
+function surfaceinfo_methods:getMaterial()
+    local surface = sunwrap(self)
+    return surface:GetMaterial()
+end
+
+--- Returns a list of vertices the brush surface is built from.
+-- @shared
+-- @return A list of Vector points. This will usually be 4 corners of a quadrilateral in counter-clockwise order.
+function surfaceinfo_methods:getVertices()
+    local surface = sunwrap(self)
+    local t = surface:GetVertices()
+    local out = {}
+    if not t then return out end
+    for K,Vec in ipairs(t) do
+        out[K] = vwrap(Vec)
+    end
+    return out
+end
+
+--- Checks if the brush surface is a nodraw surface, meaning it will not be drawn by the engine.
+-- This internally checks the SURFDRAW_NODRAW flag.
+-- @shared
+-- @return Returns true if this surface won't be drawn.
+function surfaceinfo_methods:isNoDraw()
+    local surface = sunwrap(self)
+    return surface:IsNoDraw()
+end
+
+--- Checks if the brush surface is displaying the skybox.
+-- This internally checks the SURFDRAW_SKY flag.
+-- @shared
+-- @return Returns true if the surface is the sky.
+function surfaceinfo_methods:isSky()
+    local surface = sunwrap(self)
+    return surface:IsSky()
+end
+
+--- Checks if the brush surface is water.
+-- This internally checks the SURFDRAW_WATER flag.
+-- @shared
+-- @return Returns true if the surface is water.
+function surfaceinfo_methods:isWater()
+    local surface = sunwrap(self)
+    return surface:IsWater()
+end
+
+end


### PR DESCRIPTION
Adds a new function in libs_sh,
Entity:getBrushSurfaces() which returns a surfaceinfo type, which was also added in a separate file.
( Fully registered )

The SurfaceInfo type includes functions:
- SurfaceInfo:getMaterial()
- SurfaceInfo:getVertices()
- SurfaceInfo:isNoDraw()
- SurfaceInfo:isSky()
- SurfaceInfo:isWater()

I need feedback as this is my first PR, but all functions are fully functional when testing on worldspawn