### PR TITLE
Added shared holograms example, fixes: #887

### DIFF
--- a/lua/starfall/examples/shared_holograms.lua
+++ b/lua/starfall/examples/shared_holograms.lua
@@ -32,9 +32,11 @@ else
         if ent==nil then error("Failed to get hologram!") end
         -- We need to convert it back to it's original type in order to use the Hologram methods on it
         local server_holo = ent:toHologram()
+        
         -- Let's now initialize a continuous hook that will use clientside-only method setRenderMatrix on our serverside hologram
         local m = Matrix()
         hook.add("tick", "scale", function()
+            if not server_holo:isValid() then return end
             local scale = 0.75 + math.sin(timer.curtime() * 10) / 4
             m:setScale(Vector(scale))
             m:rotate(Angle(0, 1, 0))

--- a/lua/starfall/examples/shared_holograms.lua
+++ b/lua/starfall/examples/shared_holograms.lua
@@ -47,7 +47,7 @@ else
     
     net.receive("holo", function(len)
         -- Since the client may not have created the hologram yet, it's important to use the callback of net.readEntity to wait and be sure it exists first.
-        local holo_index = net.readEntity(receivedHologram)
+        net.readEntity(receivedHologram)
     end)
     
 end

--- a/lua/starfall/examples/shared_holograms.lua
+++ b/lua/starfall/examples/shared_holograms.lua
@@ -14,8 +14,7 @@ if SERVER then
     
     hook.add("ClientInitialized", "cl_init", function(ply)
         net.start("holo")
-            -- To solve common issue with entities being invalid on client, we will send their index instead of using net.writeEntity
-            net.writeUInt(realm_holo:entIndex(), 16)
+            net.writeEntity(realm_holo)
         net.send(ply)
     end)
     
@@ -29,29 +28,24 @@ else
     -- you can manually set the render bounds (worth noting, that this method is part of the Entity type and works on clientside holograms)
     realm_holo:setRenderBounds(Vector(-5), Vector(5))
     
-    net.receive("holo", function(len)
-        local holo_index = net.readUInt(16)
-        
-        -- We now need to implement a system that will check check if the entity has initialized on the client, a timer will do for this example
-        timer.create("check_valid", 0.1, 0, function()
-            local ent = entity(holo_index)
-            if not ent or not ent:isValid() then return end
-            
-            -- Once the entity is valid, we need to convert it back to it's original type in order to use the Hologram methods on it
-            local server_holo = ent:toHologram()
-            
-            -- Let's now initialize a continuous hook that will use clientside-only method setRenderMatrix on our serverside hologram
-            local m = Matrix()
-            hook.add("tick", "scale", function()
-                local scale = 0.75 + math.sin(timer.curtime() * 10) / 4
-                m:setScale(Vector(scale))
-                m:rotate(Angle(0, 1, 0))
-                server_holo:setRenderMatrix(m)
-            end)
-            
-            -- Don't forget to remove the timer
-            timer.remove("check_valid")
+    local function receivedHologram(ent)
+        if ent==nil then error("Failed to get hologram!") end
+        -- We need to convert it back to it's original type in order to use the Hologram methods on it
+        local server_holo = ent:toHologram()
+        -- Let's now initialize a continuous hook that will use clientside-only method setRenderMatrix on our serverside hologram
+        local m = Matrix()
+        hook.add("tick", "scale", function()
+            local scale = 0.75 + math.sin(timer.curtime() * 10) / 4
+            m:setScale(Vector(scale))
+            m:rotate(Angle(0, 1, 0))
+            server_holo:setRenderMatrix(m)
         end)
+    end
+    
+    
+    net.receive("holo", function(len)
+        -- Since the client may not have created the hologram yet, it's important to use the callback of net.readEntity to wait and be sure it exists first.
+        local holo_index = net.readEntity(receivedHologram)
     end)
     
 end

--- a/lua/starfall/examples/shared_holograms.lua
+++ b/lua/starfall/examples/shared_holograms.lua
@@ -30,6 +30,7 @@ else
     
     local function receivedHologram(ent)
         if ent==nil then error("Failed to get hologram!") end
+        
         -- We need to convert it back to it's original type in order to use the Hologram methods on it
         local server_holo = ent:toHologram()
         
@@ -37,13 +38,13 @@ else
         local m = Matrix()
         hook.add("tick", "scale", function()
             if not server_holo:isValid() then return end
+            
             local scale = 0.75 + math.sin(timer.curtime() * 10) / 4
             m:setScale(Vector(scale))
             m:rotate(Angle(0, 1, 0))
             server_holo:setRenderMatrix(m)
         end)
     end
-    
     
     net.receive("holo", function(len)
         -- Since the client may not have created the hologram yet, it's important to use the callback of net.readEntity to wait and be sure it exists first.

--- a/lua/starfall/examples/shared_holograms.lua
+++ b/lua/starfall/examples/shared_holograms.lua
@@ -1,0 +1,50 @@
+--@name Shared Holograms
+--@author Name
+--@shared
+
+local offset = SERVER and Vector(10,0,30) or Vector(-10,0,30)
+local color = SERVER and Color(50,100,255) or Color(255,120,0)
+
+-- This will create 2 holograms, one on each of the realms
+local realm_holo = holograms.create(chip():getPos() + offset, Angle(), "models/hunter/blocks/cube025x025x025.mdl", Vector(0.5))
+realm_holo:setColor(color)
+
+-- Serverside holograms can be transmited to the client if needed
+if SERVER then
+    
+    hook.add("ClientInitialized", "cl_init", function(ply)
+        net.start("holo")
+            -- Most of the time you can treat them like normal entities, so using net.writeEntity will work just fine
+            net.writeEntity(realm_holo)
+        net.send(ply)
+    end)
+    
+else
+    
+    -- Clientside holograms are somewhat funky, please use them with care and note that certain functions won't work on them
+    -- realm_holo:obbSize() --> Vector(0,0,0)
+    -- realm_holo:getScale() --> Vector(0.5,0.5,0.5) - only because it's being internally accounted for when setting hologram's scale
+    
+    -- If you notice that holograms are disappearing too early, when their origin is off the screen,
+    -- you can manually set the render bounds (worth noting, that this method is part of the Entity type and works on clientside holograms)
+    realm_holo:setRenderBounds(Vector(-5), Vector(5))
+    
+    net.receive("holo", function(len)
+        -- When reading it from network, it will be just like any other entity,
+        -- so to use Hologram specific methods, we need to convert it back to the appropriate type
+        local server_holo = net.readEntity():toHologram()
+        
+        -- On a side note, please notice that script will error when reuploaded due to invalid entity later on,
+        -- it's always a good idea to implement some sort of buffer and send entity index, converting and validating it manually
+        
+        -- Let's now initialize a continuous hook that will use clientside-only method setRenderMatrix on our serverside hologram
+        local m = Matrix()
+        hook.add("tick", "scale", function()
+            local scale = 0.75 + math.sin(timer.curtime() * 10) / 4
+            m:setScale(Vector(scale))
+            m:rotate(Angle(0, 1, 0))
+            server_holo:setRenderMatrix(m)
+        end)
+    end)
+    
+end


### PR DESCRIPTION
- Creation of serverside and clientside holograms
- Transmitting holograms from server to client
- Converting to holograms from entities
- Usage of cl methods on cl holos
- Usage of cl methods on sv holos
- Simple matrix usage
- ~~Explains how certain methods might not be available~~
- Manual fixing of cl holo's render bounds
- Why am i writing this, go read code ;f
- Basic networking
- ~~Simplified explanation and possible fix to invalid entity when networking~~
