### PR TITLE
Fixed clientside holograms having incorrect render bounds

### DIFF
--- a/lua/starfall/libs_sh/holograms.lua
+++ b/lua/starfall/libs_sh/holograms.lua
@@ -32,7 +32,8 @@ if CLIENT then
 			holo:EnableMatrix("RenderMultiply", scalematrix)
 		end
 		if not holo.userrenderbounds then
-			holo:SetRenderBounds(holo:OBBMins() * scale, holo:OBBMaxs() * scale)
+			local mins, maxs = holo:GetModelBounds()
+			holo:SetRenderBounds(mins * scale, maxs * scale)
 		end
 	end
 end


### PR DESCRIPTION
Tested, seems to work fine, doesn't look like [Entity:GetModelBounds](https://wiki.facepunch.com/gmod/Entity:GetModelBounds) returns nil values.
