### PR TITLE
fix function typo

### DIFF
--- a/lua/starfall/libs_sh/bit.lua
+++ b/lua/starfall/libs_sh/bit.lua
@@ -89,7 +89,7 @@ local function PackIEEE754Float(number)
 	end
 end
 local function UnpackIEEE754Float(b4, b3, b2, b1)
-	local exponent = (b1 % 0x80) * 0x02 + math_rshift(b2, 7)
+	local exponent = (b1 % 0x80) * 0x02 + bit_rshift(b2, 7)
 	local mantissa = math_ldexp(((b2 % 0x80) * 0x100 + b3) * 0x100 + b4, -23)
 	if exponent == 0xFF then
 		if mantissa > 0 then

--- a/lua/starfall/libs_sh/color.lua
+++ b/lua/starfall/libs_sh/color.lua
@@ -5,30 +5,30 @@ local dgetmeta = debug.getmetatable
 local math_Clamp = math.Clamp
 local clamp = function(v) return math_Clamp(v, 0, 255) end
 
-local math_rshift = math.rshift
+local bit_rshift = bit.rshift
 local hex_to_rgb = {
 	[3] = function(v) return {
-		math_rshift(v, 8) % 0x10 * 0x11,
-		math_rshift(v, 4) % 0x10 * 0x11,
+		bit_rshift(v, 8) % 0x10 * 0x11,
+		bit_rshift(v, 4) % 0x10 * 0x11,
 		v % 0x10 * 0x11,
 		0xFF
 	} end,
 	[4] = function(v) return {
-		math_rshift(v, 12) % 0x10 * 0x11,
-		math_rshift(v, 8) % 0x10 * 0x11,
-		math_rshift(v, 4) % 0x10 * 0x11,
+		bit_rshift(v, 12) % 0x10 * 0x11,
+		bit_rshift(v, 8) % 0x10 * 0x11,
+		bit_rshift(v, 4) % 0x10 * 0x11,
 		v % 0x10 * 0x11,
 	} end,
 	[6] = function(v) return {
-		math_rshift(v, 16) % 0x100,
-		math_rshift(v, 8) % 0x100,
+		bit_rshift(v, 16) % 0x100,
+		bit_rshift(v, 8) % 0x100,
 		v % 0x100,
 		0xFF
 	} end,
 	[8] = function(v) return {
-		math_rshift(v, 24) % 0x100,
-		math_rshift(v, 16) % 0x100,
-		math_rshift(v, 8) % 0x100,
+		bit_rshift(v, 24) % 0x100,
+		bit_rshift(v, 16) % 0x100,
+		bit_rshift(v, 8) % 0x100,
 		v % 0x100
 	} end,
 }


### PR DESCRIPTION
Changed all instances of `math.rshift` to `bit.rshift` and all instances of `math_rshift` to `bit_rshift`.
`math.rshift` doesn't exist—I'm assuming this was just a typo.  Tested on my server, works fine after the patch.