### PR TITLE
Allow servers to block processor models

### DIFF
--- a/lua/entities/starfall_processor/init.lua
+++ b/lua/entities/starfall_processor/init.lua
@@ -19,6 +19,15 @@ function ENT:UpdateTransmitState()
 	return TRANSMIT_ALWAYS
 end
 
+function ENT:ValidateCustomModel(model)
+	if not util.IsValidModel(model) or not util.IsValidProp(model) then
+		return false
+	elseif IsValid(self.owner) and self.owner:IsPlayer() and not hook.Run("PlayerSpawnObject", self.owner, model) then
+		return false
+	end
+	return true
+end
+
 function ENT:SetCustomModel(model)
 	if self:GetModel() == model then return end
 	if self:GetParent():IsValid() then

--- a/lua/entities/starfall_processor/shared.lua
+++ b/lua/entities/starfall_processor/shared.lua
@@ -94,7 +94,7 @@ function ENT:SetupFiles(sfdata)
 	if SERVER then
 		if self.instance and self.instance.ppdata.models and self.instance.mainfile then
 			local model = self.instance.ppdata.models[self.instance.mainfile]
-			if model and util.IsValidModel(model) and util.IsValidProp(model) then
+			if model and self:ValidateCustomModel(model) then
 				self:SetCustomModel(model)
 			end
 		end


### PR DESCRIPTION
I copied this from [WireLib.CanModel](https://github.com/wiremod/wire/blob/c29e5c69df14a1f0f77dfe5ccdcfd8cdc41539ae/lua/wire/server/wirelib.lua#L1006-L1014) since we were having problem with people setting their processors to gigantic props.

(cc @jamie-34254)