### PR TITLE
Fixed animations not playing for clientside holograms

### DIFF
--- a/lua/entities/starfall_hologram/cl_init.lua
+++ b/lua/entities/starfall_hologram/cl_init.lua
@@ -81,6 +81,10 @@ function ENT:DrawCLHologram()
 	else
 		self:DrawModel()
 	end
+	
+	if self.AutomaticFrameAdvance then
+		self:FrameAdvance(0)
+	end
 end
 
 function ENT:GetRenderMesh()


### PR DESCRIPTION
[ENTITY:Think](https://wiki.facepunch.com/gmod/ENTITY:Think) is not called for clientside holograms, even if [ENTITY:NextThink](https://wiki.facepunch.com/gmod/Entity:NextThink) or [ENTITY:SetNextClientThink](https://wiki.facepunch.com/gmod/Entity:SetNextClientThink) is used, that's why I put it in [ENT:DrawCLHologram](https://github.com/thegrb93/StarfallEx/blob/master/lua/entities/starfall_hologram/cl_init.lua#L68).
[ENTITY:FrameAdvance](https://wiki.facepunch.com/gmod/Entity:FrameAdvance) is the best solution I found after few hours of trying to fix this issue, it even automatically calculates the framerate based on [ENTITY:SetPlaybackRate](https://wiki.facepunch.com/gmod/Entity:SetPlaybackRate) that's set when initializing the animation. It requires to be called constantly tho.