### PR TITLE
Hide Tool Tip

### DIFF
--- a/lua/entities/starfall_processor/cl_init.lua
+++ b/lua/entities/starfall_processor/cl_init.lua
@@ -25,6 +25,7 @@ function ENT:OnRemove()
 end
 
 function ENT:GetOverlayText()
+	if self:GetColor().a == 0 then return "" end
 	local state = self:GetNWInt("State", 1)
 	local clientstr, serverstr
 	if self.instance then


### PR DESCRIPTION
Added Alpha check to prevent the drawing of the tool tip

If you set the chips alpha to 0, it will not render a tool tip overlay. 