### PR TITLE
Fixed clientside hologram animations not playing

### DIFF
--- a/lua/entities/starfall_hologram/cl_init.lua
+++ b/lua/entities/starfall_hologram/cl_init.lua
@@ -61,6 +61,10 @@ function ENT:Draw()
 		render.PopCustomClipPlane()
 	end
 	render.EnableClipping(false)
+	
+	if self.AutomaticFrameAdvance then
+		self:FrameAdvance(0)
+	end
 end
 
 function ENT:GetRenderMesh()


### PR DESCRIPTION
dbccd25fb73241ecb67cd7e51888d970f3540f20 broke my previous fix, because it got rid of [ENT:DrawCLHologram](https://github.com/thegrb93/StarfallEx/commit/dbccd25fb73241ecb67cd7e51888d970f3540f20#diff-caa948ff23967e4f89deb8898c810fedL68)