### PR TITLE
Fixed clientside print, Fixes: #975

### DIFF
--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -552,7 +552,7 @@ else
 
 	function builtins_library.print(...)
 		if instance.player == LocalPlayer() then
-			chat.AddText(unpack(argsToChat(...)))
+			chat.AddText(unpack((argsToChat(...))))
 		end
 	end
 


### PR DESCRIPTION
c72de3d6c5b2fe0c955864d875dc18f280febaad broke `unpack` by feeding it's last two arguments with `length` and `size` from `argsToChat`
Fixes: #975