### PR TITLE
Convar library, allows for reading user settings

### DIFF
--- a/lua/starfall/libs_cl/convar.lua
+++ b/lua/starfall/libs_cl/convar.lua
@@ -28,10 +28,11 @@ end
 
 --- Check if the given ConVar exists
 -- @param name Name of the ConVar
+-- @return True if exists
 function convar_library.exists(name)
 	checkpermission(instance, nil, "convar")
 	checkluatype(name, TYPE_STRING)
-	return ConVarExists(name) and GetConVar(name)
+	return GetConVar(name) and true or false
 end
 
 --- Returns default value of the ConVar

--- a/lua/starfall/libs_cl/convar.lua
+++ b/lua/starfall/libs_cl/convar.lua
@@ -32,7 +32,7 @@ end
 function convar_library.exists(name)
 	checkpermission(instance, nil, "convar")
 	checkluatype(name, TYPE_STRING)
-	return GetConVar(name) and true or false
+	return GetConVar(name)~=nil
 end
 
 --- Returns default value of the ConVar

--- a/lua/starfall/libs_cl/convar.lua
+++ b/lua/starfall/libs_cl/convar.lua
@@ -1,0 +1,106 @@
+
+local checkluatype = SF.CheckLuaType
+
+SF.Permissions.registerPrivilege("convar", "Read ConVars", "Allows Starfall to read your game settings", { client = { default = 4 } })
+
+
+--- ConVar library https://wiki.facepunch.com/gmod/ConVar
+-- @name convar
+-- @class library
+-- @libtbl convar_library
+SF.RegisterLibrary("convar")
+
+return function(instance)
+local checkpermission = instance.player ~= NULL and SF.Permissions.check or function() end
+
+local convar_library = instance.Libraries.convar
+
+
+local function getValidConVar(name)
+	checkpermission(instance, nil, "convar")
+	checkluatype(name, TYPE_STRING)
+	
+	local cvar = GetConVar(name)
+	if not cvar then SF.Throw("Trying to access a non-existent ConVar", 3) end
+	return cvar
+end
+
+
+--- Check if the given ConVar exists
+-- @param name Name of the ConVar
+function convar_library.exists(name)
+	checkpermission(instance, nil, "convar")
+	checkluatype(name, TYPE_STRING)
+	return ConVarExists(name)
+end
+
+--- Returns default value of the ConVar
+-- @param name Name of the ConVar
+-- @return Default value as a string
+function convar_library.getDefault(name)
+	return getValidConVar(name):GetDefault()
+end
+
+--- Returns the minimum value of the convar
+-- @param name Name of the ConVar
+-- @return The minimum value or nil if not specified
+function convar_library.getMin(name)
+	return getValidConVar(name):GetMin()
+end
+
+--- Returns the maximum value of the convar
+-- @param name Name of the ConVar
+-- @return The maximum value or nil if not specified
+function convar_library.getMax(name)
+	return getValidConVar(name):GetMax()
+end
+
+--- Returns value of the ConVar as a boolean.
+-- True for numeric ConVars with the value of 1, false otherwise.
+-- @param name Name of the ConVar
+-- @return The boolean value
+function convar_library.getBool(name)
+	return getValidConVar(name):GetBool()
+end
+
+--- Returns value of the ConVar as a whole number.
+-- Floats values will be floored.
+-- @param name Name of the ConVar
+-- @return The integer value or 0 if converting fails
+function convar_library.getInt(name)
+	return getValidConVar(name):GetInt()
+end
+
+--- Returns value of the ConVar as a floating-point number.
+-- @param name Name of the ConVar
+-- @return The float value or 0 if converting fails
+function convar_library.getFloat(name)
+	return getValidConVar(name):GetFloat()
+end
+
+--- Returns value of the ConVar as a string.
+-- @param name Name of the ConVar
+-- @return Value as a string
+function convar_library.getString(name)
+	return getValidConVar(name):GetString()
+end
+
+--- Returns FCVAR flags of the given ConVar.
+-- https://wiki.facepunch.com/gmod/Enums/FCVAR
+-- @param name Name of the ConVar
+-- @return Number consisting of flag values
+function convar_library.getFlags(name)
+	return getValidConVar(name):GetFlags()
+end
+
+--- Returns true if a given FCVAR flag is set for this ConVar.
+-- https://wiki.facepunch.com/gmod/Enums/FCVAR
+-- @param name Name of the ConVar
+-- @return True if has the flag
+function convar_library.hasFlag(name, flag)
+	checkluatype(flag, TYPE_NUMBER)
+	return getValidConVar(name):IsFlagSet(flag)
+end
+
+
+end

--- a/lua/starfall/libs_cl/convar.lua
+++ b/lua/starfall/libs_cl/convar.lua
@@ -1,7 +1,7 @@
 
 local checkluatype = SF.CheckLuaType
 
-SF.Permissions.registerPrivilege("convar", "Read ConVars", "Allows Starfall to read your game settings", { client = { default = 4 } })
+SF.Permissions.registerPrivilege("convar", "Read ConVars", "Allows Starfall to read your game settings", { client = { default = 1 } })
 
 
 --- ConVar library https://wiki.facepunch.com/gmod/ConVar
@@ -21,7 +21,7 @@ local function getValidConVar(name)
 	checkluatype(name, TYPE_STRING)
 	
 	local cvar = GetConVar(name)
-	if not cvar then SF.Throw("Trying to access a non-existent ConVar", 3) end
+	if not cvar then SF.Throw("Trying to access non-existent ConVar", 3) end
 	return cvar
 end
 

--- a/lua/starfall/libs_cl/convar.lua
+++ b/lua/starfall/libs_cl/convar.lua
@@ -31,7 +31,7 @@ end
 function convar_library.exists(name)
 	checkpermission(instance, nil, "convar")
 	checkluatype(name, TYPE_STRING)
-	return ConVarExists(name)
+	return ConVarExists(name) and GetConVar(name)
 end
 
 --- Returns default value of the ConVar


### PR DESCRIPTION
Maybe not all of those functions are needed, but meh. Saves users from having to convert values themselves.
Default permission is same as `concmd`, disabled even for the owner. Whole library is only available on the clientside.
Why? Currently if you want to spawn, lets say, a gmod_lamp with specific parameters, they would override your currently set ones, which is annoying as hell! But using the convar lib, this becomes possible:
```lua
local brightness = convar.getFloat("lamp_brightness")
concmd("lamp_brightness 500; gmod_tool; gmod_toolmode lamp; +attack")

timer.simple(0.1, function()
    concmd("-attack; gmod_toolmode starfall_processor; lamp_brightness " .. brightness)
end)
```
which for now is the best way.
ofc it has many other fancy uses too.