### PR TITLE
Make the documentation for --@clientmain more clear

### DIFF
--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -977,7 +977,9 @@ end
 -- @name client
 -- @class directive
 
---- Set the client file to run as main. Can only be used in the main file. --@clientmain somefile.txt
+--- Set the client file to run as main. Can only be used in the main file. The client file must be --@include'ed. The main file will not be sent to the client if you use this directive.
+-- --@include somefile.txt
+-- --@clientmain somefile.txt
 -- @name clientmain
 -- @class directive
 -- @param filename The file to run as main on client


### PR DESCRIPTION
This is my first pull request, so I hope I did everything correctly. Is there an easy way to verify that I haven't broken the SF Docs?

I was convinced this directive was broken for *months*. I was actually just about to file a bug report when I realized that I was failing to `--@include` the file the whole time. I don't want anyone else to be hitting their head against the wall like I was.

I verified that the main file is not sent to the client by checking `instance.source` and `instance.scripts`. Unless I'm missing something, the days of networking secrets to the chip via clientside Lua are over.