### PR TITLE
tscm_compat: Introduce "tscm" preprocessor directive

### DIFF
--- a/lua/starfall/editor/syntaxmodes/starfall.lua
+++ b/lua/starfall/editor/syntaxmodes/starfall.lua
@@ -61,6 +61,7 @@ local directives = {
 	["@clientmain"] = 0,
 	["@superuser"] = 0,
 	["@model"] = 0,
+	["@tscm"] = 0
 }
 --Color scheme:
 --{foreground color, background color, fontStyle}

--- a/lua/starfall/instance.lua
+++ b/lua/starfall/instance.lua
@@ -523,6 +523,17 @@ function SF.Instance:initialize()
 	self:RunHook("initialize")
 
 	self:RunHook("prepare", "_initialize")
+
+	if self.ppdata.tscm and self.ppdata.tscm[self.mainfile] then
+		-- Enable TSCM compatibility. This operates inside the quota and other protections as it plays a lot with the environment directly.
+		local tbl = self:run(self.enableTSCMCompatibility)
+		if not tbl[1] then
+			self:RunHook("cleanup", "_initialize", true, tbl[2])
+			self:Error(tbl[2])
+			return false, tbl[2]
+		end
+	end
+
 	local func = self.scripts[self.mainfile]
 	local tbl = self:run(func)
 	if not tbl[1] then

--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -982,3 +982,7 @@ end
 -- @name superuser
 -- @class directive
 
+--- Enables TSCM compatibility mode. This is useful to get a TSCM script running, but isn't very documented right now. Can only be used in the main file. --@tscm
+-- @name tscm
+-- @class directive
+

--- a/lua/starfall/libs_sh/tscm_compat.lua
+++ b/lua/starfall/libs_sh/tscm_compat.lua
@@ -1,0 +1,39 @@
+-- Global to all starfalls
+
+return function(instance)
+
+-- This function is called as a "pre-main-file" function by instance.lua if the "@tscm" directive is supplied.
+function instance.enableTSCMCompatibility()
+	-- For obvious safety reasons, all functions here should not perform any direct actions.
+	-- This is effectively an emulation layer, though it might intervene when necessary.
+	-- For reference, see https://teamscm.co.uk/sfdoc/libraries/ents.html
+	local env = instance.env
+
+	-- New libraries
+	env.ents = env.ents or {}
+	env.ents.entity = env.entity
+	env.ents.owner = env.owner
+	env.ents.player = env.player
+	env.ents.self = env.chip
+
+	env.time = env.time or {}
+	env.time.curTime = env.timer.curtime
+	env.time.destroyTimer = env.timer.remove
+	env.time.exists = env.timer.exists
+	env.time.frameTime = env.timer.frametime
+	env.time.realTime = env.timer.realtime
+	env.time.stimer = env.timer.simple
+	env.time.sysTime = env.timer.systime
+	env.time.timer = env.timer.create
+
+	-- Entity
+	local ents_methods, ent_meta, ewrap, eunwrap = instance.Types.Entity.Methods, instance.Types.Entity, instance.Types.Entity.Wrap, instance.Types.Entity.Unwrap
+	ents_methods.class = ents_methods.getClass
+	ents_methods.pos = ents_methods.getPos
+	ents_methods.ang = ents_methods.getAngles
+	ents_methods.owner = ents_methods.getOwner
+
+end
+
+end
+

--- a/lua/starfall/preprocessor.lua
+++ b/lua/starfall/preprocessor.lua
@@ -179,3 +179,8 @@ SF.Preprocessor.SetGlobalDirective("superuser", function(args, filename, data)
 	if not data.superuser then data.superuser = {} end
 	data.superuser[filename] = true
 end)
+
+SF.Preprocessor.SetGlobalDirective("tscm", function(args, filename, data)
+	if not data.tscm then data.tscm = {} end
+	data.tscm[filename] = true
+end)


### PR DESCRIPTION
This is a basis for future work to allow the 'TSCM' Starfall variant's scripts to be executed on StarfallEx.

(For reference: https://teamscm.co.uk/sfdoc/index.html )

It adds a preprocessor directive, `@tscm`, to enable TSCM compatibility across the script (there are some mutually incompatible parts of TSCM that aren't yet dealt with here, particularly around, say, HUD rendering).

TSCM compatibility is achieved via a shared module which performs the required wrapping using other existing modules to avoid cluttering the main StarfallEx documentation with the aliases.

(Theoretically, this would be doable with completely in-Starfall code, but I'm not sure how to do that in a way that keeps said code distributed with StarfallEx.)

This adds 4 basic aliases on the Entity type (:class(), :pos(), :ang(), :owner()) along with the aliases for the `ents` and `time` sub-tables to demonstrate the concept.

The idea behind the structure is that this would severely bloat the documentation if applied directly.

An example program that works both here and on TSCM:

```lua
--@name compatibilityTest
--@author 20kdc
--@shared
--@tscm

local e = ents.self()
print(tostring(e:class()) .. " / " .. tostring(e:pos()) .. " / " .. tostring(e:ang()) .. " / " .. tostring(e:owner()))
```
