### PR TITLE
Expose editor directive highlighting

### DIFF
--- a/lua/starfall/editor/syntaxmodes/starfall.lua
+++ b/lua/starfall/editor/syntaxmodes/starfall.lua
@@ -50,18 +50,10 @@ local keywords = {
 setmetatable(keywords, { __index = function(tbl, index) return {} end })
 setmetatable(storageTypes, { __index = function(tbl, index) return {} end })
 
-local directives = {
-	["@name"] = 0,
-	["@author"] = 0,
-	["@include"] = 0,
-	["@includedir"] = 0,
-	["@shared"] = 0,
-	["@client"] = 0,
-	["@server"] = 0,
-	["@clientmain"] = 0,
-	["@superuser"] = 0,
-	["@model"] = 0,
-}
+-- Get directives from the preprocessor so we don't have to hard-code them here.
+-- Allows for addons to make their own directives that properly highlight.
+local directives = SF.Preprocessor.directives
+
 --Color scheme:
 --{foreground color, background color, fontStyle}
 --Style can be: 0 - normal  1 - italic 2 - bold
@@ -581,7 +573,7 @@ function EDITOR:SyntaxColorLine(row)
 				self.tokendata = "" -- we dont need that anymore as we already added it
 
 				self:NextPattern("[%S]*") -- Find first word
-				if directives[self.tokendata] then --Directive
+				if directives[self.tokendata:sub(2)] then -- Search directives created with SF.Preprocessor.SetGlobalDirective
 					tokenname = "directive"
 				end
 				self:NextPattern(".*") -- Rest of comment/directive

--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -1087,6 +1087,10 @@ end
 -- @name client
 -- @class directive
 
+--- Set the current file to run on both the server and client. This is enabled by default. --@shared
+-- @name shared
+-- @class directive
+
 --- Set the client file to run as main. Can only be used in the main file. The client file must be --@include'ed. The main file will not be sent to the client if you use this directive.
 -- --@include somefile.txt
 -- --@clientmain somefile.txt

--- a/lua/starfall/preprocessor.lua
+++ b/lua/starfall/preprocessor.lua
@@ -170,6 +170,8 @@ SF.Preprocessor.SetGlobalDirective("client", function(args, filename, data)
 	data.serverorclient[filename] = "client"
 end)
 
+SF.Preprocessor.SetGlobalDirective("shared", function() end)
+
 SF.Preprocessor.SetGlobalDirective("clientmain", function(args, filename, data)
 	if not data.clientmain then data.clientmain = {} end
 	data.clientmain[filename] = args


### PR DESCRIPTION
Links the editor to the preprocessor's directives, so that there's no more hardcoding those to the editor.
This allows for addons to make their own directives that properly highlight (they couldn't before)

Also gave documentation to ``--@shared``