### PR TITLE
Loosen restrictions on getfenv/setfenv

### DIFF
--- a/lua/starfall/instance.lua
+++ b/lua/starfall/instance.lua
@@ -130,6 +130,10 @@ function SF.Instance.Compile(code, mainfile, player, entity)
 		end
 	end
 
+	instance.whitelistedEnvs = setmetatable({
+		[instance.env] = true
+	}, {__mode = 'k'})
+
 	instance.startram = collectgarbage("count")
 
 	return true, instance

--- a/lua/starfall/instance.lua
+++ b/lua/starfall/instance.lua
@@ -130,10 +130,6 @@ function SF.Instance.Compile(code, mainfile, player, entity)
 		end
 	end
 
-	instance.whitelistedEnvs = setmetatable({
-		[instance.env] = true
-	}, {__mode = 'k'})
-
 	instance.startram = collectgarbage("count")
 
 	return true, instance

--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -797,8 +797,8 @@ function builtins_library.setfenv(location, environment)
 	elseif not isfunction(location) then
 		SF.ThrowTypeError("function or number", SF.GetType(location), 2)
 	end
-	if instance.whitelistedEnvs[getfenv(location)] then
-		instance.whitelistedEnvs[environment] = true
+	if whitelistedEnvs[getfenv(location)] then
+		whitelistedEnvs[environment] = true
 		return setfenv(location, environment)
 	end
 	SF.Throw("cannot change environment of given object", 2)
@@ -818,7 +818,7 @@ function builtins_library.getfenv(location)
 		SF.ThrowTypeError("function or number", SF.GetType(location), 2)
 	end
 	local fenv = getfenv(location)
-	if instance.whitelistedEnvs[fenv] then
+	if whitelistedEnvs[fenv] then
 		return fenv
 	end
 end

--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -784,6 +784,13 @@ end
 -- @param tbl New environment
 -- @return Function with environment set to tbl
 function builtins_library.setfenv(location, environment)
+	if location == nil then
+		location = 2
+	elseif isnumber(location) then
+		location = location+1 -- This makes setfenv appear as though it's not detoured.
+	elseif not isfunction(location) then
+		SF.ThrowTypeError("function or number", SF.GetType(location), 2)
+	end
 	if instance.whitelistedEnvs[getfenv(location)] then
 		instance.whitelistedEnvs[environment] = true
 		return setfenv(location, environment)
@@ -808,7 +815,14 @@ end
 -- @param funcOrStackLevel Function or stack level to get the environment of
 -- @return Environment table (or nil, if restricted)
 function builtins_library.getfenv(location)
-	local fenv = getfenv(location or 2)
+	if location == nil then
+		location = 2
+	elseif isnumber(location) then
+		location = location+1 -- This makes getfenv appear as though it's not detoured.
+	elseif not isfunction(location) then
+		SF.ThrowTypeError("function or number", SF.GetType(location), 2)
+	end
+	local fenv = getfenv(location)
 	if instance.whitelistedEnvs[fenv] then
 		return fenv
 	end

--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -777,6 +777,12 @@ function builtins_library.loadstring(str, name)
 	return func
 end
 
+-- Used for getfenv and setfenv.
+local whitelistedEnvs = setmetatable({
+	[instance.env] = true
+}, {__mode = 'k'})
+instance.whitelistedEnvs = whitelistedEnvs
+
 --- Lua's setfenv
 -- Sets the environment of either the stack level or the function specified.
 -- Note that this function will throw an error if you try to use it on anything outside of your sandbox.
@@ -798,17 +804,6 @@ function builtins_library.setfenv(location, environment)
 	SF.Throw("cannot change environment of given object", 2)
 end
 
---- Gets an SF type's methods table
--- @param sfType Name of SF type
--- @return Table of the type's methods which can be edited or iterated
-function builtins_library.getMethods(sfType)
-	checkluatype(sfType, TYPE_STRING)
-	local typemeta = instance.Types[sfType]
-	if typemeta then
-		return typemeta.Methods
-	end
-end
-
 --- Lua's getfenv
 -- Returns the environment of either the stack level or the function specified.
 -- Note that this function will return nil if the return value would be anything other than builtins_library or an environment you have passed to setfenv.
@@ -825,6 +820,17 @@ function builtins_library.getfenv(location)
 	local fenv = getfenv(location)
 	if instance.whitelistedEnvs[fenv] then
 		return fenv
+	end
+end
+
+--- Gets an SF type's methods table
+-- @param sfType Name of SF type
+-- @return Table of the type's methods which can be edited or iterated
+function builtins_library.getMethods(sfType)
+	checkluatype(sfType, TYPE_STRING)
+	local typemeta = instance.Types[sfType]
+	if typemeta then
+		return typemeta.Methods
 	end
 end
 


### PR DESCRIPTION
## New behavior
This change will allow `getfenv` to accept a function or stack level, and allow `setfenv` to accept a stack level. I am confident this is secure because I have added `instance.whitelistedEnvs`, a table that contains all environments `getfenv` is allowed to return and `setfenv` is allowed to replace. This whitelist contains only `instance.env` by default.

`getfenv` will return `nil` if the location's environment is not whitelisted.
`setfenv` will throw an error if the location's current environment is not whitelisted. If the *old* environment is whitelisted, it will add the *new* environment to the whitelist.

## Benefits
Being able to pass a function to `getfenv` would help with making sandboxes that have access to `setfenv`. To prevent the sandbox from changing the environment of external functions, `setfenv` could be detoured to refuse if the function's current environment is outside the sandbox (exactly as I've done here, but one level down). This can be done with a blacklist instead without the need for this change, but that's a pain in the ass.

This would also help with running code that is unaware of StarfallEx.

## Compatibility
This change is unlikely to break existing scripts, ~~although it could if some script depends on `getfenv` *always* returning `instance.env` no matter what, even if the caller is in a sandbox. I don't think that's likely though.~~ Whoops, I made an incorrect assumption about the old behavior. It won't break even in that case.

## Security
I've stared at my code for a while and I can't think of any way to exploit it (except as described in the next section). [I wrote some ugly scripts to check for vulnerabilities and accuracy](https://gist.github.com/x4fx77x4f/e997c64a57389349726e783b8c351554), and all of its tests pass on both your dfa6644 and my 088467c (tested on x86-64 branch on Linux).

## Things to consider

- While `getfenv` returns `nil` for out of bounds stack levels, it won't error if it's a valid level, which allows for a very minor case of information disclosure, as the chip can tell how deeply nested it is. This can be prevented.
- `setfenv` returns a function even if a stack level was put in. In the unlikely event an external function calls a sandboxed function *while having its environment set to a whitelisted environment,* the sandbox would be able to obtain a reference to the external function.
- Passing a number to parameter to `getfenv` or `setfenv` in a tail call will cause it to be as though it was called from the caller's parent. I'm not sure if this is intentional Lua behavior or a bug in LuaJIT. This is not exploitable, but it is fucking annoying.