### PR TITLE
Make wire.adjustInputs and wire.adjustOutputs able to accept one table 

### DIFF
--- a/lua/starfall/libs_sv/wire.lua
+++ b/lua/starfall/libs_sv/wire.lua
@@ -242,7 +242,7 @@ local sfTypeToWireTypeTable = {
 }
 
 --- Creates/Modifies wire inputs. All wire ports must begin with an uppercase
--- letter and contain only alphabetical characters.
+-- letter and contain only alphabetical characters or numbers but may not begin with a number.
 -- @param names An array of input names. May be modified by the function.
 -- @param types An array of input types. Can be shortcuts. May be modified by the function.
 function wire_library.adjustInputs(names, types)
@@ -270,7 +270,7 @@ function wire_library.adjustInputs(names, types)
 end
 
 --- Creates/Modifies wire outputs. All wire ports must begin with an uppercase
--- letter and contain only alphabetical characters.
+-- letter and contain only alphabetical characters or numbers but may not begin with a number.
 -- @param names An array of output names. May be modified by the function.
 -- @param types An array of output types. Can be shortcuts. May be modified by the function.
 function wire_library.adjustOutputs(names, types)
@@ -309,7 +309,7 @@ function wire_library.adjustOutputs(names, types)
 end
 
 --- Creates/Modifies wire inputs/outputs. All wire ports must begin with an uppercase
--- letter and contain only alphabetical characters.
+-- letter and contain only alphabetical characters or numbers but may not begin with a number.
 -- @param inputs A key-value table with input port names as keys and types as values. Can be nil to not affect input ports.
 -- @param outputs A key-value table with output port names as keys and types as values. Can be nil to not affect output ports.
 function wire_library.adjustPorts(inputs, outputs)

--- a/lua/starfall/libs_sv/wire.lua
+++ b/lua/starfall/libs_sv/wire.lua
@@ -313,14 +313,14 @@ end
 -- @param inputs A key-value table with input port names as keys and types as values. Can be nil to not affect input ports.
 -- @param outputs A key-value table with output port names as keys and types as values. Can be nil to not affect output ports.
 function wire_library.adjustPorts(inputs, outputs)
-	if inputs then
+	if inputs ~= nil then
 		checkluatype(inputs, TYPE_TABLE)
 
 		local names = {}
 		local types = {}
 
 		for n,t in pairs( inputs ) do
-			if not isstring(n) or not isstring(t) then SF.Throw("Expected string string key value pairs, got a " .. type(n) .. " " .. type(t) .. " pair.", 2) end
+			if not isstring(n) or not isstring(t) then SF.Throw("Expected string string key value pairs, got a " .. SF.GetType(n) .. " " .. SF.GetType(t) .. " pair.", 2) end
 
 			table.insert(names, n)
 			table.insert(types, t)
@@ -329,14 +329,14 @@ function wire_library.adjustPorts(inputs, outputs)
 		wire_library.adjustInputs(names, types)
 	end
 
-	if outputs then
+	if outputs ~= nil then
 		checkluatype(outputs, TYPE_TABLE)
 
 		local names = {}
 		local types = {}
 
 		for n,t in pairs( outputs ) do
-			if not isstring(n) or not isstring(t) then SF.Throw("Expected string string key value pairs, got a " .. type(n) .. " " .. type(t) .. " pair.", 2) end
+			if not isstring(n) or not isstring(t) then SF.Throw("Expected string string key value pairs, got a " .. SF.GetType(n) .. " " .. SF.GetType(t) .. " pair.", 2) end
 
 			table.insert(names, n)
 			table.insert(types, t)

--- a/lua/starfall/libs_sv/wire.lua
+++ b/lua/starfall/libs_sv/wire.lua
@@ -308,6 +308,44 @@ function wire_library.adjustOutputs(names, types)
 	WireLib.AdjustSpecialOutputs(ent, names, types)
 end
 
+--- Creates/Modifies wire inputs/outputs. All wire ports must begin with an uppercase
+-- letter and contain only alphabetical characters.
+-- @param inputs A key-value table with input port names as keys and types as values. Can be nil to not affect input ports.
+-- @param outputs A key-value table with output port names as keys and types as values. Can be nil to not affect output ports.
+function wire_library.adjustPorts(inputs, outputs)
+	if inputs then
+		checkluatype(inputs, TYPE_TABLE)
+
+		local names = {}
+		local types = {}
+
+		for n,t in pairs( inputs ) do
+			if not isstring(n) or not isstring(t) then SF.Throw("Expected string string key value pairs, got a " .. type(n) .. " " .. type(t) .. " pair.", 2) end
+
+			table.insert(names, n)
+			table.insert(types, t)
+		end
+
+		wire_library.adjustInputs(names, types)
+	end
+
+	if outputs then
+		checkluatype(outputs, TYPE_TABLE)
+
+		local names = {}
+		local types = {}
+
+		for n,t in pairs( outputs ) do
+			if not isstring(n) or not isstring(t) then SF.Throw("Expected string string key value pairs, got a " .. type(n) .. " " .. type(t) .. " pair.", 2) end
+
+			table.insert(names, n)
+			table.insert(types, t)
+		end
+
+		wire_library.adjustOutputs(names, types)
+	end
+end
+
 --- Returns the wirelink representing this entity.
 function wire_library.self()
 	local ent = instance.data.entity


### PR DESCRIPTION
#804 

This PR makes it possible to include types in the first parameter as key-value table.

Examples
`wire.adjustInputs({FirstInput = 'number', SecondInput = 'string'})`
`wire.adjustOutputs({FirstOutput = 'number', SecondOutput = 'string'})`

I did not change any docs (or those comments above the functions) because I'm not sure how to describe it.