### PR TITLE
Add more Bass functions (setPan, getPan ...)

### DIFF
--- a/lua/starfall/libs_cl/bass.lua
+++ b/lua/starfall/libs_cl/bass.lua
@@ -312,7 +312,6 @@ end
 -- @return Boolean of whether the bass is valid.
 function bass_methods:isValid()
 	local uw = unwrap(self)
-
 	return uw and uw:IsValid()
 end
 
@@ -321,9 +320,29 @@ end
 -- @return The right sound level, a value between 0 and 1.
 function bass_methods:getLevels()
 	local uw = unwrap(self)
-
-	if (uw and uw:IsValid()) then
+	if uw and uw:IsValid() then
 		return uw:GetLevel()
+	end
+end
+
+--- Gets the relative volume between the left and right audio channels.
+-- @return number The pan. -1 for only left, 0 for centered, 1 for only right.
+function bass_methods:getPan()
+	local uw = unwrap(self)
+	if uw and uw:IsValid() then
+		return uw:GetPan()
+	end
+end
+
+--- Sets the relative volume of the left and right channels.
+-- @param number Relative volume between the left and right channels. -1 means only in left channel, 0 is center and 1 is only in the right channel.
+function bass_methods:setPan(pan)
+	checkluatype(pan, TYPE_NUMBER)
+	checkpermission(instance, nil, "sound.modify")
+
+	local uw = unwrap(self)
+	if uw and uw:IsValid() then
+		uw:SetPan( math.Clamp(pan, -1, 1) )
 	end
 end
 

--- a/lua/starfall/libs_cl/bass.lua
+++ b/lua/starfall/libs_cl/bass.lua
@@ -247,8 +247,6 @@ end
 function bass_methods:getLength()
 	local uw = unwrap(self)
 
-	checkpermission(instance, nil, "sound.modify")
-
 	if (uw and uw:IsValid()) then
 		return uw:GetLength()
 	end
@@ -272,8 +270,6 @@ end
 function bass_methods:getTime()
 	local uw = unwrap(self)
 
-	checkpermission(instance, nil, "sound.modify")
-
 	if (uw and uw:IsValid()) then
 		return uw:GetTime()
 	end
@@ -284,8 +280,6 @@ end
 -- @return Table containing DFT magnitudes, each between 0 and 1.
 function bass_methods:getFFT(n)
 	local uw = unwrap(self)
-
-	checkpermission(instance, nil, "sound.modify")
 
 	if (uw and uw:IsValid()) then
 		local arr = {}
@@ -298,8 +292,6 @@ end
 -- @return Boolean of whether the sound channel is streamed online.
 function bass_methods:isOnline()
 	local uw = unwrap(self)
-
-	checkpermission(instance, nil, "sound.modify")
 
 	if (uw and uw:IsValid()) then
 		return uw:IsOnline()
@@ -334,15 +326,36 @@ function bass_methods:getPan()
 	end
 end
 
---- Sets the relative volume of the left and right channels.
--- @param number Relative volume between the left and right channels. -1 means only in left channel, 0 is center and 1 is only in the right channel.
+--- Sets the relative volume of the left and right channels. Can only be -1, 0 or 1.
+-- @param number Relative integer volume between the left and right channels. -1 means only in left channel, 0 is center and 1 is only in the right channel.
 function bass_methods:setPan(pan)
 	checkluatype(pan, TYPE_NUMBER)
 	checkpermission(instance, nil, "sound.modify")
 
 	local uw = unwrap(self)
 	if uw and uw:IsValid() then
-		uw:SetPan( math.Clamp(pan, -1, 1) )
+		-- If we ever use / add Set3DEnabled to SF, remember to change this Is3D to Get3DEnabled
+		if uw:Is3D() then SF.Throw("You cannot set the pan of a 3D Bass Object!", 2) end
+		uw:SetPan( pan )
+	end
+end
+
+--- Retrieves the number of bits per sample of the sound channel.
+-- Doesn't work for mp3 and ogg files.
+-- @return number Floating point number of bits per sample, or 0 if unknown.
+function bass_methods:getBitsPerSample()
+	local uw = unwrap(self)
+	if uw and uw:IsValid() then
+		return uw:GetBitsPerSample()
+	end
+end
+
+--- Returns the average bit rate of the sound channel.
+-- @return number The average bit rate of the sound channel.
+function bass_methods:getAverageBitRate()
+	local uw = unwrap(self)
+	if uw and uw:IsValid() then
+		return uw:GetAverageBitRate()
 	end
 end
 

--- a/lua/starfall/libs_cl/bass.lua
+++ b/lua/starfall/libs_cl/bass.lua
@@ -44,6 +44,11 @@ local bass_library = instance.Libraries.bass
 local bass_methods, bass_meta, wrap, unwrap = instance.Types.Bass.Methods, instance.Types.Bass, instance.Types.Bass.Wrap, instance.Types.Bass.Unwrap
 local vec_meta, vwrap, vunwrap = instance.Types.Vector, instance.Types.Vector.Wrap, instance.Types.Vector.Unwrap
 
+local function getsnd(self)
+	local snd = unwrap(self)
+	return snd:IsValid() and snd or SF.Throw("Sound is not valid.", 3)
+end
+
 
 local function not3D(flags)
 	for flag in string.gmatch(string.lower(flags), "%S+") do if flag=="3d" then return false end end
@@ -133,8 +138,8 @@ end
 
 --- Removes the sound from the game so new one can be created if limit is reached
 function bass_methods:destroy()
-	local snd = unwrap(self)
-	if snd and sounds[snd] then
+	local snd = getsnd(self)
+	if sounds[snd] then
 		deleteSound(instance.player, snd)
 		sounds[snd] = nil
 		local sensitive2sf, sf2sensitive = bass_meta.sensitive2sf, bass_meta.sf2sensitive
@@ -148,215 +153,128 @@ end
 
 --- Starts to play the sound.
 function bass_methods:play()
-	local uw = unwrap(self)
-
-	checkpermission(instance, nil, "sound.modify")
-
-	if (uw and uw:IsValid()) then
-		uw:Play()
-	end
+	getsnd(self):Play()
 end
 
 --- Stops playing the sound.
 function bass_methods:stop()
-	local uw =  unwrap(self)
-
-	checkpermission(instance, nil, "sound.modify")
-
-	if (uw and uw:IsValid()) then
-		uw:Stop()
-	end
+	getsnd(self):Stop()
 end
 
 --- Pauses the sound.
 function bass_methods:pause()
-	local uw =  unwrap(self)
-
-	checkpermission(instance, nil, "sound.modify")
-
-	if (uw and uw:IsValid()) then
-		uw:Pause()
-	end
+	getsnd(self):Pause()
 end
 
 --- Sets the volume of the sound channel.
 -- @param vol Volume multiplier (1 is normal), between 0x and 10x.
 function bass_methods:setVolume(vol)
 	checkluatype(vol, TYPE_NUMBER)
-	local uw = unwrap(self)
-
-	checkpermission(instance, nil, "sound.modify")
-
-	if (uw and uw:IsValid()) then
-		uw:SetVolume(math.Clamp(vol, 0, 10))
-	end
+	getsnd(self):SetVolume(math.Clamp(vol, 0, 10))
 end
 
 --- Sets the pitch of the sound channel.
 -- @param pitch Pitch to set to, between 0 and 100. 1 is normal pitch.
 function bass_methods:setPitch(pitch)
 	checkluatype(pitch, TYPE_NUMBER)
-	local uw = unwrap(self)
-
-	checkpermission(instance, nil, "sound.modify")
-
-	if (uw and uw:IsValid()) then
-		uw:SetPlaybackRate(math.Clamp(pitch, 0, 100))
-	end
+	getsnd(self):SetPlaybackRate(math.Clamp(pitch, 0, 100))
 end
 
 --- Sets the position of the sound in 3D space. Must have `3d` flag to get this work on.
 -- @param pos Where to position the sound.
 function bass_methods:setPos(pos)
-	local uw = unwrap(self)
-
-	checkpermission(instance, nil, "sound.modify")
-
-	if (uw and uw:IsValid()) then
-		uw:SetPos(vunwrap(pos))
-	end
+	getsnd(self):SetPos(vunwrap(pos))
 end
 
 --- Sets the fade distance of the sound in 3D space. Must have `3d` flag to get this work on.
 -- @param min The channel's volume is at maximum when the listener is within this distance
 -- @param max The channel's volume stops decreasing when the listener is beyond this distance.
 function bass_methods:setFade(min, max)
-	local uw = unwrap(self)
-
-	checkpermission(instance, nil, "sound.modify")
-
-	if (uw and uw:IsValid()) then
-		uw:Set3DFadeDistance(math.Clamp(min, 50, 1000), math.Clamp(max, 10000, 200000))
-	end
+	getsnd(self):Set3DFadeDistance(math.Clamp(min, 50, 1000), math.Clamp(max, 10000, 200000))
 end
 
 --- Sets whether the sound channel should loop. Requires the 'noblock' flag
 -- @param loop Boolean of whether the sound channel should loop.
 function bass_methods:setLooping(loop)
-	local uw = unwrap(self)
-
-	checkpermission(instance, nil, "sound.modify")
-
-	if (uw and uw:IsValid()) then
-		uw:EnableLooping(loop)
-	end
+	getsnd(self):EnableLooping(loop)
 end
 
 --- Gets the length of a sound channel.
 -- @return Sound channel length in seconds.
 function bass_methods:getLength()
-	local uw = unwrap(self)
-
-	if (uw and uw:IsValid()) then
-		return uw:GetLength()
-	end
+	return getsnd(self):GetLength()
 end
 
 --- Sets the current playback time of the sound channel. Requires the 'noblock' flag
 -- @param time Sound channel playback time in seconds.
 function bass_methods:setTime(time)
 	checkluatype(time, TYPE_NUMBER)
-	local uw = unwrap(self)
-
-	checkpermission(instance, nil, "sound.modify")
-
-	if (uw and uw:IsValid()) then
-		uw:SetTime(time)
-	end
+	getsnd(self):SetTime(time)
 end
 
 --- Gets the current playback time of the sound channel. Requires the 'noblock' flag
 -- @return Sound channel playback time in seconds.
 function bass_methods:getTime()
-	local uw = unwrap(self)
-
-	if (uw and uw:IsValid()) then
-		return uw:GetTime()
-	end
+	return getsnd(self):GetTime()
 end
 
 --- Perform fast Fourier transform algorithm to compute the DFT of the sound channel.
 -- @param n Number of consecutive audio samples, between 0 and 7. Depending on this parameter you will get 256*2^n samples.
 -- @return Table containing DFT magnitudes, each between 0 and 1.
 function bass_methods:getFFT(n)
-	local uw = unwrap(self)
-
-	if (uw and uw:IsValid()) then
-		local arr = {}
-		uw:FFT(arr, n)
-		return arr
-	end
+	local arr = {}
+	getsnd(self):FFT(arr, n)
+	return arr
 end
 
 --- Gets whether the sound channel is streamed online.
 -- @return Boolean of whether the sound channel is streamed online.
 function bass_methods:isOnline()
-	local uw = unwrap(self)
-
-	if (uw and uw:IsValid()) then
-		return uw:IsOnline()
-	end
-
-	return false
+	return getsnd(self):IsOnline()
 end
 
 --- Gets whether the bass is valid.
 -- @return Boolean of whether the bass is valid.
 function bass_methods:isValid()
 	local uw = unwrap(self)
-	return uw and uw:IsValid()
+	return uw:IsValid()
 end
 
 --- Gets the left and right levels of the audio channel
 -- @return The left sound level, a value between 0 and 1.
 -- @return The right sound level, a value between 0 and 1.
 function bass_methods:getLevels()
-	local uw = unwrap(self)
-	if uw and uw:IsValid() then
-		return uw:GetLevel()
-	end
+	return getsnd(self):GetLevel()
 end
 
 --- Gets the relative volume between the left and right audio channels.
 -- @return number The pan. -1 for only left, 0 for centered, 1 for only right.
 function bass_methods:getPan()
-	local uw = unwrap(self)
-	if uw and uw:IsValid() then
-		return uw:GetPan()
-	end
+	return getsnd(self):GetPan()
 end
 
 --- Sets the relative volume of the left and right channels. Can only be -1, 0 or 1.
 -- @param number Relative integer volume between the left and right channels. -1 means only in left channel, 0 is center and 1 is only in the right channel.
 function bass_methods:setPan(pan)
 	checkluatype(pan, TYPE_NUMBER)
-	checkpermission(instance, nil, "sound.modify")
 
-	local uw = unwrap(self)
-	if uw and uw:IsValid() then
-		-- If we ever use / add Set3DEnabled to SF, remember to change this Is3D to Get3DEnabled
-		if uw:Is3D() then SF.Throw("You cannot set the pan of a 3D Bass Object!", 2) end
-		uw:SetPan( pan )
-	end
+	local uw = getsnd(self)
+	-- If we ever use / add Set3DEnabled to SF, remember to change this Is3D to Get3DEnabled
+	if uw:Is3D() then SF.Throw("You cannot set the pan of a 3D Bass Object!", 2) end
+	uw:SetPan( pan )
 end
 
 --- Retrieves the number of bits per sample of the sound channel.
 -- Doesn't work for mp3 and ogg files.
 -- @return number Floating point number of bits per sample, or 0 if unknown.
 function bass_methods:getBitsPerSample()
-	local uw = unwrap(self)
-	if uw and uw:IsValid() then
-		return uw:GetBitsPerSample()
-	end
+	return getsnd(self):GetBitsPerSample()
 end
 
 --- Returns the average bit rate of the sound channel.
 -- @return number The average bit rate of the sound channel.
 function bass_methods:getAverageBitRate()
-	local uw = unwrap(self)
-	if uw and uw:IsValid() then
-		return uw:GetAverageBitRate()
-	end
+	return getsnd(self):GetAverageBitRate()
 end
 
 end


### PR DESCRIPTION
Allows you to get and set the volume relative to the left and right audio channels.

Don't merge yet: I still need to clarify and ask some stuff:

Why do the bass get* functions check sound.modify when they don't modify the sounds? getLevels doesn't so it's a bit inconsistent, just wanted to ask before I try and change that

and

Is there a reason for the other IGModAudioChannel functions to not exist or should I add those (like GetAverageBitrate) to this PR as well?

I also need to check whether setPan being outside of the -1 and 1 range would break anything