### PR TITLE
Fixed big endian encoding of int32 and int16.

### DIFF
--- a/lua/starfall/libs_sh/bit.lua
+++ b/lua/starfall/libs_sh/bit.lua
@@ -456,7 +456,7 @@ end
 function ss_methods_big:writeInt16(x)
 	if x==math_huge or x==-math_huge or x~=x then error("Can't convert error float to integer!", 2) end
 	if x < 0 then x = x + 0x10000 end
-	self:write(bit_rshift(x, 8)%0x100, string.char(x%0x100))
+	self:write(string.char(bit_rshift(x, 8)%0x100, x%0x100))
 end
 
 --- Writes an int to the buffer and advances the buffer pointer.
@@ -469,7 +469,7 @@ end
 function ss_methods_big:writeInt32(x)
 	if x==math_huge or x==-math_huge or x~=x then error("Can't convert error float to integer!", 2) end
 	if x < 0 then x = x + 0x100000000 end
-	self:write(string.char(bit_rshift(x, 24)%0x100, bit_rshift(x, 16)%0x100, bit_rshift(x, 8)%0x100), x%0x100)
+	self:write(string.char(bit_rshift(x, 24)%0x100, bit_rshift(x, 16)%0x100, bit_rshift(x, 8)%0x100, x%0x100))
 end
 
 --- Writes a 4 byte IEEE754 float to the byte stream and advances the buffer pointer.


### PR DESCRIPTION
Before the fix
```lua
local stream = bit.stringstream("", 1, "big")
stream:writeInt32(90)
print(stream:size()) -- 3
```
only writes 3 bytes instead of 4.
```lua
local stream = bit.stringstream("", 1, "big")
stream:writeInt16(90)
print(stream:size())
```
fails with
```
addons/starfallex/lua/starfall/libs_sh/bit.lua:324: attempt to get length of local 'v' (a number value)
stack traceback:
	addons/starfallex/lua/starfall/libs_sh/bit.lua:324: in function 'size'
	SF:tests/stringstream_bigendian_test.txt:7: in main chunk
```
because `ss_methods:write(data)` expects a single string.