### PR TITLE
Fix createFromImage bad path check

### DIFF
--- a/lua/starfall/libs_cl/material.lua
+++ b/lua/starfall/libs_cl/material.lua
@@ -498,8 +498,9 @@ function material_library.createFromImage(path, params)
 	checkluatype(params, TYPE_STRING)
 	local ext = string.GetExtensionFromFilename(path)
 	if ext ~= "jpg" and ext ~= "png" then SF.Throw("Expected a .jpg or .png file", 2) end
-
-	if not (file.Exists(SF.NormalizePath("materials/" .. path), "GAME") or (string.sub(path,1,5)=="data/" and file.Exists(SF.NormalizePath(path),"GAME" )) then
+		
+	path = SF.NormalizePath(path)
+	if not (file.Exists("materials/" .. path, "GAME") or (string.sub(path,1,5)=="data/" and file.Exists(path,"GAME"))) then
 		SF.Throw("The material path is invalid", 2)
 	end
 

--- a/lua/starfall/libs_cl/material.lua
+++ b/lua/starfall/libs_cl/material.lua
@@ -499,7 +499,7 @@ function material_library.createFromImage(path, params)
 	local ext = string.GetExtensionFromFilename(path)
 	if ext ~= "jpg" and ext ~= "png" then SF.Throw("Expected a .jpg or .png file", 2) end
 
-	if not (file.Exists(SF.NormalizePath("materials/" .. path), "GAME") or file.Exists(SF.NormalizePath("data/" .. path) , "GAME")) then
+	if not (file.Exists(SF.NormalizePath("materials/" .. path), "GAME") or (string.sub(path,1,5)=="data/" and file.Exists(SF.NormalizePath(path),"GAME" )) then
 		SF.Throw("The material path is invalid", 2)
 	end
 

--- a/lua/starfall/libs_cl/material.lua
+++ b/lua/starfall/libs_cl/material.lua
@@ -496,10 +496,11 @@ local image_params = {["nocull"] = true,["alphatest"] = true,["mips"] = true,["n
 function material_library.createFromImage(path, params)
 	checkluatype(path, TYPE_STRING)
 	checkluatype(params, TYPE_STRING)
+
+	path = SF.NormalizePath(path)
 	local ext = string.GetExtensionFromFilename(path)
 	if ext ~= "jpg" and ext ~= "png" then SF.Throw("Expected a .jpg or .png file", 2) end
-		
-	path = SF.NormalizePath(path)
+
 	if not (file.Exists("materials/" .. path, "GAME") or (string.sub(path,1,5)=="data/" and file.Exists(path,"GAME"))) then
 		SF.Throw("The material path is invalid", 2)
 	end


### PR DESCRIPTION
In material.createFromImage, Material() will never receive a valid path if used from the data/ folder. 

The current implementation prepends "data/" to the path, then checks if it exists in game using file.Exists with sf.NormalizePath 
This means that if you pass "data/sf_filedata/mymaterial.png" to the current function, the game will check to see if "data/data/sf_filedata/mymaterial.png" exists. 

The file will obviously not exist (unless it simultaneously exists in /data/data/%dest and /data/%dest)  

The function doesn't prepend /data/ to the absolute path it is passing to Material, which means that even if the file did pass the check, it would never be valid. 


The proposed changes now check to see if the first five characters of the path string are "/data", then performs the check on the absolute path if that condition is true (this also saves on IO operations)
