### PR TITLE
Changes for the hologram removing functions

### DIFF
--- a/lua/starfall/libs_sh/holograms.lua
+++ b/lua/starfall/libs_sh/holograms.lua
@@ -190,19 +190,14 @@ function holograms_library.create(pos, ang, model, scale)
 end
 
 --- Removes all holograms created by the calling chip
--- @return number of holograms removed
 function holograms_library.removeAll()
 	if CLIENT and instance.data.render.isRendering then SF.Throw("Cannot remove while in rendering hook!", 2) end
 	
-	local holos = instance.data.holograms.holos
-	local removedHolos = 0
-	
-	for holo, _ in pairs(holos) do
-		if CLIENT then checkpermission(instance, holo, "hologram.create") end
-		holo:Remove()
-		removedHolos = removedHolos + 1
+	for holoent, _ in pairs(instance.data.holograms.holos) do
+		holoent:RemoveCallOnRemove("starfall_hologram_delete")
+		hologramOnDestroy(holoent, instance.data.holograms.holos, instance.player)
+		holoent:Remove()
 	end
-	return removedHolos
 end
 
 --- Checks if a user can spawn anymore holograms.

--- a/lua/starfall/libs_sh/holograms.lua
+++ b/lua/starfall/libs_sh/holograms.lua
@@ -189,6 +189,22 @@ function holograms_library.create(pos, ang, model, scale)
 	end
 end
 
+--- Removes all holograms created by the calling chip
+-- @return number of holograms removed
+function holograms_library.removeAll()
+	if CLIENT and instance.data.render.isRendering then SF.Throw("Cannot remove while in rendering hook!", 2) end
+	
+	local holos = instance.data.holograms.holos
+	local removedHolos = 0
+	
+	for holo, _ in pairs(holos) do
+		if CLIENT then checkpermission(instance, holo, "hologram.create") end
+		holo:Remove()
+		removedHolos = removedHolos + 1
+	end
+	return removedHolos
+end
+
 --- Checks if a user can spawn anymore holograms.
 -- @return True if user can spawn holograms, False if not.
 function holograms_library.canSpawn()

--- a/lua/starfall/libs_sh/holograms.lua
+++ b/lua/starfall/libs_sh/holograms.lua
@@ -198,17 +198,6 @@ function holograms_library.create(pos, ang, model, scale)
 	end
 end
 
---- Removes all holograms created by the calling chip
-function holograms_library.removeAll()
-	if CLIENT and instance.data.render.isRendering then SF.Throw("Cannot remove while in rendering hook!", 2) end
-	
-	for holoent, _ in pairs(instance.data.holograms.holos) do
-		holoent:RemoveCallOnRemove("starfall_hologram_delete")
-		hologramOnDestroy(holoent, instance.data.holograms.holos, instance.player)
-		holoent:Remove()
-	end
-end
-
 --- Checks if a user can spawn anymore holograms.
 -- @return True if user can spawn holograms, False if not.
 function holograms_library.canSpawn()


### PR DESCRIPTION
Removes all holograms created by the calling chip. Useful for reloading holograms on a new client, cleaning up in general. Returns number of holograms removed.

I believe all permissions are up to spec.