### PR TITLE
Calcview hook documentation requires HUD

### DIFF
--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -2137,7 +2137,7 @@ end
 -- @param boolean isDrawingDepth Whether the current draw is writing depth.
 -- @param boolean isDrawSkybox Whether the current draw is drawing the skybox.
 
---- Called when the engine wants to calculate the player's view
+--- Called when the engine wants to calculate the player's view. (Only works with HUD)
 -- @name calcview
 -- @class hook
 -- @client


### PR DESCRIPTION
For consistency's sake, as other functions that require a linked HUD usually state so. Calcview requires a linked hud as per the canCalcview function.

Created pr twice because I thought I had messed up the branches.