### PR TITLE
Added fog related hooks, functions and an example

### DIFF
--- a/lua/starfall/examples/fog_controller.lua
+++ b/lua/starfall/examples/fog_controller.lua
@@ -1,0 +1,35 @@
+--@name Fog Controller
+--@author Name
+--@client
+
+local distance = 0
+local density = 0
+
+local function setupFog(scale)
+    -- distances have to be corrected according to skybox's scale
+    local skybox_mul = scale or 1
+    
+    -- only calculate fog properties once, in SetupWorldFog hook
+    if not scale then
+        local chipPos = chip():getPos()
+        local ownerPos = owner():getPos()
+        
+        distance = chipPos:getDistance(ownerPos)
+        density = 1 - math.clamp(distance / 500, 0, 1)
+    end
+    
+    render.setFogMode(1)
+    render.setFogColor(Color(230,245,255))
+    
+    -- thickens the fog when you get closer to the chip
+    render.setFogDensity(density)
+    render.setFogStart(distance / 500 * skybox_mul)
+    render.setFogEnd((distance + 1000) * skybox_mul)
+end
+
+hook.add("SetupWorldFog", "", setupFog)
+hook.add("SetupSkyboxFog", "", setupFog)
+
+if player() == owner() then
+    render.setHUDActive(true)
+end

--- a/lua/starfall/libs_sh/enum.lua
+++ b/lua/starfall/libs_sh/enum.lua
@@ -576,11 +576,11 @@ env.MATERIAL = {
 }
 
 --- ENUMs of fog modes to use with render.setFogMode
--- @name builtins_library.FOG
+-- @name builtins_library.MATERIAL_FOG
 -- @field NONE
 -- @field LINEAR
 -- @field LINEAR_BELOW_FOG_Z
-env.FOG = {
+env.MATERIAL_FOG = {
 	["NONE"] = MATERIAL_FOG_NONE,
 	["LINEAR"] = MATERIAL_FOG_LINEAR,
 	["LINEAR_BELOW_FOG_Z"] = MATERIAL_FOG_LINEAR_BELOW_FOG_Z,

--- a/lua/starfall/libs_sh/enum.lua
+++ b/lua/starfall/libs_sh/enum.lua
@@ -575,4 +575,15 @@ env.MATERIAL = {
 	["TRIANGLE_STRIP"] = MATERIAL_TRIANGLE_STRIP
 }
 
+--- ENUMs of fog modes to use with render.setFogMode
+-- @name builtins_library.FOG
+-- @field NONE
+-- @field LINEAR
+-- @field LINEAR_BELOW_FOG_Z
+env.FOG = {
+	["NONE"] = MATERIAL_FOG_NONE,
+	["LINEAR"] = MATERIAL_FOG_LINEAR,
+	["LINEAR_BELOW_FOG_Z"] = MATERIAL_FOG_LINEAR_BELOW_FOG_Z,
+}
+
 end


### PR DESCRIPTION
I found out that `render.setFog*` functions **partially** work in [PreDrawOpaqueRenderables](https://wiki.facepunch.com/gmod/GM:PreDrawOpaqueRenderables), but I think it's actually quite fun since it affects entities, but not the map.
Tested on windows and linux, no crashes.