### PR TITLE
Fixed bug in timer.create function. When passing reps = nil it doesnt…

### DIFF
--- a/lua/starfall/libs_sh/timer.lua
+++ b/lua/starfall/libs_sh/timer.lua
@@ -96,6 +96,7 @@ end
 -- @param reps The repititions of the tiemr. 0 = infinte, nil = 1
 -- @param func The function to call when the timer is fired
 function timer_library.create(name, delay, reps, func)
+	reps = reps or 1
 	SF.CheckLuaType(name, TYPE_STRING)
 	SF.CheckLuaType(delay, TYPE_NUMBER)
 	reps = SF.CheckLuaType(reps, TYPE_NUMBER, 0, 1)

--- a/lua/starfall/libs_sh/timer.lua
+++ b/lua/starfall/libs_sh/timer.lua
@@ -93,13 +93,12 @@ end
 --- Creates (and starts) a timer
 -- @param name The timer name
 -- @param delay The time, in seconds, to set the timer to.
--- @param reps The repititions of the tiemr. 0 = infinte, nil = 1
+-- @param reps The repititions of the tiemr. 0 = infinte
 -- @param func The function to call when the timer is fired
 function timer_library.create(name, delay, reps, func)
-	reps = reps or 1
 	SF.CheckLuaType(name, TYPE_STRING)
 	SF.CheckLuaType(delay, TYPE_NUMBER)
-	reps = SF.CheckLuaType(reps, TYPE_NUMBER, 0, 1)
+	SF.CheckLuaType(reps, TYPE_NUMBER)
 	SF.CheckLuaType(func, TYPE_FUNCTION)
 
 	createTimer(name, delay, reps, func, false)


### PR DESCRIPTION
In the documentation of the timer.create function it says passing `nil` in the `reps` parameter should make the number of repetitions `1`, but right now it just fails the type check and crashes the chip.
The type check function for `reps` is being called with an extra argument maybe that was supposed to be the default value but right now `CheckLuaType` only takes 3 arguments.