### PR TITLE
Doc Revamp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 doc/
 deploy_key
 deploy_key.pub
+/gendocs/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 doc/
 deploy_key
 deploy_key.pub
-/gendocs/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,27 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# production
+/build
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
 doc/
 deploy_key
 deploy_key.pub

--- a/lua/starfall/editor/docs.lua
+++ b/lua/starfall/editor/docs.lua
@@ -109,15 +109,16 @@ local generic_lua_types = {
 	["..."] = true,
 	["any"] = true,
 	["function"] = true,
+	["thread"] = true
 }
 
-local sf_types = SF.Types
+local sf_types = Docs.Types -- Get the types from documentation rather than the lua state
 
 local function valid_sftype(type1)
 	if sf_types[type1] or generic_lua_types[type1] then return true end
 
 	if string_find(type1, "|", 1, true) then
-		for _, match in next, type1:Split("|") do
+		for match in type1:gmatch("[^|]+") do
 			if not (sf_types[match] or generic_lua_types[match]) then
 				return false
 			end
@@ -219,11 +220,8 @@ local function parse(parsing, data)
 end
 
 local function scan(src, realm)
-	local linetbl = string.Explode("\r?\n", src, true)
-	local i = 0
-	local function lines() i=i+1 return linetbl[i] end
 	local parsing
-	for line in lines do
+	for line in src:gmatch("[^\n\r]+") do
 		if parsing then
 			local data = string_match(line, "^%s*%-%-%-*(.*)")
 			if data then

--- a/lua/starfall/editor/docs.lua
+++ b/lua/starfall/editor/docs.lua
@@ -121,19 +121,20 @@ local parseAttributes = {
 		t[#t+1] = value
 	end,
 	["param"] = function(parsing, value)
-		local name, description = string.match(value, "%s*([%w_%.]+)%s*(.*)")
-		if name then
+		local type, name, description = string.match(value, "%s*([%w_%.%?]+)%s*([%w_%.]+)%s*(.*)")
+		if type then
 			local t = parsing.params
 			if not t then t = {} parsing.params = t end
-			t[#t+1] = {name = name, description = description}
+			t[#t+1] = {name = name, description = string.format("Type: %s, Desc: %s", type, description)}
 		else
 			ErrorNoHalt("Invalid param doc (" .. value .. ") in file: " .. curfile .. "\n")
 		end
 	end,
 	["return"] = function(parsing, value)
+		local type, description = string.match(value, "%s*([%w_%.%?]+)%s*(.*)")
 		local t = parsing.returns
 		if not t then t = {} parsing.returns = t end
-		t[#t+1] = value
+		t[#t+1] = string.format("Type: %s, Desc: %s", type, description)
 	end,
 	["field"] = function(parsing, value)
 		local name, description = string.match(value, "%s*([%w_]+)%s*(.*)")

--- a/lua/starfall/editor/docs.lua
+++ b/lua/starfall/editor/docs.lua
@@ -228,12 +228,14 @@ end
 
 local function getLines(str)
 	local current_pos = 1
+	local lineN = 0
 	return function()
 		local start_pos, end_pos = string_find( str, "\r?\n", current_pos )
 		if start_pos then
 			local ret = string_sub( str, current_pos, start_pos - 1 )
 			current_pos = end_pos + 1
-			return ret
+			lineN = lineN + 1
+			return lineN, ret
 		else
 			return nil
 		end
@@ -246,17 +248,15 @@ local function scan(src, realm)
 	-- https://github.com/thegrb93/StarfallEx/blob/master/lua/starfall/...
 	local filePath = string_match(curfile, "%.%./lua/starfall/(libs_.+/.*)") -- libs_sh/... path that will be used for links with [src] on the sfhelper to the github.
 	local parsing
-	local lineN = 0
 	local lines = getLines(src)
-	for line in lines do
-		lineN = lineN + 1
+	for lineN, line in lines do
 		if parsing then
 			local data = string_match(line, "^%s*%-%-%-*(.*)")
 			if data then
 				parse(parsing, data, lineN)
 			else
 				while line and not string.find(line, "%S") do -- Find next non-empty line
-					line = lines()
+					lineN, line = lines()
 				end
 				process(parsing, line or "", lineN)
 				parsing = nil

--- a/lua/starfall/editor/docs.lua
+++ b/lua/starfall/editor/docs.lua
@@ -148,7 +148,7 @@ local parseAttributes = {
 		local type, name, description = string.match(value, "%s*([%w_%.%?]+)%s*([%w_%.]+)%s*(.*)")
 		if type then
 			if not valid_sftype(type) then
-				-- No type found, revert to old typeless documentation
+				-- No type found, revert to old untyped documentation
 				type = "any?"
 				name, description = string.match(value, "%s*([%w_%.]+)%s*(.*)")
 				if name==nil then
@@ -161,7 +161,7 @@ local parseAttributes = {
 			t[#t+1] = {
 				name = name,
 				description = description,
-				type = _type
+				type = type
  			}
 		else
 			ErrorNoHalt("Invalid param doc (" .. value .. ") in file: " .. curfile .. "\n")
@@ -171,7 +171,7 @@ local parseAttributes = {
 		local type, description = string.match(value, "%s*([%w_%.%?]+)%s*(.*)")
 		if type then
 			if not valid_sftype(type) then
-				-- No type found, revert to old typeless documentation
+				-- No type found, revert to old untyped documentation
 				type = "any?"
 				description = value
 			end

--- a/lua/starfall/editor/docs.lua
+++ b/lua/starfall/editor/docs.lua
@@ -145,7 +145,7 @@ local parseAttributes = {
 		t[#t+1] = value
 	end,
 	["param"] = function(parsing, value)
-		local type, name, desc = string.match(value, "%s*([%w_%.%?]+)%s*([%w_%.]+)%s*(.*)")
+		local type, name, description = string.match(value, "%s*([%w_%.%?]+)%s*([%w_%.]+)%s*(.*)")
 		if type then
 			if not valid_sftype(type) then
 				-- No type found, revert to old typeless documentation

--- a/lua/starfall/instance.lua
+++ b/lua/starfall/instance.lua
@@ -32,7 +32,7 @@ SF.playerInstances = {}
 --- Preprocesses and Compiles code and returns an Instance
 -- @param code Either a string of code, or a {path=source} table
 -- @param mainfile If code is a table, this specifies the first file to parse.
--- @param player The "owner" of the instance
+-- @param Player The "owner" of the instance
 -- @param data The table to set instance.data to. Default is a new table.
 -- @return True if no errors, false if errors occured.
 -- @return The compiled instance, or the error message.

--- a/lua/starfall/libs_cl/bass.lua
+++ b/lua/starfall/libs_cl/bass.lua
@@ -57,12 +57,12 @@ local function not3D(flags)
 end
 
 --- Loads a sound channel from a file.
--- @param path File path to play from.
--- @param flags Flags for the sound (`3d`, `mono`, `noplay`, `noblock`).
--- @param callback Function which is called when the sound channel is loaded. It'll get 3 arguments: `Bass` object, error number and name.
+-- @param string path File path to play from.
+-- @param string flags Flags for the sound (`3d`, `mono`, `noplay`, `noblock`).
+-- @param function callback Function which is called when the sound channel is loaded. It'll get 3 arguments: `Bass` object, error number and name.
 function bass_library.loadFile(path, flags, callback)
 	checkpermission(instance, nil, "bass.loadFile")
-	
+
 	checkluatype(path, TYPE_STRING)
 	checkluatype(flags, TYPE_STRING)
 	checkluatype(callback, TYPE_FUNCTION)
@@ -94,9 +94,9 @@ function bass_library.loadFile(path, flags, callback)
 end
 
 --- Loads a sound channel from an URL.
--- @param path URL path to play from.
--- @param flags Flags for the sound (`3d`, `mono`, `noplay`, `noblock`).
--- @param callback Function which is called when the sound channel is loaded. It'll get 3 arguments: `Bass` object, error number and name.
+-- @param string path URL path to play from.
+-- @param string flags Flags for the sound (`3d`, `mono`, `noplay`, `noblock`).
+-- @param function callback Function which is called when the sound channel is loaded. It'll get 3 arguments: `Bass` object, error number and name.
 function bass_library.loadURL(path, flags, callback)
 	checkpermission(instance, path, "bass.loadURL")
 
@@ -129,7 +129,7 @@ function bass_library.loadURL(path, flags, callback)
 end
 
 --- Returns the number of sounds left that can be created
--- @return The number of sounds left
+-- @return number The number of sounds left
 function bass_library.soundsLeft()
 	return plyCount:check(instance.player)
 end
@@ -167,60 +167,60 @@ function bass_methods:pause()
 end
 
 --- Sets the volume of the sound channel.
--- @param vol Volume multiplier (1 is normal), between 0x and 10x.
+-- @param number vol Volume multiplier (1 is normal), between 0x and 10x.
 function bass_methods:setVolume(vol)
 	checkluatype(vol, TYPE_NUMBER)
 	getsnd(self):SetVolume(math.Clamp(vol, 0, 10))
 end
 
 --- Sets the pitch of the sound channel.
--- @param pitch Pitch to set to, between 0 and 100. 1 is normal pitch.
+-- @param number pitch Pitch to set to. (0-100) 1 is normal pitch.
 function bass_methods:setPitch(pitch)
 	checkluatype(pitch, TYPE_NUMBER)
 	getsnd(self):SetPlaybackRate(math.Clamp(pitch, 0, 100))
 end
 
 --- Sets the position of the sound in 3D space. Must have `3d` flag to get this work on.
--- @param pos Where to position the sound.
+-- @param vector pos Where to position the sound.
 function bass_methods:setPos(pos)
 	getsnd(self):SetPos(vunwrap(pos))
 end
 
 --- Sets the fade distance of the sound in 3D space. Must have `3d` flag to get this work on.
--- @param min The channel's volume is at maximum when the listener is within this distance
--- @param max The channel's volume stops decreasing when the listener is beyond this distance.
+-- @param number min The channel's volume is at maximum when the listener is within this distance (50-1000)
+-- @param number max The channel's volume stops decreasing when the listener is beyond this distance. (10,000-200,000)
 function bass_methods:setFade(min, max)
 	getsnd(self):Set3DFadeDistance(math.Clamp(min, 50, 1000), math.Clamp(max, 10000, 200000))
 end
 
 --- Sets whether the sound channel should loop. Requires the 'noblock' flag
--- @param loop Boolean of whether the sound channel should loop.
+-- @param boolean loop Whether the sound channel should loop.
 function bass_methods:setLooping(loop)
 	getsnd(self):EnableLooping(loop)
 end
 
 --- Gets the length of a sound channel.
--- @return Sound channel length in seconds.
+-- @return number Sound channel length in seconds.
 function bass_methods:getLength()
 	return getsnd(self):GetLength()
 end
 
 --- Sets the current playback time of the sound channel. Requires the 'noblock' flag
--- @param time Sound channel playback time in seconds.
+-- @param number time Sound channel playback time in seconds.
 function bass_methods:setTime(time)
 	checkluatype(time, TYPE_NUMBER)
 	getsnd(self):SetTime(time)
 end
 
 --- Gets the current playback time of the sound channel. Requires the 'noblock' flag
--- @return Sound channel playback time in seconds.
+-- @return number Sound channel playback time in seconds.
 function bass_methods:getTime()
 	return getsnd(self):GetTime()
 end
 
 --- Perform fast Fourier transform algorithm to compute the DFT of the sound channel.
--- @param n Number of consecutive audio samples, between 0 and 7. Depending on this parameter you will get 256*2^n samples.
--- @return Table containing DFT magnitudes, each between 0 and 1.
+-- @param number n Number of consecutive audio samples, between 0 and 7. Depending on this parameter you will get 256*2^n samples.
+-- @return table Table containing DFT magnitudes, each between 0 and 1.
 function bass_methods:getFFT(n)
 	local arr = {}
 	getsnd(self):FFT(arr, n)
@@ -228,21 +228,21 @@ function bass_methods:getFFT(n)
 end
 
 --- Gets whether the sound channel is streamed online.
--- @return Boolean of whether the sound channel is streamed online.
+-- @return boolean Boolean of whether the sound channel is streamed online.
 function bass_methods:isOnline()
 	return getsnd(self):IsOnline()
 end
 
 --- Gets whether the bass is valid.
--- @return Boolean of whether the bass is valid.
+-- @return boolean Boolean of whether the bass is valid.
 function bass_methods:isValid()
 	local uw = unwrap(self)
 	return uw:IsValid()
 end
 
 --- Gets the left and right levels of the audio channel
--- @return The left sound level, a value between 0 and 1.
--- @return The right sound level, a value between 0 and 1.
+-- @return number The left sound level, a value between 0 and 1.
+-- @return number The right sound level, a value between 0 and 1.
 function bass_methods:getLevels()
 	return getsnd(self):GetLevel()
 end

--- a/lua/starfall/libs_cl/bass.lua
+++ b/lua/starfall/libs_cl/bass.lua
@@ -181,7 +181,7 @@ function bass_methods:setPitch(pitch)
 end
 
 --- Sets the position of the sound in 3D space. Must have `3d` flag to get this work on.
--- @param vector pos Where to position the sound.
+-- @param Vector pos Where to position the sound.
 function bass_methods:setPos(pos)
 	getsnd(self):SetPos(vunwrap(pos))
 end

--- a/lua/starfall/libs_cl/convar.lua
+++ b/lua/starfall/libs_cl/convar.lua
@@ -28,7 +28,7 @@ end
 
 --- Check if the given ConVar exists
 -- @param name Name of the ConVar
--- @return True if exists
+-- @return boolean True if exists
 function convar_library.exists(name)
 	checkpermission(instance, nil, "convar")
 	checkluatype(name, TYPE_STRING)
@@ -36,38 +36,38 @@ function convar_library.exists(name)
 end
 
 --- Returns default value of the ConVar
--- @param name Name of the ConVar
--- @return Default value as a string
+-- @param string name Name of the ConVar
+-- @return string Default value as a string
 function convar_library.getDefault(name)
 	return getValidConVar(name):GetDefault()
 end
 
 --- Returns the minimum value of the convar
--- @param name Name of the ConVar
--- @return The minimum value or nil if not specified
+-- @param string name Name of the ConVar
+-- @return number The minimum value or nil if not specified
 function convar_library.getMin(name)
 	return getValidConVar(name):GetMin()
 end
 
 --- Returns the maximum value of the convar
--- @param name Name of the ConVar
--- @return The maximum value or nil if not specified
+-- @param string name Name of the ConVar
+-- @return number? The maximum value or nil if not specified
 function convar_library.getMax(name)
 	return getValidConVar(name):GetMax()
 end
 
 --- Returns value of the ConVar as a boolean.
 -- True for numeric ConVars with the value of 1, false otherwise.
--- @param name Name of the ConVar
--- @return The boolean value
+-- @param string name Name of the ConVar
+-- @return boolean The boolean value
 function convar_library.getBool(name)
 	return getValidConVar(name):GetBool()
 end
 
 --- Returns value of the ConVar as a whole number.
 -- Floats values will be floored.
--- @param name Name of the ConVar
--- @return The integer value or 0 if converting fails
+-- @param string name Name of the ConVar
+-- @return number The integer value or 0 if converting fails
 function convar_library.getInt(name)
 	return getValidConVar(name):GetInt()
 end
@@ -80,24 +80,24 @@ function convar_library.getFloat(name)
 end
 
 --- Returns value of the ConVar as a string.
--- @param name Name of the ConVar
--- @return Value as a string
+-- @param string name Name of the ConVar
+-- @return string Value as a string
 function convar_library.getString(name)
 	return getValidConVar(name):GetString()
 end
 
 --- Returns FCVAR flags of the given ConVar.
 -- https://wiki.facepunch.com/gmod/Enums/FCVAR
--- @param name Name of the ConVar
--- @return Number consisting of flag values
+-- @param string name Name of the ConVar
+-- @return number Number consisting of flag values
 function convar_library.getFlags(name)
 	return getValidConVar(name):GetFlags()
 end
 
 --- Returns true if a given FCVAR flag is set for this ConVar.
 -- https://wiki.facepunch.com/gmod/Enums/FCVAR
--- @param name Name of the ConVar
--- @return True if has the flag
+-- @param string name Name of the ConVar
+-- @return boolean True if has the flag
 function convar_library.hasFlag(name, flag)
 	checkluatype(flag, TYPE_NUMBER)
 	return getValidConVar(name):IsFlagSet(flag)

--- a/lua/starfall/libs_cl/convar.lua
+++ b/lua/starfall/libs_cl/convar.lua
@@ -27,7 +27,7 @@ end
 
 
 --- Check if the given ConVar exists
--- @param name Name of the ConVar
+-- @param string name Name of the ConVar
 -- @return boolean True if exists
 function convar_library.exists(name)
 	checkpermission(instance, nil, "convar")
@@ -73,8 +73,8 @@ function convar_library.getInt(name)
 end
 
 --- Returns value of the ConVar as a floating-point number.
--- @param name Name of the ConVar
--- @return The float value or 0 if converting fails
+-- @param string name Name of the ConVar
+-- @return number? The float value or 0 if converting fails
 function convar_library.getFloat(name)
 	return getValidConVar(name):GetFloat()
 end

--- a/lua/starfall/libs_cl/convar.lua
+++ b/lua/starfall/libs_cl/convar.lua
@@ -19,7 +19,7 @@ local convar_library = instance.Libraries.convar
 local function getValidConVar(name)
 	checkpermission(instance, nil, "convar")
 	checkluatype(name, TYPE_STRING)
-	
+
 	local cvar = GetConVar(name)
 	if not cvar then SF.Throw("Trying to access non-existent ConVar", 3) end
 	return cvar
@@ -74,7 +74,7 @@ end
 
 --- Returns value of the ConVar as a floating-point number.
 -- @param string name Name of the ConVar
--- @return number? The float value or 0 if converting fails
+-- @return number The float value or 0 if converting fails
 function convar_library.getFloat(name)
 	return getValidConVar(name):GetFloat()
 end

--- a/lua/starfall/libs_cl/file.lua
+++ b/lua/starfall/libs_cl/file.lua
@@ -176,7 +176,7 @@ local file_methods, file_meta, wrap, unwrap = instance.Types.File.Methods, insta
 --- Opens and returns a file
 -- @param string path Filepath relative to data/sf_filedata/.
 -- @param string mode The file mode to use. See lua manual for explaination
--- @return File File object or nil if it failed
+-- @return File? File object or nil if it failed
 function file_library.open(path, mode)
 	checkpermission (instance, path, "file.open")
 	checkluatype (path, TYPE_STRING)

--- a/lua/starfall/libs_cl/file.lua
+++ b/lua/starfall/libs_cl/file.lua
@@ -315,7 +315,7 @@ end
 
 --- Enumerates a directory
 -- @param string path The folder to enumerate, relative to data/sf_filedata/.
--- @param string? sorting Optional sorting arguement. Either nameasc, namedesc, dateasc, datedesc
+-- @param string? sorting Optional sorting argument. Either nameasc, namedesc, dateasc, datedesc
 -- @return table Table of file names
 -- @return table Table of directory names
 function file_library.find(path, sorting)

--- a/lua/starfall/libs_cl/file.lua
+++ b/lua/starfall/libs_cl/file.lua
@@ -174,9 +174,9 @@ local file_methods, file_meta, wrap, unwrap = instance.Types.File.Methods, insta
 
 
 --- Opens and returns a file
--- @param path Filepath relative to data/sf_filedata/.
--- @param mode The file mode to use. See lua manual for explaination
--- @return File object or nil if it failed
+-- @param string path Filepath relative to data/sf_filedata/.
+-- @param string mode The file mode to use. See lua manual for explaination
+-- @return file File object or nil if it failed
 function file_library.open(path, mode)
 	checkpermission (instance, path, "file.open")
 	checkluatype (path, TYPE_STRING)
@@ -189,8 +189,8 @@ function file_library.open(path, mode)
 end
 
 --- Reads a file from path
--- @param path Filepath relative to data/sf_filedata/.
--- @return Contents, or nil if error
+-- @param string path Filepath relative to data/sf_filedata/.
+-- @return string? Contents, or nil if error
 function file_library.read(path)
 	checkpermission (instance, path, "file.read")
 	checkluatype (path, TYPE_STRING)
@@ -204,9 +204,9 @@ local function checkExtension(filename)
 end
 
 --- Writes to a file
--- @param path Filepath relative to data/sf_filedata/.
--- @param data The data to write
--- @return True if OK, nil if error
+-- @param string path Filepath relative to data/sf_filedata/.
+-- @param string data The data to write
+-- @return boolean? True if OK, nil if error
 function file_library.write(path, data)
 	checkpermission (instance, path, "file.write")
 	checkluatype (path, TYPE_STRING)
@@ -221,8 +221,8 @@ function file_library.write(path, data)
 end
 
 --- Reads a temp file's data if it exists. Otherwise returns nil
--- @param filename The temp file name. Must be only a file and not a path
--- @return The data of the temp file or nil if it doesn't exist
+-- @param string filename The temp file name. Must be only a file and not a path
+-- @return string? The data of the temp file or nil if it doesn't exist
 function file_library.readTemp(filename)
 	checkluatype(filename, TYPE_STRING)
 
@@ -234,9 +234,9 @@ function file_library.readTemp(filename)
 end
 
 --- Writes a temporary file. Throws an error if it is unable to.
--- @param filename The name to give the file. Must be only a file and not a path
--- @param data The data to write
--- @return The generated path for your temp file
+-- @param string filename The name to give the file. Must be only a file and not a path
+-- @param string data The data to write
+-- @return string The generated path for your temp file
 function file_library.writeTemp(filename, data)
 	checkluatype(filename, TYPE_STRING)
 	checkluatype(data, TYPE_STRING)
@@ -254,8 +254,8 @@ function file_library.writeTemp(filename, data)
 end
 
 --- Returns the path of a temp file if it exists. Otherwise returns nil
--- @param filename The temp file name. Must be only a file and not a path
--- @return The path to the temp file or nil if it doesn't exist
+-- @param string filename The temp file name. Must be only a file and not a path
+-- @return string? The path to the temp file or nil if it doesn't exist
 function file_library.existsTemp(filename)
 	checkluatype(filename, TYPE_STRING)
 
@@ -270,8 +270,8 @@ function file_library.existsTemp(filename)
 end
 
 --- Appends a string to the end of a file
--- @param path Filepath relative to data/sf_filedata/.
--- @param data String that will be appended to the file.
+-- @param string path Filepath relative to data/sf_filedata/.
+-- @param string data String that will be appended to the file.
 function file_library.append(path, data)
 	checkpermission (instance, path, "file.write")
 	checkluatype (path, TYPE_STRING)
@@ -284,8 +284,8 @@ function file_library.append(path, data)
 end
 
 --- Checks if a file exists
--- @param path Filepath relative to data/sf_filedata/.
--- @return True if exists, false if not, nil if error
+-- @param string path Filepath relative to data/sf_filedata/.
+-- @return boolean? True if exists, false if not, nil if error
 function file_library.exists(path)
 	checkpermission (instance, path, "file.exists")
 	checkluatype (path, TYPE_STRING)
@@ -293,8 +293,8 @@ function file_library.exists(path)
 end
 
 --- Deletes a file
--- @param path Filepath relative to data/sf_filedata/.
--- @return True if successful, nil if it wasn't found
+-- @param string path Filepath relative to data/sf_filedata/.
+-- @return boolean? True if successful, nil if it wasn't found
 function file_library.delete(path)
 	checkpermission (instance, path, "file.write")
 	checkluatype (path, TYPE_STRING)
@@ -306,7 +306,7 @@ function file_library.delete(path)
 end
 
 --- Creates a directory
--- @param path Filepath relative to data/sf_filedata/.
+-- @param string path Filepath relative to data/sf_filedata/.
 function file_library.createDir(path)
 	checkpermission (instance, path, "file.write")
 	checkluatype (path, TYPE_STRING)
@@ -314,10 +314,10 @@ function file_library.createDir(path)
 end
 
 --- Enumerates a directory
--- @param path The folder to enumerate, relative to data/sf_filedata/.
--- @param sorting Optional sorting arguement. Either nameasc, namedesc, dateasc, datedesc
--- @return Table of file names
--- @return Table of directory names
+-- @param string path The folder to enumerate, relative to data/sf_filedata/.
+-- @param string? sorting Optional sorting arguement. Either nameasc, namedesc, dateasc, datedesc
+-- @return table Table of file names
+-- @return table Table of directory names
 function file_library.find(path, sorting)
 	checkpermission (instance, path, "file.find")
 	checkluatype (path, TYPE_STRING)
@@ -326,10 +326,10 @@ function file_library.find(path, sorting)
 end
 
 --- Enumerates a directory relative to gmod
--- @param path The folder to enumerate, relative to garrysmod.
--- @param sorting Optional sorting arguement. Either nameasc, namedesc, dateasc, datedesc
--- @return Table of file names
--- @return Table of directory names
+-- @param string path The folder to enumerate, relative to garrysmod.
+-- @param string? sorting Optional sorting arguement. Either nameasc, namedesc, dateasc, datedesc
+-- @return table Table of file names
+-- @return table Table of directory names
 function file_library.findInGame(path, sorting)
 	checkpermission (instance, path, "file.findInGame")
 	checkluatype (path, TYPE_STRING)
@@ -350,125 +350,125 @@ function file_methods:close()
 end
 
 --- Sets the file position
--- @param n The position to set it to
+-- @param number n The position to set it to
 function file_methods:seek(n)
 	checkluatype (n, TYPE_NUMBER)
 	unwrap(self):Seek(n)
 end
 
 --- Moves the file position relative to its current position
--- @param n How much to move the position
--- @return The resulting position
+-- @param number n How much to move the position
+-- @return number The resulting position
 function file_methods:skip(n)
 	checkluatype (n, TYPE_NUMBER)
 	return unwrap(self):Skip(n)
 end
 
 --- Returns the current file position
--- @return The current file position
+-- @return number The current file position
 function file_methods:tell()
 	return unwrap(self):Tell()
 end
 
 --- Returns the file's size in bytes
--- @return The file's size
+-- @return number The file's size
 function file_methods:size()
 	return unwrap(self):Size()
 end
 
 --- Reads a certain length of the file's bytes
--- @param n The length to read
--- @return The data
+-- @param number n The length to read
+-- @return string The data
 function file_methods:read(n)
 	return unwrap(self):Read(n)
 end
 
 --- Reads a boolean and advances the file position
--- @return The data
+-- @return boolean Boolean
 function file_methods:readBool()
 	return unwrap(self):ReadBool()
 end
 
 --- Reads a byte and advances the file position
--- @return The data
+-- @return number UInt8 number
 function file_methods:readByte()
 	return unwrap(self):ReadByte()
 end
 
 --- Reads a double and advances the file position
--- @return The data
+-- @return number Float64 number
 function file_methods:readDouble()
 	return unwrap(self):ReadDouble()
 end
 
 --- Reads a float and advances the file position
--- @return The data
+-- @return number Float32 number
 function file_methods:readFloat()
 	return unwrap(self):ReadFloat()
 end
 
 --- Reads a line and advances the file position
--- @return The data
+-- @return string Line contents
 function file_methods:readLine()
 	return unwrap(self):ReadLine()
 end
 
 --- Reads a long and advances the file position
--- @return The data
+-- @return number Int32 number
 function file_methods:readLong()
 	return unwrap(self):ReadLong()
 end
 
 --- Reads a short and advances the file position
--- @return The data
+-- @return number Int16 number
 function file_methods:readShort()
 	return unwrap(self):ReadShort()
 end
 
 --- Writes a string to the file and advances the file position
--- @param str The data to write
+-- @param string str The data to write
 function file_methods:write(str)
 	checkluatype (str, TYPE_STRING)
 	unwrap(self):Write(str)
 end
 
 --- Writes a boolean and advances the file position
--- @param x The boolean to write
+-- @param boolean x The boolean to write
 function file_methods:writeBool(x)
 	checkluatype (x, TYPE_BOOL)
 	unwrap(self):WriteBool(x)
 end
 
 --- Writes a byte and advances the file position
--- @param x The byte to write
+-- @param number x The byte to write
 function file_methods:writeByte(x)
 	checkluatype (x, TYPE_NUMBER)
 	unwrap(self):WriteByte(x)
 end
 
 --- Writes a double and advances the file position
--- @param x The double to write
+-- @param number x The double to write
 function file_methods:writeDouble(x)
 	checkluatype (x, TYPE_NUMBER)
 	unwrap(self):WriteDouble(x)
 end
 
 --- Writes a float and advances the file position
--- @param x The float to write
+-- @param number x The float to write
 function file_methods:writeFloat(x)
 	checkluatype (x, TYPE_NUMBER)
 	unwrap(self):WriteFloat(x)
 end
 
 --- Writes a long and advances the file position
--- @param x The long to write
+-- @param number x The long to write
 function file_methods:writeLong(x)
 	checkluatype (x, TYPE_NUMBER)
 	unwrap(self):WriteLong(x)
 end
 
 --- Writes a short and advances the file position
--- @param x The short to write
+-- @param number x The short to write
 function file_methods:writeShort(x)
 	checkluatype (x, TYPE_NUMBER)
 	unwrap(self):WriteShort(x)

--- a/lua/starfall/libs_cl/file.lua
+++ b/lua/starfall/libs_cl/file.lua
@@ -176,7 +176,7 @@ local file_methods, file_meta, wrap, unwrap = instance.Types.File.Methods, insta
 --- Opens and returns a file
 -- @param string path Filepath relative to data/sf_filedata/.
 -- @param string mode The file mode to use. See lua manual for explaination
--- @return file File object or nil if it failed
+-- @return File File object or nil if it failed
 function file_library.open(path, mode)
 	checkpermission (instance, path, "file.open")
 	checkluatype (path, TYPE_STRING)

--- a/lua/starfall/libs_cl/joystick.lua
+++ b/lua/starfall/libs_cl/joystick.lua
@@ -23,65 +23,65 @@ local joystick_library = instance.Libraries.joystick
 
 
 --- Gets the axis data value.
--- @param enum Joystick number. Starts at 0
--- @param axis Joystick axis number. Ranges from 0 to 7.
--- @return 0 - 65535 where 32767 is the middle.
+-- @param number enum Joystick number. Starts at 0
+-- @param number axis Joystick axis number. Ranges from 0 to 7.
+-- @return number 0 - 65535 where 32767 is the middle.
 function joystick_library.getAxis(enum, axis)
 	refresh(enum)
 	return joystick.axis(enum, axis)
 end
 
 --- Gets the pov data value.
--- @param enum Joystick number. Starts at 0
--- @param pov Joystick pov number. Ranges from 0 to 7.
--- @return 0 - 65535 where 32767 is the middle.
+-- @param number enum Joystick number. Starts at 0
+-- @param number pov Joystick pov number. Ranges from 0 to 7.
+-- @return number 0 - 65535 where 32767 is the middle.
 function joystick_library.getPov(enum, pov)
 	refresh(enum)
 	return joystick.pov(enum, pov)
 end
 
 --- Returns if the button is pushed or not
--- @param enum Joystick number. Starts at 0
--- @param button Joystick button number. Starts at 0
--- @return 0 or 1
+-- @param number enum Joystick number. Starts at 0
+-- @param number button Joystick button number. Starts at 0
+-- @return number 0 or 1
 function joystick_library.getButton(enum, button)
 	refresh(enum)
 	return joystick.button(enum, button)
 end
 
 --- Gets the hardware name of the joystick
--- @param enum Joystick number. Starts at 0
--- @return Name of the device
+-- @param number enum Joystick number. Starts at 0
+-- @return string Name of the device
 function joystick_library.getName(enum)
 	refresh(enum)
 	return joystick.name(enum)
 end
 
 --- Gets the number of detected joysticks.
--- @return Number of joysticks
+-- @return number Number of joysticks
 function joystick_library.numJoysticks()
 	return joystick.count()
 end
 
 --- Gets the number of detected axes on a joystick
--- @param enum Joystick number. Starts at 0
--- @return Number of axes
+-- @param number enum Joystick number. Starts at 0
+-- @return number Number of axes
 function joystick_library.numAxes(enum)
 	refresh(enum)
 	return joystick.count(enum, 1)
 end
 
 --- Gets the number of detected povs on a joystick
--- @param enum Joystick number. Starts at 0
--- @return Number of povs
+-- @param number enum Joystick number. Starts at 0
+-- @return number Number of povs
 function joystick_library.numPovs(enum)
 	refresh(enum)
 	return joystick.count(enum, 2)
 end
 
 --- Gets the number of detected buttons on a joystick
--- @param enum Joystick number. Starts at 0
--- @return Number of buttons
+-- @param number enum Joystick number. Starts at 0
+-- @return number Number of buttons
 function joystick_library.numButtons(enum)
 	refresh(enum)
 	return joystick.count(enum, 3)

--- a/lua/starfall/libs_cl/light.lua
+++ b/lua/starfall/libs_cl/light.lua
@@ -100,10 +100,10 @@ local col_meta, cwrap, cunwrap = instance.Types.Color, instance.Types.Color.Wrap
 
 
 --- Creates a dynamic light (make sure to draw it)
--- @param vector pos The position of the light
+-- @param Vector pos The position of the light
 -- @param number size The size of the light. Must be lower than sf_light_maxsize
 -- @param number brightness The brightness of the light
--- @param color color The color of the light
+-- @param Color color The color of the light
 -- @return light Dynamic light
 function light_library.create(pos, size, brightness, color)
 	if table.Count(lights) >= 256 then SF.Throw("Too many lights have already been allocated (max 256)", 2) end
@@ -169,7 +169,7 @@ function light_methods:setDieTime(dietime)
 end
 
 --- Sets the light direction (used with setInnerAngle and setOuterAngle)
--- @param vector dir Direction of the light
+-- @param Vector dir Direction of the light
 function light_methods:setDirection(dir)
 	unwrap(self).data.dir = vunwrap(dir)
 end
@@ -210,7 +210,7 @@ function light_methods:setNoModel(on)
 end
 
 --- Sets the light position
--- @param vector pos The position of the light
+-- @param Vector pos The position of the light
 function light_methods:setPos(pos)
 	unwrap(self).data.pos = vunwrap(pos)
 end
@@ -230,7 +230,7 @@ function light_methods:setStyle(style)
 end
 
 --- Sets the color of the light
--- @param color col The color of the light
+-- @param Color col The color of the light
 function light_methods:setColor(color)
 	local col = cunwrap(color)
 	local data = unwrap(self).data

--- a/lua/starfall/libs_cl/light.lua
+++ b/lua/starfall/libs_cl/light.lua
@@ -104,7 +104,7 @@ local col_meta, cwrap, cunwrap = instance.Types.Color, instance.Types.Color.Wrap
 -- @param number size The size of the light. Must be lower than sf_light_maxsize
 -- @param number brightness The brightness of the light
 -- @param Color color The color of the light
--- @return light Dynamic light
+-- @return Light Dynamic light
 function light_library.create(pos, size, brightness, color)
 	if table.Count(lights) >= 256 then SF.Throw("Too many lights have already been allocated (max 256)", 2) end
 	if maxSize:GetFloat() == 0 then SF.Throw("sf_light_maxsize is set to 0", 2) end

--- a/lua/starfall/libs_cl/light.lua
+++ b/lua/starfall/libs_cl/light.lua
@@ -100,11 +100,11 @@ local col_meta, cwrap, cunwrap = instance.Types.Color, instance.Types.Color.Wrap
 
 
 --- Creates a dynamic light (make sure to draw it)
--- @param pos The position of the light
--- @param size The size of the light. Must be lower than sf_light_maxsize
--- @param brightness The brightness of the light
--- @param color The color of the light
--- @return Dynamic light
+-- @param vector pos The position of the light
+-- @param number size The size of the light. Must be lower than sf_light_maxsize
+-- @param number brightness The brightness of the light
+-- @param color color The color of the light
+-- @return light Dynamic light
 function light_library.create(pos, size, brightness, color)
 	if table.Count(lights) >= 256 then SF.Throw("Too many lights have already been allocated (max 256)", 2) end
 	if maxSize:GetFloat() == 0 then SF.Throw("sf_light_maxsize is set to 0", 2) end
@@ -148,89 +148,89 @@ function light_methods:draw()
 end
 
 --- Sets the light brightness
--- @param brightness The light's brightness
+-- @param number brightness The light's brightness
 function light_methods:setBrightness(brightness)
 	checkluatype(brightness, TYPE_NUMBER)
 	unwrap(self).data.brightness = brightness
 end
 
 --- Sets the light decay speed in thousandths per second. 1000 lasts for 1 second, 2000 lasts for 0.5 seconds
--- @param decay The light's decay speed
+-- @param number decay The light's decay speed
 function light_methods:setDecay(decay)
 	checkluatype(decay, TYPE_NUMBER)
 	unwrap(self).data.decay = decay
 end
 
 --- Sets the light lifespan (Required for fade effect i.e. decay)
--- @param dietime The how long the light will stay alive after turning it off.
+-- @param number dietime The how long the light will stay alive after turning it off.
 function light_methods:setDieTime(dietime)
 	checkluatype(dietime, TYPE_NUMBER)
 	unwrap(self).dietime = math.max(dietime, 0)
 end
 
 --- Sets the light direction (used with setInnerAngle and setOuterAngle)
--- @param dir Direction of the light
+-- @param vector dir Direction of the light
 function light_methods:setDirection(dir)
-	unwrap(self).data.dir = vunwrap(dir) 
+	unwrap(self).data.dir = vunwrap(dir)
 end
 
 --- Sets the light inner angle (used with setDirection and setOuterAngle)
--- @param ang Number inner angle of the light
+-- @param number ang Inner angle of the light
 function light_methods:setInnerAngle(ang)
 	checkluatype(ang, TYPE_NUMBER)
 	unwrap(self).data.innerangle = ang
 end
 
 --- Sets the light outer angle (used with setDirection and setInnerAngle)
--- @param ang Number outer angle of the light
+-- @param number ang Outer angle of the light
 function light_methods:setOuterAngle(ang)
 	checkluatype(ang, TYPE_NUMBER)
 	unwrap(self).data.outerangle = ang
 end
 
 --- Sets the minimum light amount
--- @param min The minimum light
+-- @param number min The minimum light
 function light_methods:setMinLight(min)
 	checkluatype(min, TYPE_NUMBER)
 	unwrap(self).data.minlight = min
 end
 
 --- Sets whether the light should cast onto the world or not
--- @param on Whether the light shouldn't cast onto the world
+-- @param boolean on Whether the light shouldn't cast onto the world
 function light_methods:setNoWorld(on)
 	checkluatype(on, TYPE_BOOL)
 	unwrap(self).data.noworld = on
 end
 
 --- Sets whether the light should cast onto models or not
--- @param on Whether the light shouldn't cast onto the models
+-- @param boolean on Whether the light shouldn't cast onto the models
 function light_methods:setNoModel(on)
 	checkluatype(on, TYPE_BOOL)
 	unwrap(self).data.nomodel = on
 end
 
 --- Sets the light position
--- @param pos The position of the light
+-- @param vector pos The position of the light
 function light_methods:setPos(pos)
-	unwrap(self).data.pos = vunwrap(pos) 
+	unwrap(self).data.pos = vunwrap(pos)
 end
 
 --- Sets the size of the light (max is sf_light_maxsize)
--- @param size The size of the light
+-- @param number size The size of the light
 function light_methods:setSize(size)
 	checkluatype(size, TYPE_NUMBER)
 	unwrap(self).data.size = math.Clamp(size, 0, maxSize:GetFloat())
 end
 
 --- Sets the flicker style of the light https://developer.valvesoftware.com/wiki/Light_dynamic#Appearances
--- @param style The number of the flicker style
+-- @param number style The number of the flicker style
 function light_methods:setStyle(style)
 	checkluatype(style, TYPE_NUMBER)
 	unwrap(self).data.style = style
 end
 
 --- Sets the color of the light
--- @param color The color of the light
+-- @param color col The color of the light
 function light_methods:setColor(color)
 	local col = cunwrap(color)
 	local data = unwrap(self).data

--- a/lua/starfall/libs_cl/material.lua
+++ b/lua/starfall/libs_cl/material.lua
@@ -475,6 +475,7 @@ end
 --- Sky_DX9
 --- gmodscreenspace
 --- Modulate_DX9
+-- @return Material The Material created.
 function material_library.create(shader)
 	checkluatype(shader, TYPE_STRING)
 	checkpermission(instance, nil, "material.create")
@@ -488,8 +489,9 @@ end
 local image_params = {["nocull"] = true,["alphatest"] = true,["mips"] = true,["noclamp"] = true,["smooth"] = true}
 --- Creates a .jpg or .png material from file
 --- Can't be modified
--- @param string path The path to the image file
+-- @param string path The path to the image file, must be a jpg or png image
 -- @param string params The shader parameters to apply to the material. See https://wiki.facepunch.com/gmod/Material_Parameters
+-- @return Material The Material created.
 function material_library.createFromImage(path, params)
 	checkluatype(path, TYPE_STRING)
 	checkluatype(params, TYPE_STRING)
@@ -513,7 +515,7 @@ function material_library.createFromImage(path, params)
 	return lwrap(m)
 end
 
---- Free's a user created material allowing you to create others
+--- Frees a user created material allowing you to create others
 function material_methods:destroy()
 
 	local m = unwrap(self)
@@ -524,7 +526,7 @@ function material_methods:destroy()
 	if rt then
 		instance.env.render.destroyRenderTarget(name)
 	end
-	
+
 	local sensitive2sf, sf2sensitive = material_meta.sensitive2sf, material_meta.sf2sensitive
 	sensitive2sf[m] = nil
 	sf2sensitive[self] = nil

--- a/lua/starfall/libs_cl/material.lua
+++ b/lua/starfall/libs_cl/material.lua
@@ -332,8 +332,8 @@ end)
 --- Loads a .vmt material or existing material. Throws an error if the material fails to load
 --- Existing created materials can be loaded with ! prepended to the name
 --- Can't be modified
--- @param path The path of the material (don't include .vmt in the path)
--- @return The material object. Can't be modified.
+-- @param string path The path of the material (don't include .vmt in the path)
+-- @return material The material object. Can't be modified.
 function material_library.load(path)
 	checkluatype(path, TYPE_STRING)
 	if string.GetExtensionFromFilename(path) then SF.Throw("The path cannot have an extension", 2) end
@@ -344,9 +344,9 @@ function material_library.load(path)
 end
 
 --- Gets a texture from a material
--- @param path The path of the material (don't include .vmt in the path)
--- @param texture The texture key to get
--- @return The texture's name or nil if texture key isn't found
+-- @param string path The path of the material (don't include .vmt in the path)
+-- @param string texture The texture key to get
+-- @return string? The texture's name or nil if texture key isn't found
 function material_library.getTexture(path, texture)
 	checkluatype(path, TYPE_STRING)
 	checkluatype(texture, TYPE_STRING)
@@ -355,50 +355,50 @@ function material_library.getTexture(path, texture)
 end
 
 --- Returns a table of keyvalues from a material
--- @param path The path of the material (don't include .vmt in the path)
--- @return The table of keyvalues
+-- @param string path The path of the material (don't include .vmt in the path)
+-- @return table The table of keyvalues
 function material_library.getKeyValues(path)
 	checkluatype(path, TYPE_STRING)
 	return instance.Sanitize(Material(path):GetKeyValues())
 end
 
 --- Returns a material's engine name
--- @param path The path of the material (don't include .vmt in the path)
--- @return The name of a material. If this material is user created, add ! to the beginning of this to use it with entity.setMaterial
+-- @param string path The path of the material (don't include .vmt in the path)
+-- @return string The name of a material. If this material is user created, add ! to the beginning of this to use it with entity.setMaterial
 function material_library.getName(path)
 	checkluatype(path, TYPE_STRING)
 	return Material(path):GetName()
 end
 
 --- Returns the shader name of a material
--- @param path The path of the material (don't include .vmt in the path)
--- @return The shader name of the material
+-- @param string path The path of the material (don't include .vmt in the path)
+-- @return string The shader name of the material
 function material_library.getShader(path)
 	checkluatype(path, TYPE_STRING)
 	return Material(path):GetShader()
 end
 
 --- Returns the width of the member texture set for $basetexture of a material
--- @param path The path of the material (don't include .vmt in the path)
--- @return The basetexture's width
+-- @param string path The path of the material (don't include .vmt in the path)
+-- @return number The basetexture's width
 function material_library.getWidth(path)
 	checkluatype(path, TYPE_STRING)
 	return Material(path):Width()
 end
 
 --- Returns the height of the member texture set for $basetexture of a material
--- @param path The path of the material (don't include .vmt in the path)
--- @return The basetexture's height
+-- @param string path The path of the material (don't include .vmt in the path)
+-- @return number The basetexture's height
 function material_library.getHeight(path)
 	checkluatype(path, TYPE_STRING)
 	return Material(path):Height()
 end
 
 --- Returns a color pixel value of the $basetexture of a .png or .jpg material.
--- @param path The path of the material (don't include .vmt in the path)
--- @param x The x coordinate of the pixel
--- @param y The y coordinate of the pixel
--- @return The color value
+-- @param string path The path of the material (don't include .vmt in the path)
+-- @param number x The x coordinate of the pixel
+-- @param number y The y coordinate of the pixel
+-- @return color The color value
 function material_library.getColor(path, x, y)
 	checkluatype(path, TYPE_STRING)
 	checkluatype(x, TYPE_NUMBER)
@@ -407,9 +407,9 @@ function material_library.getColor(path, x, y)
 end
 
 --- Returns a float keyvalue of a material
--- @param path The path of the material (don't include .vmt in the path)
--- @param key The key to get the float from
--- @return The float value or nil if it doesn't exist
+-- @param string path The path of the material (don't include .vmt in the path)
+-- @param string key The key to get the float from
+-- @return number? The float value or nil if it doesn't exist
 function material_library.getFloat(path, key)
 	checkluatype(path, TYPE_STRING)
 	checkluatype(key, TYPE_STRING)
@@ -417,9 +417,9 @@ function material_library.getFloat(path, key)
 end
 
 --- Returns an int keyvalue of a material
--- @param path The path of the material (don't include .vmt in the path)
--- @param key The key to get the int from
--- @return The int value or nil if it doesn't exist
+-- @param string path The path of the material (don't include .vmt in the path)
+-- @param string key The key to get the int from
+-- @return number? The int value or nil if it doesn't exist
 function material_library.getInt(path, key)
 	checkluatype(path, TYPE_STRING)
 	checkluatype(key, TYPE_STRING)
@@ -427,9 +427,9 @@ function material_library.getInt(path, key)
 end
 
 --- Returns a matrix keyvalue of a material
--- @param path The path of the material (don't include .vmt in the path)
--- @param key The key to get the matrix from
--- @return The matrix value or nil if it doesn't exist
+-- @param string path The path of the material (don't include .vmt in the path)
+-- @param string key The key to get the matrix from
+-- @return vmatrix? The matrix value or nil if it doesn't exist
 function material_library.getMatrix(path, key)
 	checkluatype(path, TYPE_STRING)
 	checkluatype(key, TYPE_STRING)
@@ -437,9 +437,9 @@ function material_library.getMatrix(path, key)
 end
 
 --- Returns a string keyvalue
--- @param path The path of the material (don't include .vmt in the path)
--- @param key The key to get the string from
--- @return The string value or nil if it doesn't exist
+-- @param string path The path of the material (don't include .vmt in the path)
+-- @param string key The key to get the string from
+-- @return string? The string value or nil if it doesn't exist
 function material_library.getString(path, key)
 	checkluatype(path, TYPE_STRING)
 	checkluatype(key, TYPE_STRING)
@@ -447,9 +447,9 @@ function material_library.getString(path, key)
 end
 
 --- Returns a vector keyvalue of a material
--- @param path The path of the material (don't include .vmt in the path)
--- @param key The key to get the vector from
--- @return The string id of the texture
+-- @param string path The path of the material (don't include .vmt in the path)
+-- @param string key The key to get the vector from
+-- @return vector? The vector value or nil if it doesn't exist
 function material_library.getVector(path, key)
 	checkluatype(path, TYPE_STRING)
 	checkluatype(key, TYPE_STRING)
@@ -457,9 +457,9 @@ function material_library.getVector(path, key)
 end
 
 --- Returns a linear color-corrected vector keyvalue of a material
--- @param path The path of the material (don't include .vmt in the path)
--- @param key The key to get the vector from
--- @return The vector value or nil if it doesn't exist
+-- @param string path The path of the material (don't include .vmt in the path)
+-- @param string key The key to get the vector from
+-- @return vector? The vector value or nil if it doesn't exist
 function material_library.getVectorLinear(path, key)
 	checkluatype(path, TYPE_STRING)
 	checkluatype(key, TYPE_STRING)
@@ -467,7 +467,7 @@ function material_library.getVectorLinear(path, key)
 end
 
 --- Creates a new blank material
--- @param shader The shader of the material. Must be one of
+-- @param string shader The shader of the material. Must be one of
 --- UnlitGeneric
 --- VertexLitGeneric
 --- Refract_DX90
@@ -488,8 +488,8 @@ end
 local image_params = {["nocull"] = true,["alphatest"] = true,["mips"] = true,["noclamp"] = true,["smooth"] = true}
 --- Creates a .jpg or .png material from file
 --- Can't be modified
--- @param path The path to the image file
--- @param params The shader parameters to apply to the material. See https://wiki.facepunch.com/gmod/Material_Parameters
+-- @param string path The path to the image file
+-- @param string params The shader parameters to apply to the material. See https://wiki.facepunch.com/gmod/Material_Parameters
 function material_library.createFromImage(path, params)
 	checkluatype(path, TYPE_STRING)
 	checkluatype(params, TYPE_STRING)
@@ -538,37 +538,37 @@ end
 
 --- Returns the material's engine name
 -- @name material_methods.getName
--- @return The name of the material. If this material is user created, add ! to the beginning of this to use it with entity.setMaterial
+-- @return string The name of the material. If this material is user created, add ! to the beginning of this to use it with entity.setMaterial
 function lmaterial_methods:getName()
 	return lunwrap(self):GetName()
 end
 
 --- Returns the shader name of the material
 -- @name material_methods.getShader
--- @return The shader name of the material
+-- @return string The shader name of the material
 function lmaterial_methods:getShader()
 	return lunwrap(self):GetShader()
 end
 
 --- Gets the base texture set to the material's width
 -- @name material_methods.getWidth
--- @return The basetexture's width
+-- @return number The basetexture's width
 function lmaterial_methods:getWidth()
 	return lunwrap(self):Width()
 end
 
 --- Gets the base texture set to the material's height
 -- @name material_methods.getHeight
--- @return The basetexture's height
+-- @return number The basetexture's height
 function lmaterial_methods:getHeight()
 	return lunwrap(self):Height()
 end
 
 --- Returns a color pixel value of the $basetexture of a .png or .jpg material.
 -- @name material_methods.getColor
--- @param x The x coordinate of the pixel
--- @param y The y coordinate of the pixel
--- @return The color value
+-- @param number x The x coordinate of the pixel
+-- @param number y The y coordinate of the pixel
+-- @return color The color value
 function lmaterial_methods:getColor(x, y)
 	checkluatype(x, TYPE_NUMBER)
 	checkluatype(y, TYPE_NUMBER)
@@ -577,8 +577,8 @@ end
 
 --- Returns a float keyvalue
 -- @name material_methods.getFloat
--- @param key The key to get the float from
--- @return The float value or nil if it doesn't exist
+-- @param string key The key to get the float from
+-- @return number? The float value or nil if it doesn't exist
 function lmaterial_methods:getFloat(key)
 	checkluatype(key, TYPE_STRING)
 	return lunwrap(self):GetFloat(key)
@@ -586,8 +586,8 @@ end
 
 --- Returns an int keyvalue
 -- @name material_methods.getInt
--- @param key The key to get the int from
--- @return The int value or nil if it doesn't exist
+-- @param string key The key to get the int from
+-- @return number? The int value or nil if it doesn't exist
 function lmaterial_methods:getInt(key)
 	checkluatype(key, TYPE_STRING)
 	return lunwrap(self):GetInt(key)
@@ -595,15 +595,15 @@ end
 
 --- Returns a table of material keyvalues
 -- @name material_methods.getKeyValues
--- @return The table of keyvalues
+-- @return table The table of keyvalues
 function lmaterial_methods:getKeyValues()
 	return instance.Sanitize(lunwrap(self):GetKeyValues())
 end
 
 --- Returns a matrix keyvalue
 -- @name material_methods.getMatrix
--- @param key The key to get the matrix from
--- @return The matrix value or nil if it doesn't exist
+-- @param string key The key to get the matrix from
+-- @return vmatrix? The matrix value or nil if it doesn't exist
 function lmaterial_methods:getMatrix(key)
 	checkluatype(key, TYPE_STRING)
 	return mwrap(lunwrap(self):GetMatrix(key))
@@ -611,8 +611,8 @@ end
 
 --- Returns a string keyvalue
 -- @name material_methods.getString
--- @param key The key to get the string from
--- @return The string value or nil if it doesn't exist
+-- @param string key The key to get the string from
+-- @return string? The string value or nil if it doesn't exist
 function lmaterial_methods:getString(key)
 	checkluatype(key, TYPE_STRING)
 	return lunwrap(self):GetString(key)
@@ -620,8 +620,8 @@ end
 
 --- Returns a texture id keyvalue
 -- @name material_methods.getTexture
--- @param key The key to get the texture from
--- @return The string id of the texture or nil if it doesn't exist
+-- @param string key The key to get the texture from
+-- @return string? The string id of the texture or nil if it doesn't exist
 function lmaterial_methods:getTexture(key)
 	checkluatype(key, TYPE_STRING)
 	local tex = lunwrap(self):GetTexture(key)
@@ -630,8 +630,8 @@ end
 
 --- Returns a vector keyvalue
 -- @name material_methods.getVector
--- @param key The key to get the vector from
--- @return The string id of the texture
+-- @param string key The key to get the vector from
+-- @return string? The string id of the texture or nil if it doesn't exist
 function lmaterial_methods:getVector(key)
 	checkluatype(key, TYPE_STRING)
 	return vwrap(lunwrap(self):GetVector(key))
@@ -639,8 +639,8 @@ end
 
 --- Returns a linear color-corrected vector keyvalue
 -- @name material_methods.getVectorLinear
--- @param key The key to get the vector from
--- @return The vector value or nil if it doesn't exist
+-- @param string key The key to get the vector from
+-- @return vector? The vector value or nil if it doesn't exist
 function lmaterial_methods:getVectorLinear(key)
 	checkluatype(key, TYPE_STRING)
 	return vwrap(lunwrap(self):GetVectorLinear(key))
@@ -652,8 +652,8 @@ function material_methods:recompute()
 end
 
 --- Sets a float keyvalue
--- @param key The key name to set
--- @param v The value to set it to
+-- @param string key The key name to set
+-- @param number v The value to set it to
 function material_methods:setFloat(key, v)
 	checkkey(key)
 	checkluatype(v, TYPE_NUMBER)
@@ -661,8 +661,8 @@ function material_methods:setFloat(key, v)
 end
 
 --- Sets an int keyvalue
--- @param key The key name to set
--- @param v The value to set it to
+-- @param string key The key name to set
+-- @param number v The value to set it to
 function material_methods:setInt(key, v)
 	checkkey(key)
 	checkluatype(v, TYPE_NUMBER)
@@ -670,16 +670,16 @@ function material_methods:setInt(key, v)
 end
 
 --- Sets a matrix keyvalue
--- @param key The key name to set
--- @param v The value to set it to
+-- @param string key The key name to set
+-- @param vmatrix v The value to set it to
 function material_methods:setMatrix(key, v)
 	checkkey(key)
 	unwrap(self):SetMatrix(key, munwrap(v))
 end
 
 --- Sets a string keyvalue
--- @param key The key name to set
--- @param v The value to set it to
+-- @param string key The key name to set
+-- @param string v The value to set it to
 function material_methods:setString(key, v)
 	checkkey(key)
 	checkluatype(v, TYPE_STRING)
@@ -687,8 +687,8 @@ function material_methods:setString(key, v)
 end
 
 --- Sets a texture keyvalue
--- @param key The key name to set. $basetexture is the key name for most purposes.
--- @param v The texture name to set it to.
+-- @param string key The key name to set. $basetexture is the key name for most purposes.
+-- @param string v The texture name to set it to.
 function material_methods:setTexture(key, v)
 	checkkey(key)
 	checkluatype(v, TYPE_STRING)
@@ -697,11 +697,11 @@ function material_methods:setTexture(key, v)
 end
 
 --- Loads an online image or base64 data to the specified texture key
--- @param key The key name to set. $basetexture is the key name for most purposes.
 -- If the texture in key is not set to a rendertarget, a rendertarget will be created and used.
--- @param url The url or base64 data
--- @param cb An optional callback called when image is loaded. Passes nil if it fails or Passes the material, url, width, height, and layout function which can be called with x, y, w, h to reposition the image in the texture
--- @param done An optional callback called when the image is done loading. Passes the material, url
+-- @param string key The key name to set. $basetexture is the key name for most purposes.
+-- @param string url The url or base64 data
+-- @param function? cb An optional callback called when image is loaded. Passes nil if it fails or Passes the material, url, width, height, and layout function which can be called with x, y, w, h to reposition the image in the texture
+-- @param function? done An optional callback called when the image is done loading. Passes the material, url
 function material_methods:setTextureURL(key, url, cb, done)
 	checkkey(key)
 	checkluatype(url, TYPE_STRING)
@@ -759,8 +759,8 @@ function material_methods:setTextureURL(key, url, cb, done)
 end
 
 --- Sets a rendertarget texture to the specified texture key
--- @param key The key name to set. $basetexture is the key name for most purposes.
--- @param name The name of the rendertarget
+-- @param string key The key name to set. $basetexture is the key name for most purposes.
+-- @param string name The name of the rendertarget
 function material_methods:setTextureRenderTarget(key, name)
 	checkkey(key)
 	checkluatype(name, TYPE_STRING)
@@ -773,15 +773,15 @@ function material_methods:setTextureRenderTarget(key, name)
 end
 
 --- Sets a keyvalue to be undefined
--- @param key The key name to set
+-- @param string key The key name to set
 function material_methods:setUndefined(key)
 	checkkey(key)
 	unwrap(self):SetUndefined(key)
 end
 
 --- Sets a vector keyvalue
--- @param key The key name to set
--- @param v The value to set it to
+-- @param string key The key name to set
+-- @param vector v The value to set it to
 function material_methods:setVector(key, v)
 	checkkey(key)
 	unwrap(self):SetVector(key, vunwrap(v))

--- a/lua/starfall/libs_cl/material.lua
+++ b/lua/starfall/libs_cl/material.lua
@@ -333,7 +333,7 @@ end)
 --- Existing created materials can be loaded with ! prepended to the name
 --- Can't be modified
 -- @param string path The path of the material (don't include .vmt in the path)
--- @return material The material object. Can't be modified.
+-- @return Material The material object. Can't be modified.
 function material_library.load(path)
 	checkluatype(path, TYPE_STRING)
 	if string.GetExtensionFromFilename(path) then SF.Throw("The path cannot have an extension", 2) end
@@ -398,7 +398,7 @@ end
 -- @param string path The path of the material (don't include .vmt in the path)
 -- @param number x The x coordinate of the pixel
 -- @param number y The y coordinate of the pixel
--- @return color The color value
+-- @return Color The color value
 function material_library.getColor(path, x, y)
 	checkluatype(path, TYPE_STRING)
 	checkluatype(x, TYPE_NUMBER)
@@ -429,7 +429,7 @@ end
 --- Returns a matrix keyvalue of a material
 -- @param string path The path of the material (don't include .vmt in the path)
 -- @param string key The key to get the matrix from
--- @return vmatrix? The matrix value or nil if it doesn't exist
+-- @return VMatrix? The matrix value or nil if it doesn't exist
 function material_library.getMatrix(path, key)
 	checkluatype(path, TYPE_STRING)
 	checkluatype(key, TYPE_STRING)
@@ -449,7 +449,7 @@ end
 --- Returns a vector keyvalue of a material
 -- @param string path The path of the material (don't include .vmt in the path)
 -- @param string key The key to get the vector from
--- @return vector? The vector value or nil if it doesn't exist
+-- @return Vector? The vector value or nil if it doesn't exist
 function material_library.getVector(path, key)
 	checkluatype(path, TYPE_STRING)
 	checkluatype(key, TYPE_STRING)
@@ -459,7 +459,7 @@ end
 --- Returns a linear color-corrected vector keyvalue of a material
 -- @param string path The path of the material (don't include .vmt in the path)
 -- @param string key The key to get the vector from
--- @return vector? The vector value or nil if it doesn't exist
+-- @return Vector? The vector value or nil if it doesn't exist
 function material_library.getVectorLinear(path, key)
 	checkluatype(path, TYPE_STRING)
 	checkluatype(key, TYPE_STRING)
@@ -568,7 +568,7 @@ end
 -- @name material_methods.getColor
 -- @param number x The x coordinate of the pixel
 -- @param number y The y coordinate of the pixel
--- @return color The color value
+-- @return Color The color value
 function lmaterial_methods:getColor(x, y)
 	checkluatype(x, TYPE_NUMBER)
 	checkluatype(y, TYPE_NUMBER)
@@ -603,7 +603,7 @@ end
 --- Returns a matrix keyvalue
 -- @name material_methods.getMatrix
 -- @param string key The key to get the matrix from
--- @return vmatrix? The matrix value or nil if it doesn't exist
+-- @return VMatrix? The matrix value or nil if it doesn't exist
 function lmaterial_methods:getMatrix(key)
 	checkluatype(key, TYPE_STRING)
 	return mwrap(lunwrap(self):GetMatrix(key))
@@ -640,7 +640,7 @@ end
 --- Returns a linear color-corrected vector keyvalue
 -- @name material_methods.getVectorLinear
 -- @param string key The key to get the vector from
--- @return vector? The vector value or nil if it doesn't exist
+-- @return Vector? The vector value or nil if it doesn't exist
 function lmaterial_methods:getVectorLinear(key)
 	checkluatype(key, TYPE_STRING)
 	return vwrap(lunwrap(self):GetVectorLinear(key))
@@ -671,7 +671,7 @@ end
 
 --- Sets a matrix keyvalue
 -- @param string key The key name to set
--- @param vmatrix v The value to set it to
+-- @param VMatrix v The value to set it to
 function material_methods:setMatrix(key, v)
 	checkkey(key)
 	unwrap(self):SetMatrix(key, munwrap(v))
@@ -781,7 +781,7 @@ end
 
 --- Sets a vector keyvalue
 -- @param string key The key name to set
--- @param vector v The value to set it to
+-- @param Vector v The value to set it to
 function material_methods:setVector(key, v)
 	checkkey(key)
 	unwrap(self):SetVector(key, vunwrap(v))

--- a/lua/starfall/libs_cl/notification.lua
+++ b/lua/starfall/libs_cl/notification.lua
@@ -26,14 +26,14 @@ end)
 local notification_library = instance.Libraries.notification
 
 --- Displays a standard notification.
--- @param text The text to display
--- @param type Determines the notification method.
+-- @param string text The text to display
+-- @param number type Determines the notification method.
 ---NOTIFY.GENERIC
 ---NOTIFY.ERROR
 ---NOTIFY.UNDO
 ---NOTIFY.HINT
 ---NOTIFY.CLEANUP
--- @param length Time in seconds to display the notification (Max length of 30)
+-- @param number length Time in seconds to display the notification (Max length of 30)
 function notification_library.addLegacy(text, type, length)
 	if SF.IsHUDActive(instance.entity) then
 		checkpermission(instance, nil, "notification.hud")
@@ -49,8 +49,8 @@ end
 
 
 --- Displays a notification with an animated progress bar, will persist unless killed or chip is removed.
--- @param id String index of the notification
--- @param text The text to display
+-- @param string id String index of the notification
+-- @param string text The text to display
 function notification_library.addProgress(id, text)
 	if SF.IsHUDActive(instance.entity) then
 		checkpermission(instance, nil, "notification.hud")
@@ -77,7 +77,7 @@ function notification_library.addProgress(id, text)
 end
 
 --- Removes the notification with the given index after 0.8 seconds
--- @param id String index of the notification to kill
+-- @param string id String index of the notification to kill
 function notification_library.kill(id)
 	if SF.IsHUDActive(instance.entity) then
 		checkpermission(instance, nil, "notification.hud")

--- a/lua/starfall/libs_cl/particle.lua
+++ b/lua/starfall/libs_cl/particle.lua
@@ -51,7 +51,7 @@ end)
 --- Creates a ParticleEmitter data structure
 -- @param Vector position The particle emitter's position
 -- @param boolean use3D Create the emitter in 3D mode
--- @return particleemitter ParticleEmitter Object
+-- @return ParticleEmitter ParticleEmitter Object
 function particle_library.create(position, use3D)
 	checkluatype(use3D, TYPE_BOOL)
 	checkpermission(instance, nil, "particle.create")

--- a/lua/starfall/libs_cl/particle.lua
+++ b/lua/starfall/libs_cl/particle.lua
@@ -49,7 +49,7 @@ instance:AddHook("deinitialize", function()
 end)
 
 --- Creates a ParticleEmitter data structure
--- @param vector position The particle emitter's position
+-- @param Vector position The particle emitter's position
 -- @param boolean use3D Create the emitter in 3D mode
 -- @return particleemitter ParticleEmitter Object
 function particle_library.create(position, use3D)
@@ -68,8 +68,8 @@ function particle_library.particleEmittersLeft()
 end
 
 --- Creates a new Particle with the given material and position.
--- @param material material The material object to set the particle
--- @param vector position The position to create the particle
+-- @param Material material The material object to set the particle
+-- @param Vector position The position to create the particle
 -- @param number startSize Sets the initial size value of the particle.
 -- @param number endSize Sets the size of the particle that it will reach when it dies.
 -- @param number startLength Sets the initial length value of the particle.
@@ -134,7 +134,7 @@ function particleem_methods:getParticlesLeft()
 end
 
 --- Returns the position of this emitter. This is set when creating the emitter with ParticleEmitter.
--- @return vector Position of the Emitter
+-- @return Vector Position of the Emitter
 function particleem_methods:getPos()
 	return vwrap(unwrap(self):GetPos())
 end
@@ -152,8 +152,8 @@ function particleem_methods:isValid()
 end
 
 --- Sets the bounding box for this emitter. Usually the bounding box is automatically determined by the particles, but this function overrides it.
--- @param vector mins Min vector
--- @param vector maxs Max vector
+-- @param Vector mins Min vector
+-- @param Vector maxs Max vector
 function particleem_methods:setBBox(mins, maxs)
 	peunwrap(self):SetBBox(vunwrap(mins), vunwrap(maxs))
 end
@@ -182,7 +182,7 @@ function particleem_methods:setParticleCullRadius(radius)
 end
 
 --- Sets the position of the particle emitter.
--- @param vector position The position
+-- @param Vector position The position
 function particleem_methods:setPos( position )
 	 peunwrap(self):SetPos(vunwrap(position))
 end
@@ -191,25 +191,25 @@ end
 
 
 --- Returns the current orientation of the particle.
--- @return angle Angles of the particle
+-- @return Angle Angles of the particle
 function particle_methods:getAngles()
 	return awrap(punwrap(self):GetAngles())
 end
 
 --- Returns the angular velocity of the particle
--- @return angle Angular velocity of the particle
+-- @return Angle Angular velocity of the particle
 function particle_methods:getAngleVelocity()
 	return awrap(punwrap(self):GetAngleVelocity())
 end
 
 --- Returns the color of the particle.
--- @return color Color of the particle
+-- @return Color Color of the particle
 function particle_methods:getColor()
 	return cwrap(Color(punwrap(self):GetColor()))
 end
 
 --- Returns the absolute position of the particle.
--- @return vector Position of the particle
+-- @return Vector Position of the particle
 function particle_methods:getPos()
 	return vwrap(punwrap(self):GetPos())
 end
@@ -221,19 +221,19 @@ function particle_methods:getRoll()
 end
 
 --- Returns the current velocity of the particle.
--- @return vector Velocity
+-- @return Vector Velocity
 function particle_methods:getVelocity()
 	return vwrap(punwrap(self):GetVelocity())
 end
 
 --- Sets the angles of the particle.
--- @param angle ang Angles to set the particle's angles to
+-- @param Angle ang Angles to set the particle's angles to
 function particle_methods:setAngles(ang)
 	punwrap(self):SetAngles(aunwrap(ang))
 end
 
 --- Sets the angular velocity of the the particle.
--- @param angle angVel Angular velocity to set the particle's to
+-- @param Angle angVel Angular velocity to set the particle's to
 function particle_methods:setAngleVelocity(angVel)
 	punwrap(self):SetAngleVelocity(aunwrap(angVel))
 end
@@ -253,7 +253,7 @@ function particle_methods:setCollide(shouldCollide)
 end
 
 --- Sets the color of the particle.
--- @param color col Color to set to
+-- @param Color col Color to set to
 function particle_methods:setColor(col)
 	col = cunwrap(col)
 	punwrap(self):SetColor(col[1], col[2], col[3])
@@ -267,13 +267,13 @@ function particle_methods:setLighting(useLighting)
 end
 
 --- Sets the material of the particle.
--- @param material mat Material to set
+-- @param Material mat Material to set
 function particle_methods:setMaterial(mat)
 	punwrap(self):SetMaterial(munwrap(mat))
 end
 
 --- Sets the absolute position of the particle.
--- @param vector pos Vector position to set to
+-- @param Vector pos Vector position to set to
 function particle_methods:setPos(pos)
 	punwrap(self):SetPos(vunwrap(pos))
 end
@@ -293,7 +293,7 @@ function particle_methods:setRollDelta(rollDelta)
 end
 
 --- Sets the velocity of the particle.
--- @param vector vel Velocity to set to
+-- @param Vector vel Velocity to set to
 function particle_methods:setVelocity(vel)
 	punwrap(self):SetVelocity(vunwrap(vel))
 end
@@ -306,7 +306,7 @@ function particle_methods:setAirResistance(airResistance)
 end
 
 --- Sets the directional gravity aka. acceleration of the particle.
--- @param vector gravity Directional gravity
+-- @param Vector gravity Directional gravity
 function particle_methods:setGravity(gravity)
 	punwrap(self):SetGravity(vunwrap(gravity))
 end

--- a/lua/starfall/libs_cl/particle.lua
+++ b/lua/starfall/libs_cl/particle.lua
@@ -76,8 +76,8 @@ end
 -- @param number endLength Sets the length of the particle that it will reach when it dies.
 -- @param number startAlpha Sets the initial alpha value of the particle.
 -- @param number endAlpha Sets the alpha value of the particle that it will reach when it dies.
--- @param number dieTime Sets the time where the particle will be removed.
--- @return particle A Particle object
+-- @param number dieTime Sets the time where the particle will be removed. (0-60)
+-- @return Particle A Particle object
 function particleem_methods:add(material, position, startSize, endSize, startLength, endLength, startAlpha, endAlpha, dieTime)
 	self = peunwrap(self)
 	if not emitters[self] then SF.Throw("Tried to use invalid emitter!", 2) end
@@ -174,11 +174,13 @@ function particleem_methods:setNoDraw(noDraw)
 	peunwrap(self):SetNoDraw(noDraw)
 end
 
---- The function name has not much in common with its actual function, it applies a radius to every particles that affects the building of the bounding box, as it, usually is constructed by the particle that has the lowest x, y and z and the highest x, y and z, this function just adds/subtracts the radius and inflates the bounding box.
--- @param number radius
+--- The function name has not much in common with its actual function.
+-- It applies a radius to every particles that affects the building of the bounding box, as it usually is constructed by the particle that has the lowest x, y and z and the highest x, y and z.
+-- This function just adds/subtracts the radius and inflates the bounding box.
+-- @param number radius Particle radius
 function particleem_methods:setParticleCullRadius(radius)
 	checkluatype(radius, TYPE_NUMBER)
-	peunwrap(self):SetPos(vunwrap(position))
+	peunwrap(self):SetParticleCullRadius(radius)
 end
 
 --- Sets the position of the particle emitter.
@@ -186,8 +188,6 @@ end
 function particleem_methods:setPos( position )
 	 peunwrap(self):SetPos(vunwrap(position))
 end
-
-
 
 
 --- Returns the current orientation of the particle.

--- a/lua/starfall/libs_cl/particle.lua
+++ b/lua/starfall/libs_cl/particle.lua
@@ -49,9 +49,9 @@ instance:AddHook("deinitialize", function()
 end)
 
 --- Creates a ParticleEmitter data structure
--- @param position vector The particle emitter's position
--- @param use3D boolean Create the emitter in 3D mode
--- @return ParticleEmitter Object
+-- @param vector position The particle emitter's position
+-- @param boolean use3D Create the emitter in 3D mode
+-- @return particleemitter ParticleEmitter Object
 function particle_library.create(position, use3D)
 	checkluatype(use3D, TYPE_BOOL)
 	checkpermission(instance, nil, "particle.create")
@@ -62,22 +62,22 @@ function particle_library.create(position, use3D)
 end
 
 --- Returns number of particle emitters left able to be created
--- @return number
+-- @return number Number of particle emitters left
 function particle_library.particleEmittersLeft()
 	return plyEmitterCount:check()
 end
 
 --- Creates a new Particle with the given material and position.
--- @param material The material object to set the particle
--- @param position The position to create the particle
--- @param startSize number Sets the initial size value of the particle.
--- @param endSize number Sets the size of the particle that it will reach when it dies.
--- @param startLength number Sets the initial length value of the particle.
--- @param endLength number Sets the length of the particle that it will reach when it dies.
--- @param startAlpha number Sets the initial alpha value of the particle.
--- @param endAlpha number Sets the alpha value of the particle that it will reach when it dies.
--- @param dieTime number Sets the time where the particle will be removed.
--- @return A Particle object
+-- @param material material The material object to set the particle
+-- @param vector position The position to create the particle
+-- @param number startSize Sets the initial size value of the particle.
+-- @param number endSize Sets the size of the particle that it will reach when it dies.
+-- @param number startLength Sets the initial length value of the particle.
+-- @param number endLength Sets the length of the particle that it will reach when it dies.
+-- @param number startAlpha Sets the initial alpha value of the particle.
+-- @param number endAlpha Sets the alpha value of the particle that it will reach when it dies.
+-- @param number dieTime Sets the time where the particle will be removed.
+-- @return particle A Particle object
 function particleem_methods:add(material, position, startSize, endSize, startLength, endLength, startAlpha, endAlpha, dieTime)
 	self = peunwrap(self)
 	if not emitters[self] then SF.Throw("Tried to use invalid emitter!", 2) end
@@ -122,45 +122,45 @@ function particleem_methods:destroy()
 end
 
 --- Returns the amount of active particles of this emitter.
--- @return number
+-- @return number Number of active particles
 function particleem_methods:getNumActiveParticles()
 	return peunwrap(self):GetNumActiveParticles()
 end
 
 --- Returns number of particles left able to be created from the emitter
--- @return number
+-- @return number Number of particles left
 function particleem_methods:getParticlesLeft()
 	return cv_particle_count:GetInt() - peunwrap(self):GetNumActiveParticles()
 end
 
 --- Returns the position of this emitter. This is set when creating the emitter with ParticleEmitter.
--- @return vector
+-- @return vector Position of the Emitter
 function particleem_methods:getPos()
 	return vwrap(unwrap(self):GetPos())
 end
 
 --- Returns whether this emitter is 3D or not. This is set when creating the emitter with ParticleEmitter.
--- @return boolean
+-- @return boolean If it's 3D
 function particleem_methods:is3D()
 	return peunwrap(self):Is3D()
 end
 
 --- Returns whether this object is valid or not.
--- @return boolean
+-- @return boolean If it's valid
 function particleem_methods:isValid()
 	return peunwrap(self):IsValid()
 end
 
 --- Sets the bounding box for this emitter. Usually the bounding box is automatically determined by the particles, but this function overrides it.
--- @param mins vector
--- @param maxs vector
+-- @param vector mins Min vector
+-- @param vector maxs Max vector
 function particleem_methods:setBBox(mins, maxs)
 	peunwrap(self):SetBBox(vunwrap(mins), vunwrap(maxs))
 end
 
 --- This function sets the the distance between the render camera and the emitter at which the particles should start fading and at which distance fade ends ( alpha becomes 0 ).
--- @param distanceMin number
--- @param distanceMax number
+-- @param number distanceMin
+-- @param number distanceMax
 function particleem_methods:setNearClip(distanceMin, distanceMax)
 	checkluatype(distanceMin, TYPE_NUMBER)
 	checkluatype(distanceMax, TYPE_NUMBER)
@@ -168,21 +168,21 @@ function particleem_methods:setNearClip(distanceMin, distanceMax)
 end
 
 --- Prevents all particles of the emitter from automatically drawing. They can be manually drawn with draw()
--- @param noDraw boolean
+-- @param boolean noDraw Whether not to draw
 function particleem_methods:setNoDraw(noDraw)
 	checkluatype(noDraw, TYPE_BOOL)
 	peunwrap(self):SetNoDraw(noDraw)
 end
 
 --- The function name has not much in common with its actual function, it applies a radius to every particles that affects the building of the bounding box, as it, usually is constructed by the particle that has the lowest x, y and z and the highest x, y and z, this function just adds/subtracts the radius and inflates the bounding box.
--- @param radius number
+-- @param number radius
 function particleem_methods:setParticleCullRadius(radius)
 	checkluatype(radius, TYPE_NUMBER)
 	peunwrap(self):SetPos(vunwrap(position))
 end
 
 --- Sets the position of the particle emitter.
--- @param position The position
+-- @param vector position The position
 function particleem_methods:setPos( position )
 	 peunwrap(self):SetPos(vunwrap(position))
 end
@@ -191,128 +191,128 @@ end
 
 
 --- Returns the current orientation of the particle.
--- @return angle
+-- @return angle Angles of the particle
 function particle_methods:getAngles()
 	return awrap(punwrap(self):GetAngles())
 end
 
 --- Returns the angular velocity of the particle
--- @return angle
+-- @return angle Angular velocity of the particle
 function particle_methods:getAngleVelocity()
 	return awrap(punwrap(self):GetAngleVelocity())
 end
 
 --- Returns the color of the particle.
--- @return color
+-- @return color Color of the particle
 function particle_methods:getColor()
 	return cwrap(Color(punwrap(self):GetColor()))
 end
 
 --- Returns the absolute position of the particle.
--- @return vector
+-- @return vector Position of the particle
 function particle_methods:getPos()
 	return vwrap(punwrap(self):GetPos())
 end
 
 --- Returns the current rotation of the particle in radians, this should only be used for 2D particles.
--- @return number
+-- @return number Roll
 function particle_methods:getRoll()
 	return punwrap(self):GetRoll()
 end
 
 --- Returns the current velocity of the particle.
--- @return vector
+-- @return vector Velocity
 function particle_methods:getVelocity()
 	return vwrap(punwrap(self):GetVelocity())
 end
 
 --- Sets the angles of the particle.
--- @param ang angle
+-- @param angle ang Angles to set the particle's angles to
 function particle_methods:setAngles(ang)
 	punwrap(self):SetAngles(aunwrap(ang))
 end
 
 --- Sets the angular velocity of the the particle.
--- @param angVel angle
+-- @param angle angVel Angular velocity to set the particle's to
 function particle_methods:setAngleVelocity(angVel)
 	punwrap(self):SetAngleVelocity(aunwrap(angVel))
 end
 
 --- Sets the 'bounciness' of the the particle.
--- @param bounce number
+-- @param number bounce Bounciness to set to
 function particle_methods:setBounce(bounce)
 	checkluatype(bounce, TYPE_NUMBER)
 	punwrap(self):SetBounce(bounce)
 end
 
 --- Sets the whether the particle should collide with the world or not.
--- @param shouldCollide boolean
+-- @param boolean shouldCollide Whether it should collide
 function particle_methods:setCollide(shouldCollide)
 	checkluatype(shouldCollide, TYPE_BOOL)
 	punwrap(self):SetCollide(shouldCollide)
 end
 
 --- Sets the color of the particle.
--- @param col color
+-- @param color col Color to set to
 function particle_methods:setColor(col)
 	col = cunwrap(col)
 	punwrap(self):SetColor(col[1], col[2], col[3])
 end
 
 --- Sets whether the particle should be affected by lighting.
--- @param useLighting boolean
+-- @param boolean useLighting Whether the particle should be affected by lighting
 function particle_methods:setLighting(useLighting)
 	checkluatype(useLighting, TYPE_BOOL)
 	punwrap(self):SetLighting(useLighting)
 end
 
 --- Sets the material of the particle.
--- @param mat material
+-- @param material mat Material to set
 function particle_methods:setMaterial(mat)
 	punwrap(self):SetMaterial(munwrap(mat))
 end
 
 --- Sets the absolute position of the particle.
--- @param pos vector
+-- @param vector pos Vector position to set to
 function particle_methods:setPos(pos)
 	punwrap(self):SetPos(vunwrap(pos))
 end
 
 --- Sets the roll of the particle in radians. This should only be used for 2D particles.
--- @param roll number
+-- @param number roll Roll
 function particle_methods:setRoll(roll)
 	checkluatype(roll, TYPE_NUMBER)
 	punwrap(self):SetRoll(roll)
 end
 
 --- Sets the rotation speed of the particle in radians. This should only be used for 2D particles.
--- @param rollDelta number
+-- @param number rollDelta Rolldelta
 function particle_methods:setRollDelta(rollDelta)
 	checkluatype(rollDelta, TYPE_NUMBER)
 	punwrap(self):SetRollDelta(rollDelta)
 end
 
 --- Sets the velocity of the particle.
--- @param vel vector
+-- @param vector vel Velocity to set to
 function particle_methods:setVelocity(vel)
 	punwrap(self):SetVelocity(vunwrap(vel))
 end
 
 --- Sets the air resistance of the the particle.
--- @param airResistance number
+-- @param number airResistance AirResistance to set to
 function particle_methods:setAirResistance(airResistance)
 	checkluatype(airResistance, TYPE_NUMBER)
 	punwrap(self):SetAirResistance(airResistance)
 end
 
 --- Sets the directional gravity aka. acceleration of the particle.
--- @param gravity vector
+-- @param vector gravity Directional gravity
 function particle_methods:setGravity(gravity)
 	punwrap(self):SetGravity(vunwrap(gravity))
 end
 
 --- Scales the velocity based on the particle speed.
--- @param doScale boolean
+-- @param boolean doScale Whether it should scale
 function particle_methods:setVelocityScale(doScale)
 	checkluatype(doScale, TYPE_BOOL)
 	punwrap(self):SetVelocityScale(doScale)

--- a/lua/starfall/libs_cl/particle_effect.lua
+++ b/lua/starfall/libs_cl/particle_effect.lua
@@ -60,7 +60,7 @@ end
 
 
 --- Attaches a particleEffect to an entity.
--- @param entity entity Entity to attach to
+-- @param Entity entity Entity to attach to
 -- @param string name Name of the particle effect
 -- @param number pattach PATTACH enum
 -- @param table options Table of options
@@ -154,7 +154,7 @@ end
 
 
 --- Sets the sort origin for given particle effect system. This is used as a helper to determine which particles are in front of which.
--- @param vector origin Sort Origin
+-- @param Vector origin Sort Origin
 function particleef_methods:setSortOrigin(origin)
 	local uw = unwrap(self)
 
@@ -166,7 +166,7 @@ end
 
 --- Sets a value for given control point.
 -- @param number id Control Point ID (0-63)
--- @param vector value Value
+-- @param Vector value Value
 function particleef_methods:setControlPoint(id,value)
 	local uw = unwrap(self)
 
@@ -180,7 +180,7 @@ end
 
 --- Essentially makes child control point follow the parent entity.
 -- @param number id Child Control Point ID (0-63)
--- @param entity entity Entity parent
+-- @param Entity entity Entity parent
 function particleef_methods:setControlPointEntity(id,entity)
 	local uw = unwrap(self)
 	local entity = getent(entity)
@@ -195,7 +195,7 @@ end
 
 --- Sets the forward direction for given control point.
 -- @param number id Control Point ID (0-63)
--- @param vector fwd Forward vector
+-- @param Vector fwd Forward vector
 function particleef_methods:setForwardVector(id,value)
 	local uw = unwrap(self)
 
@@ -208,7 +208,7 @@ end
 
 --- Sets the right direction for given control point.
 -- @param number id Control Point ID (0-63)
--- @param vector right Right vector
+-- @param Vector right Right vector
 function particleef_methods:setRightVector(id,value)
 	local uw = unwrap(self)
 
@@ -222,7 +222,7 @@ end
 
 --- Sets the up direction for given control point.
 -- @param number id Control Point ID (0-63)
--- @param vector up Up vector
+-- @param Vector up Up vector
 function particleef_methods:setUpVector(id,value)
 	local uw = unwrap(self)
 

--- a/lua/starfall/libs_cl/particle_effect.lua
+++ b/lua/starfall/libs_cl/particle_effect.lua
@@ -60,11 +60,11 @@ end
 
 
 --- Attaches a particleEffect to an entity.
--- @param entity Entity to attach to
--- @param name Name of the particle effect
--- @param pattach PATTACH enum
--- @param options Table of options
--- @return ParticleEffect type.
+-- @param entity entity Entity to attach to
+-- @param string name Name of the particle effect
+-- @param number pattach PATTACH enum
+-- @param table options Table of options
+-- @return particleeffect ParticleEffect type.
 function particleef_library.attach(entity, name, pattach, options)
 	checkpermission(instance, entity, "particleEffect.attach")
 
@@ -94,12 +94,11 @@ end
 
 
 --- Gets if the particle effect is valid or not.
--- @return Is valid or not
+-- @return boolean Is valid or not
 function particleef_methods:isValid()
 	local uw = unwrap(self)
 
 	return uw and uw:IsValid()
-
 end
 
 --- Starts emission of the particle effect.
@@ -109,8 +108,6 @@ function particleef_methods:startEmission()
 	checkValid(uw)
 
 	uw:StartEmission()
-
-
 end
 
 
@@ -121,8 +118,6 @@ function particleef_methods:stopEmission()
 	checkValid(uw)
 
 	uw:StopEmission()
-
-
 end
 
 --- Stops emission of the particle effect and destroys the object.
@@ -133,7 +128,6 @@ function particleef_methods:destroy()
 		uw:StopEmissionAndDestroyImmediately()
 		plyCount:free(instance.player, 1)
 	end
-
 end
 
 --- Restarts emission of the particle effect.
@@ -143,13 +137,11 @@ function particleef_methods:restart()
 	checkValid(uw)
 
 	uw:Restart()
-
-
 end
 
 
---- Restarts emission of the particle effect.
--- @return bool finished
+--- Returns if the particle effect is finished
+-- @return boolean If the particle effect is finished
 function particleef_methods:isFinished()
 	local uw = unwrap(self)
 
@@ -158,26 +150,23 @@ function particleef_methods:isFinished()
 	end
 
 	return true
-
 end
 
 
 --- Sets the sort origin for given particle effect system. This is used as a helper to determine which particles are in front of which.
--- @param vector Sort Origin
+-- @param vector origin Sort Origin
 function particleef_methods:setSortOrigin(origin)
 	local uw = unwrap(self)
 
 	checkValid(uw)
 
 	uw:SetSortOrgin(vunwrap(origin))
-
-
 end
 
 
 --- Sets a value for given control point.
--- @param number Control Point ID (0-63)
--- @param vector Value
+-- @param number id Control Point ID (0-63)
+-- @param vector value Value
 function particleef_methods:setControlPoint(id,value)
 	local uw = unwrap(self)
 
@@ -186,14 +175,12 @@ function particleef_methods:setControlPoint(id,value)
 	checkValid(uw)
 
 	uw:SetControlPoint(id,vunwrap(value))
-
-
 end
 
 
 --- Essentially makes child control point follow the parent entity.
--- @param number Child Control Point ID (0-63)
--- @param entity Entity parent
+-- @param number id Child Control Point ID (0-63)
+-- @param entity entity Entity parent
 function particleef_methods:setControlPointEntity(id,entity)
 	local uw = unwrap(self)
 	local entity = getent(entity)
@@ -203,14 +190,12 @@ function particleef_methods:setControlPointEntity(id,entity)
 	checkValid(uw)
 
 	uw:SetControlPointEntity(id,entity)
-
-
 end
 
 
 --- Sets the forward direction for given control point.
--- @param number Control Point ID (0-63)
--- @param vector Forward
+-- @param number id Control Point ID (0-63)
+-- @param vector fwd Forward vector
 function particleef_methods:setForwardVector(id,value)
 	local uw = unwrap(self)
 
@@ -219,13 +204,11 @@ function particleef_methods:setForwardVector(id,value)
 	checkValid(uw)
 
 	uw:SetControlPointForwardVector(id,vunwrap(value))
-
-
 end
 
 --- Sets the right direction for given control point.
--- @param number Control Point ID (0-63)
--- @param vector Right
+-- @param number id Control Point ID (0-63)
+-- @param vector right Right vector
 function particleef_methods:setRightVector(id,value)
 	local uw = unwrap(self)
 
@@ -234,14 +217,12 @@ function particleef_methods:setRightVector(id,value)
 	checkValid(uw)
 
 	uw:SetControlPointRightVector(id,vunwrap(value))
-
-
 end
 
 
---- Sets the right direction for given control point.
--- @param number Control Point ID (0-63)
--- @param vector Right
+--- Sets the up direction for given control point.
+-- @param number id Control Point ID (0-63)
+-- @param vector up Up vector
 function particleef_methods:setUpVector(id,value)
 	local uw = unwrap(self)
 
@@ -254,9 +235,9 @@ function particleef_methods:setUpVector(id,value)
 end
 
 
---- Sets the forward direction for given control point.
--- @param number Child Control Point ID (0-63)
--- @param number Parent
+--- Sets the parent for given control point.
+-- @param number id Child Control Point ID (0-63)
+-- @param number parentid Parent
 function particleef_methods:setControlPointParent(id,value)
 	local uw = unwrap(self)
 

--- a/lua/starfall/libs_cl/particle_effect.lua
+++ b/lua/starfall/libs_cl/particle_effect.lua
@@ -64,7 +64,7 @@ end
 -- @param string name Name of the particle effect
 -- @param number pattach PATTACH enum
 -- @param table options Table of options
--- @return particleeffect ParticleEffect type.
+-- @return ParticleEffect ParticleEffect type.
 function particleef_library.attach(entity, name, pattach, options)
 	checkpermission(instance, entity, "particleEffect.attach")
 

--- a/lua/starfall/libs_cl/particle_effect.lua
+++ b/lua/starfall/libs_cl/particle_effect.lua
@@ -237,16 +237,16 @@ end
 
 --- Sets the parent for given control point.
 -- @param number id Child Control Point ID (0-63)
--- @param number parentid Parent
-function particleef_methods:setControlPointParent(id,value)
+-- @param number parentid Parent control point ID (0-63)
+function particleef_methods:setControlPointParent(id,parentid)
 	local uw = unwrap(self)
 
 	checkluatype (id, TYPE_NUMBER)
-	checkluatype (value, TYPE_NUMBER)
+	checkluatype (parentid, TYPE_NUMBER)
 
 	checkValid(uw)
 
-	uw:SetControlPointParent(id,value)
+	uw:SetControlPointParent(id,parentid)
 
 end
 

--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -1465,7 +1465,7 @@ end
 --- Constructs a markup object for quick styled text drawing.
 -- @param string str The markup string to parse
 -- @param number? maxsize The max width of the markup. Default nil
--- @return markup The markup object. See https://wiki.facepunch.com/gmod/markup.Parse
+-- @return Markup The markup object. See https://wiki.facepunch.com/gmod/markup.Parse
 function render_library.parseMarkup(str, maxsize)
 	checkluatype (str, TYPE_STRING)
 	if maxsize~=nil then checkluatype (maxsize, TYPE_NUMBER) end

--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -472,7 +472,7 @@ end
 -- ------------------------------------------------------------------ --
 
 --- Pushes a matrix onto the matrix stack.
--- @param vmatrix m The matrix
+-- @param VMatrix m The matrix
 -- @param boolean? world Should the transformation be relative to the screen or world?
 function render_library.pushMatrix(m, world)
 	if world == nil then
@@ -590,8 +590,8 @@ function render_library.popViewMatrix()
 end
 
 --- Sets background color of screen
--- @param color col Color of background
--- @param entity? screen (Optional) entity of screen
+-- @param Color col Color of background
+-- @param Entity? screen (Optional) entity of screen
 function render_library.setBackgroundColor(col, screen)
 	if screen then
 		screen = getent(screen)
@@ -622,7 +622,7 @@ function render_library.setLightingMode(mode)
 end
 
 --- Sets the draw color
--- @param color clr Color type
+-- @param Color clr Color type
 function render_library.setColor(clr)
 	currentcolor = clr
 	surface.SetDrawColor(clr)
@@ -648,7 +648,7 @@ end
 -- @param string tx Texture file path, a http url, or image data: https://en.wikipedia.org/wiki/Data_URI_scheme
 -- @param function? cb An optional callback called when loading is done. Passes nil if it fails or Passes the material, url, width, height, and layout function which can be called with x, y, w, h to reposition the image in the texture.
 -- @param function? done An optional callback called when the image is done loading. Passes the material, url
--- @return material The material. Use with render.setMaterial to draw with it.
+-- @return Material The material. Use with render.setMaterial to draw with it.
 function render_library.createMaterial(tx, cb, done)
 	checkluatype (tx, TYPE_STRING)
 
@@ -663,13 +663,13 @@ function render_library.createMaterial(tx, cb, done)
 end
 
 --- Releases the texture. Required if you reach the maximum url textures.
--- @param material mat The material object
+-- @param Material mat The material object
 function render_library.destroyTexture(mat)
 	mat:destroy()
 end
 
 --- Sets the current render material
--- @param material mat The material object
+-- @param Material mat The material object
 function render_library.setMaterial(mat)
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	if mat then
@@ -694,7 +694,7 @@ local function gettexture(mat)
 end
 
 --- Sets the current render material to the given material or the rendertarget, applying an additive shader when drawn.
--- @param material mat The material object to use the texture of, or the name of a rendertarget to use instead.
+-- @param Material mat The material object to use the texture of, or the name of a rendertarget to use instead.
 function render_library.setMaterialEffectAdd(mat)
 
 	checkpermission(instance, nil, "render.effects")
@@ -708,7 +708,7 @@ function render_library.setMaterialEffectAdd(mat)
 end
 
 --- Sets the current render material to the given material or the rendertarget, applying a subtractive shader when drawn.
--- @param material mat The material object to use the texture of, or the name of a rendertarget to use instead.
+-- @param Material mat The material object to use the texture of, or the name of a rendertarget to use instead.
 function render_library.setMaterialEffectSub(mat)
 
 	checkpermission(instance, nil, "render.effects")
@@ -722,7 +722,7 @@ function render_library.setMaterialEffectSub(mat)
 end
 
 --- Sets the current render material to the given material or the rendertarget, applying a bloom shader to the texture.
--- @param material mat The material object to use the texture of, or the name of a rendertarget to use instead.
+-- @param Material mat The material object to use the texture of, or the name of a rendertarget to use instead.
 -- @param number levelr Multiplier for all red pixels. 1 = unchanged
 -- @param number levelg Multiplier for all green pixels. 1 = unchanged
 -- @param number levelb Multiplier for all blue pixels. 1 = unchanged
@@ -752,7 +752,7 @@ function render_library.setMaterialEffectBloom(mat, levelr, levelg, levelb, colo
 end
 
 --- Sets the current render material to the given material or the rendertarget, darkening the texture, and scaling up color values.
--- @param material mat The material object to use the texture of, or the name of a rendertarget to use instead.
+-- @param Material mat The material object to use the texture of, or the name of a rendertarget to use instead.
 -- @param number darken The amount to darken the texture by. -1 to 1 inclusive.
 -- @param number multiply The amount to multiply the pixel colors by. (0-1024)
 function render_library.setMaterialEffectDownsample(mat, darken, multiply)
@@ -787,7 +787,7 @@ local defaultCM = {
 }
 
 --- Sets the current render material to the given material or the rendertarget, applying a color modification shader to the texture. Alias: render.setMaterialEffectColourModify
--- @param material mat The material object to use the texture of, or the name of a rendertarget to use instead.
+-- @param Material mat The material object to use the texture of, or the name of a rendertarget to use instead.
 -- @param table cmStructure A table where each key must be of "addr", "addg", "addb", "brightness", "color" or "colour", "contrast", "mulr", "mulg", and "mulb". All keys are optional.
 function render_library.setMaterialEffectColorModify(mat, cmStructure)
 
@@ -952,7 +952,7 @@ function render_library.setRenderTargetTexture(name)
 end
 
 --- Sets the texture of a screen entity
--- @param entity ent Screen entity
+-- @param Entity ent Screen entity
 function render_library.setTextureFromScreen(ent)
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 
@@ -999,7 +999,7 @@ function render_library.setCullMode(mode)
 end
 
 --- Clears the active render target
--- @param color? clr Color type to clear with
+-- @param Color? clr Color type to clear with
 -- @param boolean? depth Boolean if should clear depth. Default false
 function render_library.clear(clr, depth)
 	if not renderdata.isRendering then SF.Throw("Not in a rendering hook.", 2) end
@@ -1545,7 +1545,7 @@ function render_library.clearDepth()
 end
 
 --- Draws a sprite in 3d space.
--- @param vector pos Position of the sprite.
+-- @param Vector pos Position of the sprite.
 -- @param number width Width of the sprite.
 -- @param number height Height of the sprite.
 function render_library.draw3DSprite(pos, width, height)
@@ -1554,7 +1554,7 @@ function render_library.draw3DSprite(pos, width, height)
 end
 
 --- Draws a sphere
--- @param vector pos Position of the sphere
+-- @param Vector pos Position of the sphere
 -- @param number radius Radius of the sphere
 -- @param number longitudeSteps The amount of longitude steps. The larger this number is, the smoother the sphere is
 -- @param number latitudeSteps The amount of latitude steps. The larger this number is, the smoother the sphere is
@@ -1570,7 +1570,7 @@ function render_library.draw3DSphere(pos, radius, longitudeSteps, latitudeSteps)
 end
 
 --- Draws a wireframe sphere
--- @param vector pos Position of the sphere
+-- @param Vector pos Position of the sphere
 -- @param number radius Radius of the sphere
 -- @param number longitudeSteps The amount of longitude steps. The larger this number is, the smoother the sphere is
 -- @param number latitudeSteps The amount of latitude steps. The larger this number is, the smoother the sphere is
@@ -1586,8 +1586,8 @@ function render_library.draw3DWireframeSphere(pos, radius, longitudeSteps, latit
 end
 
 --- Draws a 3D Line
--- @param vector startPos Starting position
--- @param vector endPos Ending position
+-- @param Vector startPos Starting position
+-- @param Vector endPos Ending position
 function render_library.draw3DLine(startPos, endPos)
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	startPos = vunwrap(startPos)
@@ -1597,10 +1597,10 @@ function render_library.draw3DLine(startPos, endPos)
 end
 
 --- Draws a box in 3D space
--- @param vector origin Origin of the box.
--- @param angle angle Orientation of the box
--- @param vector mins Start position of the box, relative to origin.
--- @param vector maxs End position of the box, relative to origin.
+-- @param Vector origin Origin of the box.
+-- @param Angle angle Orientation of the box
+-- @param Vector mins Start position of the box, relative to origin.
+-- @param Vector maxs End position of the box, relative to origin.
 function render_library.draw3DBox(origin, angle, mins, maxs)
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	origin = vunwrap(origin)
@@ -1612,10 +1612,10 @@ function render_library.draw3DBox(origin, angle, mins, maxs)
 end
 
 --- Draws a wireframe box in 3D space
--- @param vector origin Origin of the box.
--- @param angle angle Orientation of the box
--- @param vector mins Start position of the box, relative to origin.
--- @param vector maxs End position of the box, relative to origin.
+-- @param Vector origin Origin of the box.
+-- @param Angle angle Orientation of the box
+-- @param Vector mins Start position of the box, relative to origin.
+-- @param Vector maxs End position of the box, relative to origin.
 function render_library.draw3DWireframeBox(origin, angle, mins, maxs)
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	origin = vunwrap(origin)
@@ -1627,8 +1627,8 @@ function render_library.draw3DWireframeBox(origin, angle, mins, maxs)
 end
 
 --- Draws textured beam.
--- @param vector startPos Beam start position.
--- @param vector endPos Beam end position.
+-- @param Vector startPos Beam start position.
+-- @param Vector endPos Beam end position.
 -- @param number width The width of the beam.
 -- @param number textureStart The start coordinate of the texture used.
 -- @param number textureEnd The end coordinate of the texture used.
@@ -1645,10 +1645,10 @@ function render_library.draw3DBeam(startPos, endPos, width, textureStart, textur
 end
 
 --- Draws 2 connected triangles.
--- @param vector vert1 First vertex.
--- @param vector vert2 The second vertex.
--- @param vector vert3 The third vertex.
--- @param vector vert4 The fourth vertex.
+-- @param Vector vert1 First vertex.
+-- @param Vector vert2 The second vertex.
+-- @param Vector vert3 The third vertex.
+-- @param Vector vert4 The fourth vertex.
 function render_library.draw3DQuad(vert1, vert2, vert3, vert4)
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 
@@ -1661,10 +1661,10 @@ function render_library.draw3DQuad(vert1, vert2, vert3, vert4)
 end
 
 --- Draws 2 connected triangles with custom UVs.
--- @param vector vert1 First vertex. {x, y, z, u, v}
--- @param vector vert2 The second vertex.
--- @param vector vert3 The third vertex.
--- @param vector vert4 The fourth vertex.
+-- @param Vector vert1 First vertex. {x, y, z, u, v}
+-- @param Vector vert2 The second vertex.
+-- @param Vector vert3 The third vertex.
+-- @param Vector vert4 The fourth vertex.
 function render_library.draw3DQuadUV(vert1, vert2, vert3, vert4)
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	mesh.Begin(MATERIAL_QUADS, 1)
@@ -1691,8 +1691,8 @@ function render_library.draw3DQuadUV(vert1, vert2, vert3, vert4)
 end
 
 --- Gets a 2D cursor position where ply is aiming at the current rendered screen or nil if they aren't aiming at it.
--- @param player? ply player to get cursor position from. Default player()
--- @param entity? screen An explicit screen to get the cursor pos of (default: The current rendering screen using 'render' hook)
+-- @param Player? ply player to get cursor position from. Default player()
+-- @param Entity? screen An explicit screen to get the cursor pos of (default: The current rendering screen using 'render' hook)
 -- @return number X position
 -- @return number Y position
 function render_library.cursorPos(ply, screen)
@@ -1736,7 +1736,7 @@ end
 
 --- Returns information about the screen, such as world offsets, dimentions, and rotation.
 -- Note: this does a table copy so move it out of your draw hook
--- @param entity e The screen to get info from.
+-- @param Entity e The screen to get info from.
 -- @return table A table describing the screen.
 function render_library.getScreenInfo(e)
 	local screen = getent(e)
@@ -1745,7 +1745,7 @@ function render_library.getScreenInfo(e)
 end
 
 --- Returns the entity currently being rendered to
--- @return entity Entity of the screen or hud being rendered
+-- @return Entity Entity of the screen or hud being rendered
 function render_library.getScreenEntity()
 	return ewrap(renderdata.renderEnt)
 end
@@ -1763,7 +1763,7 @@ end
 --- Reads the color of the specified pixel.
 -- @param number x Pixel x-coordinate.
 -- @param number y Pixel y-coordinate.
--- @return color Color object with ( r, g, b, 255 ) from the specified pixel.
+-- @return Color Color object with ( r, g, b, 255 ) from the specified pixel.
 function render_library.readPixel(x, y)
 	if not renderdata.isRendering then
 		SF.Throw("Not in rendering hook.", 2)
@@ -1793,9 +1793,9 @@ function render_library.getGameResolution()
 end
 
 --- Does a trace and returns the color of the textel the trace hits.
--- @param vector vec1 The starting vector
--- @param vector vec2 The ending vector
--- @return color The color
+-- @param Vector vec1 The starting vector
+-- @param Vector vec2 The ending vector
+-- @return Color The color
 function render_library.traceSurfaceColor(vec1, vec2)
 	return cwrap(render.GetSurfaceColor(vunwrap(vec1), vunwrap(vec2)):ToColor())
 end
@@ -1971,7 +1971,7 @@ function render_library.enableClipping(state)
 end
 
 --- Pushes a new clipping plane of the clip plane stack.
--- @param vector normal The normal of the clipping plane.
+-- @param Vector normal The normal of the clipping plane.
 -- @param number distance The normal of the clipping plane.
 function render_library.pushCustomClipPlane(normal, distance)
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
@@ -1998,30 +1998,30 @@ function render_library.popCustomClipPlane()
 end
 
 --- Calculates the light color of a certain surface
--- @param vector pos Vector position to sample from
--- @param vector normal Normal vector of the surface
--- @return vector Vector representing color of the light
+-- @param Vector pos Vector position to sample from
+-- @param Vector normal Normal vector of the surface
+-- @return Vector Vector representing color of the light
 function render_library.computeLighting(pos, normal)
 	return vwrap(render.ComputeLighting(vunwrap(pos), vunwrap(normal)))
 end
 
 --- Calculates the lighting caused by dynamic lights for the specified surface
--- @param vector pos Vector position to sample from
--- @param vector normal Normal vector of the surface
--- @return vector Vector representing color of the light
+-- @param Vector pos Vector position to sample from
+-- @param Vector normal Normal vector of the surface
+-- @return Vector Vector representing color of the light
 function render_library.computeDynamicLighting(pos, normal)
 	return vwrap(render.ComputeDynamicLighting(vunwrap(pos), vunwrap(normal)))
 end
 
 --- Gets the light exposure on the specified position
--- @param vector pos Vector position to sample from
--- @return vector Vector representing color of the light
+-- @param Vector pos Vector position to sample from
+-- @return Vector Vector representing color of the light
 function render_library.getLightColor(pos)
 	return vwrap(render.GetLightColor(vunwrap(pos)))
 end
 
 --- Returns the ambient color of the map
--- @return vector Vector representing color of the light
+-- @return Vector Vector representing color of the light
 function render_library.getAmbientLightColor()
 	return vwrap(render.GetAmbientLightColor())
 end
@@ -2037,7 +2037,7 @@ function render_library.setFogMode(mode)
 end
 
 --- Changes color of the fog
--- @param color col Color (alpha won't have any effect)
+-- @param Color col Color (alpha won't have any effect)
 function render_library.setFogColor(color)
 	checkpermission(instance, nil, "render.fog")
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
@@ -2107,7 +2107,7 @@ function render_library.setChipOverlay(name)
 end
 
 --- Using the custom screen model, sets the screen offset and size as long as its within bounds of -1024 to 1024 units
--- @param entity screen The custom screen to be resized
+-- @param Entity screen The custom screen to be resized
 -- @param number x The x offset of the screen
 -- @param number y The y offset of the screen
 -- @param number w The width of the screen
@@ -2182,8 +2182,8 @@ end
 -- @name renderscene
 -- @class hook
 -- @client
--- @param vector origin View origin
--- @param angle angles View angles
+-- @param Vector origin View origin
+-- @param Angle angles View angles
 -- @param number fov View FOV
 
 --- Called when the player connects to a HUD component linked to the Starfall Chip
@@ -2233,8 +2233,8 @@ end
 -- @name calcview
 -- @class hook
 -- @client
--- @param vector pos Current position of the camera
--- @param angle ang Current angles of the camera
+-- @param Vector pos Current position of the camera
+-- @param Angle ang Current angles of the camera
 -- @param number fov Current fov of the camera
 -- @param number znear Current near plane of the camera
 -- @param number zfar Current far plane of the camera
@@ -2254,8 +2254,8 @@ end
 --- Called when a player uses the screen
 -- @name starfallUsed
 -- @class hook
--- @param player activator Player who used the screen or chip
--- @param entity used The screen or chip entity that was used
+-- @param Player activator Player who used the screen or chip
+-- @param Entity used The screen or chip entity that was used
 
 ---
 -- @name render_library.Screen information table

--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -337,7 +337,7 @@ end)
 -- ------------------------------------------------------------------ --
 
 --- Sets whether stencil tests are carried out for each rendered pixel. Only pixels passing the stencil test are written to the render target.
--- @param enable true to enable, false to disable
+-- @param boolean enable true to enable, false to disable
 function render_library.setStencilEnable(enable)
 	enable = (enable == true) -- Make sure it's a boolean
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
@@ -352,10 +352,10 @@ function render_library.clearStencil()
 end
 
 --- Clears the current rendertarget for obeying the current stencil buffer conditions.
--- @param r Value of the red channel to clear the current rt with.
--- @param g Value of the green channel to clear the current rt with.
--- @param b Value of the blue channel to clear the current rt with.
--- @param depth Clear the depth buffer.
+-- @param number r Value of the red channel to clear the current rt with.
+-- @param number g Value of the green channel to clear the current rt with.
+-- @param number b Value of the blue channel to clear the current rt with.
+-- @param boolean Clear the depth buffer.
 function render_library.clearBuffersObeyStencil(r, g, b, a, depth)
 	checkluatype (r, TYPE_NUMBER)
 	checkluatype (g, TYPE_NUMBER)
@@ -368,11 +368,11 @@ function render_library.clearBuffersObeyStencil(r, g, b, a, depth)
 end
 
 --- Sets the stencil value in a specified rect.
--- @param originX X origin of the rectangle.
--- @param originY Y origin of the rectangle.
--- @param endX The end X coordinate of the rectangle.
--- @param endY The end Y coordinate of the rectangle.
--- @param stencilValue Value to set cleared stencil buffer to.
+-- @param number originX X origin of the rectangle.
+-- @param number originY Y origin of the rectangle.
+-- @param number endX The end X coordinate of the rectangle.
+-- @param number endY The end Y coordinate of the rectangle.
+-- @param number stencilValue Value to set cleared stencil buffer to.
 function render_library.clearStencilBufferRectangle(originX, originY, endX, endY, stencilValue)
 	checkluatype (originX, TYPE_NUMBER)
 	checkluatype (originY, TYPE_NUMBER)
@@ -386,7 +386,7 @@ function render_library.clearStencilBufferRectangle(originX, originY, endX, endY
 end
 
 --- Sets the compare function of the stencil. More: https://wiki.facepunch.com/gmod/render.SetStencilCompareFunction
--- @param compareFunction
+-- @param number compareFunction
 function render_library.setStencilCompareFunction(compareFunction)
 	checkluatype (compareFunction, TYPE_NUMBER)
 
@@ -396,7 +396,7 @@ function render_library.setStencilCompareFunction(compareFunction)
 end
 
 --- Sets the operation to be performed on the stencil buffer values if the compare function was not successful. More: http://wiki.facepunch.com/gmod/render.SetStencilFailOperation
--- @param operation
+-- @param number operation
 function render_library.setStencilFailOperation(operation)
 	checkluatype (operation, TYPE_NUMBER)
 
@@ -406,7 +406,7 @@ function render_library.setStencilFailOperation(operation)
 end
 
 --- Sets the operation to be performed on the stencil buffer values if the compare function was successful. More: http://wiki.facepunch.com/gmod/render.SetStencilPassOperation
--- @param operation
+-- @param number operation
 function render_library.setStencilPassOperation(operation)
 	checkluatype (operation, TYPE_NUMBER)
 
@@ -416,7 +416,7 @@ function render_library.setStencilPassOperation(operation)
 end
 
 --- Sets the operation to be performed on the stencil buffer values if the stencil test is passed but the depth buffer test fails. More: http://wiki.facepunch.com/gmod/render.SetStencilZFailOperation
--- @param operation
+-- @param number operation
 function render_library.setStencilZFailOperation(operation)
 	checkluatype (operation, TYPE_NUMBER)
 
@@ -426,7 +426,7 @@ function render_library.setStencilZFailOperation(operation)
 end
 
 --- Sets the reference value which will be used for all stencil operations. This is an unsigned integer.
--- @param referenceValue Reference value.
+-- @param number referenceValue Reference value.
 function render_library.setStencilReferenceValue(referenceValue)
 	checkluatype (referenceValue, TYPE_NUMBER)
 
@@ -436,7 +436,7 @@ function render_library.setStencilReferenceValue(referenceValue)
 end
 
 --- Sets the unsigned 8-bit test bitflag mask to be used for any stencil testing.
--- @param mask The mask bitflag.
+-- @param number mask The mask bitflag.
 function render_library.setStencilTestMask(mask)
 	checkluatype (mask, TYPE_NUMBER)
 
@@ -446,7 +446,7 @@ function render_library.setStencilTestMask(mask)
 end
 
 --- Sets the unsigned 8-bit write bitflag mask to be used for any writes to the stencil buffer.
--- @param mask The mask bitflag.
+-- @param number mask The mask bitflag.
 function render_library.setStencilWriteMask(mask)
 	checkluatype (mask, TYPE_NUMBER)
 
@@ -458,7 +458,7 @@ end
 --- Resets stencil operations to their default behavior
 function render_library.resetStencil()
 	if renderdata.noStencil and not renderdata.usingRT then SF.Throw("Stencil operations must be used inside RenderTarget or HUD") end
-	
+
 	render.SetStencilWriteMask(0xFF)
 	render.SetStencilTestMask(0xFF)
 	render.SetStencilReferenceValue(0)
@@ -472,8 +472,8 @@ end
 -- ------------------------------------------------------------------ --
 
 --- Pushes a matrix onto the matrix stack.
--- @param m The matrix
--- @param world Should the transformation be relative to the screen or world?
+-- @param vmatrix m The matrix
+-- @param boolean? world Should the transformation be relative to the screen or world?
 function render_library.pushMatrix(m, world)
 	if world == nil then
 		world = renderdata.usingRT
@@ -497,10 +497,10 @@ function render_library.pushMatrix(m, world)
 end
 
 --- Enables a scissoring rect which limits the drawing area. Only works 2D contexts such as HUD or render targets.
--- @param startX X start coordinate of the scissor rect.
--- @param startY Y start coordinate of the scissor rect.
--- @param endX X end coordinate of the scissor rect.
--- @param endX Y end coordinate of the scissor rect.
+-- @param number startX X start coordinate of the scissor rect.
+-- @param number startY Y start coordinate of the scissor rect.
+-- @param number endX X end coordinate of the scissor rect.
+-- @param number endX Y end coordinate of the scissor rect.
 function render_library.enableScissorRect(startX, startY, endX, endY)
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	checkluatype (startX, TYPE_NUMBER)
@@ -514,7 +514,6 @@ end
 function render_library.disableScissorRect()
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	render.SetScissorRect(0 , 0 , 0 , 0, false)
-
 end
 
 --- Pops a matrix from the matrix stack.
@@ -535,7 +534,7 @@ local viewmatrix_checktypes =
 local viewmatrix_checktypes_ignore = {origin = true, angles = true}
 
 --- Pushes a perspective matrix onto the view matrix stack.
--- @param tbl The view matrix data. See http://wiki.facepunch.com/gmod/Structures/RenderCamData
+-- @param table tbl The view matrix data. See http://wiki.facepunch.com/gmod/Structures/RenderCamData
 function render_library.pushViewMatrix(tbl)
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	if #view_matrix_stack == MATRIX_STACK_LIMIT then SF.Throw("Pushed too many matrices", 2) end
@@ -591,8 +590,8 @@ function render_library.popViewMatrix()
 end
 
 --- Sets background color of screen
--- @param col Color of background
--- @param screen (Optional) entity of screen
+-- @param color col Color of background
+-- @param entity? screen (Optional) entity of screen
 function render_library.setBackgroundColor(col, screen)
 	if screen then
 		screen = getent(screen)
@@ -615,15 +614,15 @@ function render_library.setBackgroundColor(col, screen)
 end
 
 --- Sets the lighting mode
--- @param mode The lighting mode. 0 - Default, 1 - Fullbright, 2 - Increased Fullbright
+-- @param number mode The lighting mode. 0 - Default, 1 - Fullbright, 2 - Increased Fullbright
 function render_library.setLightingMode(mode)
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	if mode ~= 0 and mode ~= 1 and mode ~= 2 then SF.Throw("Invalid mode.", 2) end
-	render.SetLightingMode(mode) 
+	render.SetLightingMode(mode)
 end
 
 --- Sets the draw color
--- @param clr Color type
+-- @param color clr Color type
 function render_library.setColor(clr)
 	currentcolor = clr
 	surface.SetDrawColor(clr)
@@ -631,10 +630,10 @@ function render_library.setColor(clr)
 end
 
 --- Sets the draw color by RGBA values
--- @param r Number, red value
--- @param g Number, green value
--- @param b Number, blue value
--- @param a Number, alpha value
+-- @param number r Number, red value
+-- @param number g Number, green value
+-- @param number b Number, blue value
+-- @param number a Number, alpha value
 function render_library.setRGBA(r, g, b, a)
 	checkluatype (r, TYPE_NUMBER) checkluatype (g, TYPE_NUMBER) checkluatype (b, TYPE_NUMBER) checkluatype (a, TYPE_NUMBER)
 	currentcolor = Color(r, g, b, a)
@@ -646,10 +645,10 @@ end
 --- Also supports image URLs or image data (These will create a rendertarget for the $basetexture): https://en.wikipedia.org/wiki/Data_URI_scheme
 --- Make sure to store the material to use it rather than calling this slow function repeatedly.
 --- NOTE: This no longer supports material names. Use texture names instead (Textures are .vtf, material are .vmt)
--- @param tx Texture file path, a http url, or image data: https://en.wikipedia.org/wiki/Data_URI_scheme
--- @param cb An optional callback called when loading is done. Passes nil if it fails or Passes the material, url, width, height, and layout function which can be called with x, y, w, h to reposition the image in the texture.
--- @param done An optional callback called when the image is done loading. Passes the material, url
--- @return The material. Use with render.setMaterial to draw with it.
+-- @param string tx Texture file path, a http url, or image data: https://en.wikipedia.org/wiki/Data_URI_scheme
+-- @param function? cb An optional callback called when loading is done. Passes nil if it fails or Passes the material, url, width, height, and layout function which can be called with x, y, w, h to reposition the image in the texture.
+-- @param function? done An optional callback called when the image is done loading. Passes the material, url
+-- @return material The material. Use with render.setMaterial to draw with it.
 function render_library.createMaterial(tx, cb, done)
 	checkluatype (tx, TYPE_STRING)
 
@@ -664,13 +663,13 @@ function render_library.createMaterial(tx, cb, done)
 end
 
 --- Releases the texture. Required if you reach the maximum url textures.
--- @param mat The material object
+-- @param material mat The material object
 function render_library.destroyTexture(mat)
 	mat:destroy()
 end
 
 --- Sets the current render material
--- @param mat The material object
+-- @param material mat The material object
 function render_library.setMaterial(mat)
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	if mat then
@@ -695,7 +694,7 @@ local function gettexture(mat)
 end
 
 --- Sets the current render material to the given material or the rendertarget, applying an additive shader when drawn.
--- @param mat The material object to use the texture of, or the name of a rendertarget to use instead.
+-- @param material mat The material object to use the texture of, or the name of a rendertarget to use instead.
 function render_library.setMaterialEffectAdd(mat)
 
 	checkpermission(instance, nil, "render.effects")
@@ -709,7 +708,7 @@ function render_library.setMaterialEffectAdd(mat)
 end
 
 --- Sets the current render material to the given material or the rendertarget, applying a subtractive shader when drawn.
--- @param mat The material object to use the texture of, or the name of a rendertarget to use instead.
+-- @param material mat The material object to use the texture of, or the name of a rendertarget to use instead.
 function render_library.setMaterialEffectSub(mat)
 
 	checkpermission(instance, nil, "render.effects")
@@ -723,11 +722,11 @@ function render_library.setMaterialEffectSub(mat)
 end
 
 --- Sets the current render material to the given material or the rendertarget, applying a bloom shader to the texture.
--- @param mat The material object to use the texture of, or the name of a rendertarget to use instead.
--- @param levelr Multiplier for all red pixels. 1 = unchanged
--- @param levelg Multiplier for all green pixels. 1 = unchanged
--- @param levelb Multiplier for all blue pixels. 1 = unchanged
--- @param colormul Multiplier for all three colors. 1 = unchanged
+-- @param material mat The material object to use the texture of, or the name of a rendertarget to use instead.
+-- @param number levelr Multiplier for all red pixels. 1 = unchanged
+-- @param number levelg Multiplier for all green pixels. 1 = unchanged
+-- @param number levelb Multiplier for all blue pixels. 1 = unchanged
+-- @param number colormul Multiplier for all three colors. 1 = unchanged
 function render_library.setMaterialEffectBloom(mat, levelr, levelg, levelb, colormul)
 
 	checkpermission(instance, nil, "render.effects")
@@ -753,9 +752,9 @@ function render_library.setMaterialEffectBloom(mat, levelr, levelg, levelb, colo
 end
 
 --- Sets the current render material to the given material or the rendertarget, darkening the texture, and scaling up color values.
--- @param mat The material object to use the texture of, or the name of a rendertarget to use instead.
--- @param darken The amount to darken the texture by. -1 to 1 inclusive.
--- @param multiply The amount to multiply the pixel colors by.
+-- @param material mat The material object to use the texture of, or the name of a rendertarget to use instead.
+-- @param number darken The amount to darken the texture by. -1 to 1 inclusive.
+-- @param number multiply The amount to multiply the pixel colors by. (0-1024)
 function render_library.setMaterialEffectDownsample(mat, darken, multiply)
 
 	checkpermission(instance, nil, "render.effects")
@@ -788,8 +787,8 @@ local defaultCM = {
 }
 
 --- Sets the current render material to the given material or the rendertarget, applying a color modification shader to the texture. Alias: render.setMaterialEffectColourModify
--- @param mat The material object to use the texture of, or the name of a rendertarget to use instead.
--- @param cmStructure A table where each key must be of "addr", "addg", "addb", "brightness", "color" or "colour", "contrast", "mulr", "mulg", and "mulb". All keys are optional.
+-- @param material mat The material object to use the texture of, or the name of a rendertarget to use instead.
+-- @param table cmStructure A table where each key must be of "addr", "addg", "addb", "brightness", "color" or "colour", "contrast", "mulr", "mulg", and "mulb". All keys are optional.
 function render_library.setMaterialEffectColorModify(mat, cmStructure)
 
 	checkpermission(instance, nil, "render.effects")
@@ -821,9 +820,9 @@ render_library.setMaterialEffectColourModify = render_library.setMaterialEffectC
 
 
 --- Applies a blur effect to the active rendertarget. This must be used with a rendertarget created beforehand.
--- @param blurx The amount of horizontal blur to apply.
--- @param blury The amount of vertical blur to apply.
--- @param passes The number of times the blur effect is applied.
+-- @param number blurx The amount of horizontal blur to apply.
+-- @param number blury The amount of vertical blur to apply.
+-- @param number passes The number of times the blur effect is applied.
 function render_library.drawBlurEffect(blurx, blury, passes)
 
 	checkpermission(instance, nil, "render.effects")
@@ -846,7 +845,7 @@ function render_library.drawBlurEffect(blurx, blury, passes)
 end
 
 --- Check if the specified render target exists.
--- @param name The name of the render target
+-- @param string name The name of the render target
 function render_library.renderTargetExists(name)
 	checkluatype (name, TYPE_STRING)
 	return renderdata.rendertargets[name] ~= nil
@@ -854,7 +853,7 @@ end
 
 --- Creates a new render target to draw onto.
 -- The dimensions will always be 1024x1024
--- @param name The name of the render target
+-- @param string name The name of the render target
 function render_library.createRenderTarget(name)
 	checkluatype (name, TYPE_STRING)
 
@@ -869,7 +868,7 @@ function render_library.createRenderTarget(name)
 end
 
 --- Releases the rendertarget. Required if you reach the maximum rendertargets.
--- @param name Rendertarget name
+-- @param string name Rendertarget name
 function render_library.destroyRenderTarget(name)
 	local rt = renderdata.rendertargets[name]
 	if rt then
@@ -883,7 +882,7 @@ end
 
 --- Selects the render target to draw on.
 -- Nil for the visible RT.
--- @param name Name of the render target to use
+-- @param string? name Name of the render target to use
 function render_library.selectRenderTarget(name)
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	if name then
@@ -931,7 +930,7 @@ end
 
 --- Sets the active texture to the render target with the specified name.
 -- Nil to reset.
--- @param name Name of the render target to use
+-- @param string? name Name of the render target to use
 function render_library.setRenderTargetTexture(name)
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	if name == nil then
@@ -953,7 +952,7 @@ function render_library.setRenderTargetTexture(name)
 end
 
 --- Sets the texture of a screen entity
--- @param ent Screen entity
+-- @param entity ent Screen entity
 function render_library.setTextureFromScreen(ent)
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 
@@ -970,7 +969,7 @@ function render_library.setTextureFromScreen(ent)
 end
 
 --- Sets the texture filtering function when viewing a close texture
--- @param val The filter function to use http://wiki.facepunch.com/gmod/Enums/TEXFILTER
+-- @param number val The filter function to use http://wiki.facepunch.com/gmod/Enums/TEXFILTER
 function render_library.setFilterMag(val)
 	checkluatype (val, TYPE_NUMBER)
 	if renderdata.changedFilterMag then
@@ -981,7 +980,7 @@ function render_library.setFilterMag(val)
 end
 
 --- Sets the texture filtering function when viewing a far texture
--- @param val The filter function to use http://wiki.facepunch.com/gmod/Enums/TEXFILTER
+-- @param number val The filter function to use http://wiki.facepunch.com/gmod/Enums/TEXFILTER
 function render_library.setFilterMin(val)
 	checkluatype (val, TYPE_NUMBER)
 	if renderdata.changedFilterMin then
@@ -992,7 +991,7 @@ function render_library.setFilterMin(val)
 end
 
 --- Changes the cull mode
--- @param mode Cull mode. 0 for counter clock wise, 1 for clock wise
+-- @param number mode Cull mode. 0 for counter clock wise, 1 for clock wise
 function render_library.setCullMode(mode)
 	if not renderdata.isRendering then SF.Throw("Not in a rendering hook.", 2) end
 
@@ -1000,8 +999,8 @@ function render_library.setCullMode(mode)
 end
 
 --- Clears the active render target
--- @param clr Color type to clear with
--- @param depth Boolean if should clear depth
+-- @param color? clr Color type to clear with
+-- @param boolean? depth Boolean if should clear depth. Default false
 function render_library.clear(clr, depth)
 	if not renderdata.isRendering then SF.Throw("Not in a rendering hook.", 2) end
 	if renderdata.usingRT then
@@ -1014,26 +1013,26 @@ function render_library.clear(clr, depth)
 end
 
 --- Draws a rounded rectangle using the current color
--- @param r The corner radius
--- @param x Top left corner x coordinate
--- @param y Top left corner y coordinate
--- @param w Width
--- @param h Height
+-- @param number r The corner radius
+-- @param number x Top left corner x coordinate
+-- @param number y Top left corner y coordinate
+-- @param number w Width
+-- @param number h Height
 function render_library.drawRoundedBox(r, x, y, w, h)
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	draw.RoundedBox(r, x, y, w, h, currentcolor)
 end
 
 --- Draws a rounded rectangle using the current color
--- @param r The corner radius
--- @param x Top left corner x coordinate
--- @param y Top left corner y coordinate
--- @param w Width
--- @param h Height
--- @param tl Boolean Top left corner
--- @param tr Boolean Top right corner
--- @param bl Boolean Bottom left corner
--- @param br Boolean Bottom right corner
+-- @param number r The corner radius
+-- @param number x Top left corner x coordinate
+-- @param number y Top left corner y coordinate
+-- @param number w Width
+-- @param number h Height
+-- @param boolean? tl Top left corner. Default false
+-- @param boolean? tr Top right corner. Default false
+-- @param boolean? bl Bottom left corner. Default false
+-- @param boolean? br Bottom right corner. Default false
 function render_library.drawRoundedBoxEx(r, x, y, w, h, tl, tr, bl, br)
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	draw.RoundedBoxEx(r, x, y, w, h, currentcolor, tl, tr, bl, br)
@@ -1053,20 +1052,20 @@ local function makeQuad(x, y, w, h)
 end
 --- Draws a rectangle using the current color
 --- Faster, but uses integer coordinates and will get clipped by user's screen resolution
--- @param x Top left corner x
--- @param y Top left corner y
--- @param w Width
--- @param h Height
+-- @param number x Top left corner x
+-- @param number y Top left corner y
+-- @param number w Width
+-- @param number h Height
 function render_library.drawRectFast(x, y, w, h)
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	surface.DrawRect(x, y, w, h)
 end
 
 --- Draws a rectangle using the current color
--- @param x Top left corner x
--- @param y Top left corner y
--- @param w Width
--- @param h Height
+-- @param number x Top left corner x
+-- @param number y Top left corner y
+-- @param number w Width
+-- @param number h Height
 function render_library.drawRect(x, y, w, h)
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	makeQuad(x, y, w, h)
@@ -1075,20 +1074,20 @@ function render_library.drawRect(x, y, w, h)
 end
 
 --- Draws a rectangle outline using the current color.
--- @param x Top left corner x integer coordinate
--- @param y Top left corner y integer coordinate
--- @param w Width
--- @param h Height
--- @param thickness Optional inset border width
+-- @param number x Top left corner x integer coordinate
+-- @param number y Top left corner y integer coordinate
+-- @param number w Width
+-- @param number h Height
+-- @param number? thickness Optional inset border width
 function render_library.drawRectOutline(x, y, w, h, thickness)
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	surface.DrawOutlinedRect(x, y, w, h, thickness)
 end
 
 --- Draws a circle outline
--- @param x Center x coordinate
--- @param y Center y coordinate
--- @param r Radius
+-- @param number x Center x coordinate
+-- @param number y Center y coordinate
+-- @param number r Radius
 function render_library.drawCircle(x, y, r)
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	surface.DrawCircle(x, y, r, currentcolor)
@@ -1096,20 +1095,20 @@ end
 
 --- Draws a textured rectangle
 --- Faster, but uses integer coordinates and will get clipped by user's screen resolution
--- @param x Top left corner x
--- @param y Top left corner y
--- @param w Width
--- @param h Height
+-- @param number x Top left corner x
+-- @param number y Top left corner y
+-- @param number w Width
+-- @param number h Height
 function render_library.drawTexturedRectFast(x, y, w, h)
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	surface.DrawTexturedRect(x, y, w, h)
 end
 
 --- Draws a textured rectangle
--- @param x Top left corner x
--- @param y Top left corner y
--- @param w Width
--- @param h Height
+-- @param number x Top left corner x
+-- @param number y Top left corner y
+-- @param number w Width
+-- @param number h Height
 function render_library.drawTexturedRect(x, y, w, h)
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	makeQuad(x, y, w, h)
@@ -1118,15 +1117,15 @@ end
 
 --- Draws a textured rectangle with UV coordinates
 --- Faster, but uses integer coordinates and will get clipped by user's screen resolution
--- @param x Top left corner x
--- @param y Top left corner y
--- @param w Width
--- @param h Height
--- @param startU Texture mapping at rectangle's origin U
--- @param startV Texture mapping at rectangle's origin V
--- @param endU Texture mapping at rectangle's end U
--- @param endV Texture mapping at rectangle's end V
--- @param UVHack If enabled, will scale the UVs to compensate for internal bug. Should be true for user created materials.
+-- @param number x Top left corner x
+-- @param number y Top left corner y
+-- @param number w Width
+-- @param number h Height
+-- @param number startU Texture mapping at rectangle's origin U
+-- @param number startV Texture mapping at rectangle's origin V
+-- @param number endU Texture mapping at rectangle's end U
+-- @param number endV Texture mapping at rectangle's end V
+-- @param boolean? UVHack If enabled, will scale the UVs to compensate for internal bug. Should be true for user created materials.
 function render_library.drawTexturedRectUVFast(x, y, w, h, startU, startV, endU, endV, UVHack)
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 
@@ -1141,14 +1140,14 @@ function render_library.drawTexturedRectUVFast(x, y, w, h, startU, startV, endU,
 end
 
 --- Draws a textured rectangle with UV coordinates
--- @param x Top left corner x
--- @param y Top left corner y
--- @param w Width
--- @param h Height
--- @param startU Texture mapping at rectangle origin
--- @param startV Texture mapping at rectangle origin
--- @param endU Texture mapping at rectangle end
--- @param endV Texture mapping at rectangle end
+-- @param number x Top left corner x
+-- @param number y Top left corner y
+-- @param number w Width
+-- @param number h Height
+-- @param number startU Texture mapping at rectangle origin
+-- @param number startV Texture mapping at rectangle origin
+-- @param number endU Texture mapping at rectangle end
+-- @param number endV Texture mapping at rectangle end
 function render_library.drawTexturedRectUV(x, y, w, h, startU, startV, endU, endV)
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	checkluatype (x, TYPE_NUMBER)
@@ -1185,11 +1184,11 @@ end
 
 --- Draws a rotated, textured rectangle.
 --- Faster, but uses integer coordinates and will get clipped by user's screen resolution
--- @param x X coordinate of center of rect
--- @param y Y coordinate of center of rect
--- @param w Width
--- @param h Height
--- @param rot Rotation in degrees
+-- @param number x X coordinate of center of rect
+-- @param number y Y coordinate of center of rect
+-- @param number w Width
+-- @param number h Height
+-- @param number rot Rotation in degrees
 function render_library.drawTexturedRectRotatedFast(x, y, w, h, rot)
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 
@@ -1197,11 +1196,11 @@ function render_library.drawTexturedRectRotatedFast(x, y, w, h, rot)
 end
 
 --- Draws a rotated, textured rectangle.
--- @param x X coordinate of center of rect
--- @param y Y coordinate of center of rect
--- @param w Width
--- @param h Height
--- @param rot Rotation in degrees
+-- @param number x X coordinate of center of rect
+-- @param number y Y coordinate of center of rect
+-- @param number w Width
+-- @param number h Height
+-- @param number rot Rotation in degrees
 function render_library.drawTexturedRectRotated(x, y, w, h, rot)
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 
@@ -1225,11 +1224,11 @@ function render_library.drawTexturedRectRotated(x, y, w, h, rot)
 end
 
 --- Draws RGB color channel tables to current render target.
--- @param w Width of image to be drawn.
--- @param h Height of image to be drawn.
--- @param dataR Red channel data.
--- @param dataG Green channel data.
--- @param dataB Blue channel data.
+-- @param number w Width of image to be drawn.
+-- @param number h Height of image to be drawn.
+-- @param table dataR Red channel data.
+-- @param table dataG Green channel data.
+-- @param table dataB Blue channel data.
 function render_library.drawPixelsRGB(w, h, dataR, dataG, dataB) 
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	if not renderdata.usingRT then SF.Throw("Cannot use this function outside of a rendertarget.", 2) end
@@ -1241,13 +1240,13 @@ function render_library.drawPixelsRGB(w, h, dataR, dataG, dataB)
 end
 
 --- Draws RGBA color channel tables to current render target.
--- @param w Width of image to be drawn.
--- @param h Height of image to be drawn.
--- @param dataR Red channel data.
--- @param dataG Green channel data.
--- @param dataB Blue channel data.
--- @param dataA Alpha channel data.
-function render_library.drawPixelsRGBA(w, h, dataR, dataG, dataB, dataA) 
+-- @param number w Width of image to be drawn.
+-- @param number h Height of image to be drawn.
+-- @param table dataR Red channel data.
+-- @param table dataG Green channel data.
+-- @param table dataB Blue channel data.
+-- @param table dataA Alpha channel data.
+function render_library.drawPixelsRGBA(w, h, dataR, dataG, dataB, dataA)
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	if not renderdata.usingRT then SF.Throw("Cannot use this function outside of a rendertarget.", 2) end
 	for i = 1, w*h do
@@ -1257,18 +1256,18 @@ function render_library.drawPixelsRGBA(w, h, dataR, dataG, dataB, dataA)
 	render.SetViewPort(0, 0, 1024, 1024)
 end
 --- Draws region of RGB color channel tables to current render target.
--- @param dstX Destination x coordinate
--- @param dstY Destination y coordinate
--- @param srcX Source x coordinate
--- @param srcY Source y coordinate
--- @param srcW Source original width
--- @param srcH Source original height
--- @param subrectW Width of subrect
--- @param subrectH Height of subrect
--- @param dataR Red channel data.
--- @param dataG Green channel data.
--- @param dataB Blue channel data.
-function render_library.drawPixelsSubrectRGB(dstX, dstY, srcX, srcY, srcW, srcH, subrectW, subrectH, dataR, dataG, dataB) 
+-- @param number dstX Destination x coordinate
+-- @param number dstY Destination y coordinate
+-- @param number srcX Source x coordinate
+-- @param number srcY Source y coordinate
+-- @param number srcW Source original width
+-- @param number srcH Source original height
+-- @param number subrectW Width of subrect
+-- @param number subrectH Height of subrect
+-- @param table dataR Red channel data.
+-- @param table dataG Green channel data.
+-- @param table dataB Blue channel data.
+function render_library.drawPixelsSubrectRGB(dstX, dstY, srcX, srcY, srcW, srcH, subrectW, subrectH, dataR, dataG, dataB)
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	if not renderdata.usingRT then SF.Throw("Cannot use this function outside of a rendertarget.", 2) end
 	for i = 0, subrectW*subrectH-1 do
@@ -1280,18 +1279,18 @@ function render_library.drawPixelsSubrectRGB(dstX, dstY, srcX, srcY, srcW, srcH,
 	render.SetViewPort(0, 0, 1024, 1024)
 end
 --- Draws region of RGBA color channel tables to current render target.
--- @param dstX Destination x coordinate
--- @param dstY Destination y coordinate
--- @param srcX Source x coordinate
--- @param srcY Source y coordinate
--- @param srcW Source original width
--- @param srcH Source original height
--- @param subrectW Width of subrect
--- @param subrectH Height of subrect
--- @param dataR Red channel data.
--- @param dataG Green channel data.
--- @param dataB Blue channel data.
--- @param dataA Alpha channel data.
+-- @param number dstX Destination x coordinate
+-- @param number dstY Destination y coordinate
+-- @param number srcX Source x coordinate
+-- @param number srcY Source y coordinate
+-- @param number srcW Source original width
+-- @param number srcH Source original height
+-- @param number subrectW Width of subrect
+-- @param number subrectH Height of subrect
+-- @param table dataR Red channel data.
+-- @param table dataG Green channel data.
+-- @param table dataB Blue channel data.
+-- @param table dataA Alpha channel data.
 function render_library.drawPixelsSubrectRGBA(dstX, dstY, srcX, srcY, srcW, srcH, subrectW, subrectH, dataR, dataG, dataB, dataA) 
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	if not renderdata.usingRT then SF.Throw("Cannot use this function outside of a rendertarget.", 2) end
@@ -1305,25 +1304,25 @@ function render_library.drawPixelsSubrectRGBA(dstX, dstY, srcX, srcY, srcW, srcH
 end
 
 --- Draws a line. Use 3D functions for float coordinates
--- @param x1 X start integer coordinate
--- @param y1 Y start integer coordinate
--- @param x2 X end interger coordinate
--- @param y2 Y end integer coordinate
+-- @param number x1 X start integer coordinate
+-- @param number y1 Y start integer coordinate
+-- @param number x2 X end interger coordinate
+-- @param number y2 Y end integer coordinate
 function render_library.drawLine(x1, y1, x2, y2)
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	surface.DrawLine(x1, y1, x2, y2)
 end
 
 --- Creates a font. Does not require rendering hook
--- @param font Base font to use
--- @param size Font size
--- @param weight Font weight (default: 400)
--- @param antialias Antialias font?
--- @param additive If true, adds brightness to pixels behind it rather than drawing over them.
--- @param shadow Enable drop shadow?
--- @param outline Enable outline?
--- @param blur Enable blur?
--- @param extended Allows the font to display glyphs outside of Latin-1 range. Unicode code points above 0xFFFF are not supported. Required to use FontAwesome
+-- @param string font Base font to use
+-- @param number? size Font size. Default 16
+-- @param number? weight Font weight. Default 400
+-- @param boolean? antialias Antialias font? Default false
+-- @param boolean? additive If true, adds brightness to pixels behind it rather than drawing over them. Default false
+-- @param boolean? shadow Enable drop shadow? Default false
+-- @param boolean? outline Enable outline? Default false
+-- @param boolean? blur Enable blur? Default false
+-- @param boolean? extended Allows the font to display glyphs outside of Latin-1 range. Unicode code points above 0xFFFF are not supported. Required to use FontAwesome
 -- Base font can be one of (keep in mind that these may not exist on all clients if they are not shipped with starfall):
 -- \- Akbar
 -- \- Coolvetica
@@ -1378,9 +1377,9 @@ end
 defaultFont = render_library.createFont("Default", 16, 400, false, false, false, false, 0)
 
 --- Gets the size of the specified text. Don't forget to use setFont before calling this function
--- @param text Text to get the size of
--- @return width of the text
--- @return height of the text
+-- @param string text Text to get the size of
+-- @return number width of the text
+-- @return number height of the text
 function render_library.getTextSize(text)
 	checkluatype (text, TYPE_STRING)
 
@@ -1389,7 +1388,7 @@ function render_library.getTextSize(text)
 end
 
 --- Sets the font
--- @param font The font to use
+-- @param string font The font to use
 -- Use a font created by render.createFont or use one of these already defined fonts:
 -- \- DebugFixed
 -- \- DebugFixedSmall
@@ -1420,16 +1419,16 @@ function render_library.setFont(font)
 end
 
 --- Gets the default font
--- @return Default font
+-- @return string Default font
 function render_library.getDefaultFont()
 	return defaultFont
 end
 
 --- Draws text with newlines and tabs
--- @param x X coordinate
--- @param y Y coordinate
--- @param text Text to draw
--- @param alignment Text alignment
+-- @param number x X coordinate
+-- @param number y Y coordinate
+-- @param string text Text to draw
+-- @param number alignment Text alignment
 function render_library.drawText(x, y, text, alignment)
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	checkluatype (x, TYPE_NUMBER)
@@ -1445,11 +1444,11 @@ function render_library.drawText(x, y, text, alignment)
 end
 
 --- Draws text more easily and quickly but no new lines or tabs.
--- @param x X coordinate
--- @param y Y coordinate
--- @param text Text to draw
--- @param xalign Text x alignment
--- @param yalign Text y alignment
+-- @param number x X coordinate
+-- @param number y Y coordinate
+-- @param string text Text to draw
+-- @param number? xalign Text x alignment
+-- @param number? yalign Text y alignment
 function render_library.drawSimpleText(x, y, text, xalign, yalign)
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	checkluatype (x, TYPE_NUMBER)
@@ -1464,9 +1463,9 @@ function render_library.drawSimpleText(x, y, text, xalign, yalign)
 end
 
 --- Constructs a markup object for quick styled text drawing.
--- @param str The markup string to parse
--- @param maxsize The max width of the markup (default nil)
--- @return The markup object. See https://wiki.facepunch.com/gmod/markup.Parse
+-- @param string str The markup string to parse
+-- @param number? maxsize The max width of the markup. Default nil
+-- @return markup The markup object. See https://wiki.facepunch.com/gmod/markup.Parse
 function render_library.parseMarkup(str, maxsize)
 	checkluatype (str, TYPE_STRING)
 	if maxsize~=nil then checkluatype (maxsize, TYPE_NUMBER) end
@@ -1475,11 +1474,11 @@ function render_library.parseMarkup(str, maxsize)
 end
 
 --- Draw the markup object
--- @param x number The x offset
--- @param y number The x offset
--- @param xalign number The x TEXT_ALIGN (default TEXT_ALIGN.LEFT)
--- @param yalign number The y TEXT_ALIGN (default TEXT_ALIGN.TOP)
--- @param a number The alpha to draw it with. (default 255)
+-- @param number x number The x offset
+-- @param number y number The x offset
+-- @param number? xalign number The x TEXT_ALIGN. Default TEXT_ALIGN.LEFT
+-- @param number? yalign number The y TEXT_ALIGN. Default TEXT_ALIGN.TOP
+-- @param number? alpha The alpha to draw it with. Default 255
 function markup_methods:draw(x, y, xalign, yalign, a)
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	checkluatype(x, TYPE_NUMBER)
@@ -1510,14 +1509,14 @@ function markup_methods:getSize()
 end
 
 --- Draws a polygon.
--- @param poly Table of polygon vertices. Texture coordinates are optional. {{x=x1, y=y1, u=u1, v=v1}, ... }
+-- @param table poly Table of polygon vertices. Texture coordinates are optional. {{x=x1, y=y1, u=u1, v=v1}, ... }
 function render_library.drawPoly(poly)
 	checkluatype (poly, TYPE_TABLE)
 	surface.DrawPoly(poly)
 end
 
 --- Enables or disables Depth Buffer
--- @param enable true to enable
+-- @param boolean enable True to enable
 function render_library.enableDepth(enable)
 	if not renderdata.isRendering then SF.Throw("Not in a rendering hook.", 2) end
 	checkluatype (enable, TYPE_BOOL)
@@ -1525,13 +1524,13 @@ function render_library.enableDepth(enable)
 end
 
 --- Enables blend mode control. Read OpenGL or DirectX docs for more info
--- @param on Whether to control the blend mode of upcoming rendering
--- @param srcBlend Number http://wiki.facepunch.com/gmod/Enums/BLEND
--- @param destBlend Number
--- @param blendFunc Number http://wiki.facepunch.com/gmod/Enums/BLENDFUNC
--- @param srcBlendAlpha Optional Number http://wiki.facepunch.com/gmod/Enums/BLEND
--- @param destBlendAlpha Optional Number
--- @param blendFuncAlpha Optional Number http://wiki.facepunch.com/gmod/Enums/BLENDFUNC
+-- @param boolean on Whether to control the blend mode of upcoming rendering
+-- @param number srcBlend http://wiki.facepunch.com/gmod/Enums/BLEND
+-- @param number destBlend
+-- @param number blendFunc http://wiki.facepunch.com/gmod/Enums/BLENDFUNC
+-- @param number? srcBlendAlpha http://wiki.facepunch.com/gmod/Enums/BLEND
+-- @param number? destBlendAlpha
+-- @param number? blendFuncAlpha http://wiki.facepunch.com/gmod/Enums/BLENDFUNC
 function render_library.overrideBlend(on, srcBlend, destBlend, blendFunc, srcBlendAlpha, destBlendAlpha, blendFuncAlpha)
 	if not renderdata.isRendering then SF.Throw("Not in a rendering hook.", 2) end
 	render.OverrideBlend(on, srcBlend, destBlend, blendFunc, srcBlendAlpha, destBlendAlpha, blendFuncAlpha)
@@ -1546,19 +1545,19 @@ function render_library.clearDepth()
 end
 
 --- Draws a sprite in 3d space.
--- @param pos Position of the sprite.
--- @param width Width of the sprite.
--- @param height Height of the sprite.
+-- @param vector pos Position of the sprite.
+-- @param number width Width of the sprite.
+-- @param number height Height of the sprite.
 function render_library.draw3DSprite(pos, width, height)
 	pos = vunwrap(pos)
 	render.DrawSprite(pos, width, height)
 end
 
 --- Draws a sphere
--- @param pos Position of the sphere
--- @param radius Radius of the sphere
--- @param longitudeSteps The amount of longitude steps. The larger this number is, the smoother the sphere is
--- @param latitudeSteps The amount of latitude steps. The larger this number is, the smoother the sphere is
+-- @param vector pos Position of the sphere
+-- @param number radius Radius of the sphere
+-- @param number longitudeSteps The amount of longitude steps. The larger this number is, the smoother the sphere is
+-- @param number latitudeSteps The amount of latitude steps. The larger this number is, the smoother the sphere is
 function render_library.draw3DSphere(pos, radius, longitudeSteps, latitudeSteps)
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	checkluatype (radius, TYPE_NUMBER)
@@ -1571,10 +1570,10 @@ function render_library.draw3DSphere(pos, radius, longitudeSteps, latitudeSteps)
 end
 
 --- Draws a wireframe sphere
--- @param pos Position of the sphere
--- @param radius Radius of the sphere
--- @param longitudeSteps The amount of longitude steps. The larger this number is, the smoother the sphere is
--- @param latitudeSteps The amount of latitude steps. The larger this number is, the smoother the sphere is
+-- @param vector pos Position of the sphere
+-- @param number radius Radius of the sphere
+-- @param number longitudeSteps The amount of longitude steps. The larger this number is, the smoother the sphere is
+-- @param number latitudeSteps The amount of latitude steps. The larger this number is, the smoother the sphere is
 function render_library.draw3DWireframeSphere(pos, radius, longitudeSteps, latitudeSteps)
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	checkluatype (radius, TYPE_NUMBER)
@@ -1587,8 +1586,8 @@ function render_library.draw3DWireframeSphere(pos, radius, longitudeSteps, latit
 end
 
 --- Draws a 3D Line
--- @param startPos Starting position
--- @param endPos Ending position
+-- @param vector startPos Starting position
+-- @param vector endPos Ending position
 function render_library.draw3DLine(startPos, endPos)
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	startPos = vunwrap(startPos)
@@ -1598,10 +1597,10 @@ function render_library.draw3DLine(startPos, endPos)
 end
 
 --- Draws a box in 3D space
--- @param origin Origin of the box.
--- @param angle Orientation of the box
--- @param mins Start position of the box, relative to origin.
--- @param maxs End position of the box, relative to origin.
+-- @param vector origin Origin of the box.
+-- @param angle angle Orientation of the box
+-- @param vector mins Start position of the box, relative to origin.
+-- @param vector maxs End position of the box, relative to origin.
 function render_library.draw3DBox(origin, angle, mins, maxs)
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	origin = vunwrap(origin)
@@ -1613,10 +1612,10 @@ function render_library.draw3DBox(origin, angle, mins, maxs)
 end
 
 --- Draws a wireframe box in 3D space
--- @param origin Origin of the box.
--- @param angle Orientation of the box
--- @param mins Start position of the box, relative to origin.
--- @param maxs End position of the box, relative to origin.
+-- @param vector origin Origin of the box.
+-- @param angle angle Orientation of the box
+-- @param vector mins Start position of the box, relative to origin.
+-- @param vector maxs End position of the box, relative to origin.
 function render_library.draw3DWireframeBox(origin, angle, mins, maxs)
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	origin = vunwrap(origin)
@@ -1628,11 +1627,11 @@ function render_library.draw3DWireframeBox(origin, angle, mins, maxs)
 end
 
 --- Draws textured beam.
--- @param startPos Beam start position.
--- @param endPos Beam end position.
--- @param width The width of the beam.
--- @param textureStart The start coordinate of the texture used.
--- @param textureEnd The end coordinate of the texture used.
+-- @param vector startPos Beam start position.
+-- @param vector endPos Beam end position.
+-- @param number width The width of the beam.
+-- @param number textureStart The start coordinate of the texture used.
+-- @param number textureEnd The end coordinate of the texture used.
 function render_library.draw3DBeam(startPos, endPos, width, textureStart, textureEnd)
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	checkluatype (width, TYPE_NUMBER)
@@ -1646,10 +1645,10 @@ function render_library.draw3DBeam(startPos, endPos, width, textureStart, textur
 end
 
 --- Draws 2 connected triangles.
--- @param vert1 First vertex.
--- @param vert2 The second vertex.
--- @param vert3 The third vertex.
--- @param vert4 The fourth vertex.
+-- @param vector vert1 First vertex.
+-- @param vector vert2 The second vertex.
+-- @param vector vert3 The third vertex.
+-- @param vector vert4 The fourth vertex.
 function render_library.draw3DQuad(vert1, vert2, vert3, vert4)
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 
@@ -1662,10 +1661,10 @@ function render_library.draw3DQuad(vert1, vert2, vert3, vert4)
 end
 
 --- Draws 2 connected triangles with custom UVs.
--- @param vert1 First vertex. {x, y, z, u, v}
--- @param vert2 The second vertex.
--- @param vert3 The third vertex.
--- @param vert4 The fourth vertex.
+-- @param vector vert1 First vertex. {x, y, z, u, v}
+-- @param vector vert2 The second vertex.
+-- @param vector vert3 The third vertex.
+-- @param vector vert4 The fourth vertex.
 function render_library.draw3DQuadUV(vert1, vert2, vert3, vert4)
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	mesh.Begin(MATERIAL_QUADS, 1)
@@ -1692,10 +1691,10 @@ function render_library.draw3DQuadUV(vert1, vert2, vert3, vert4)
 end
 
 --- Gets a 2D cursor position where ply is aiming at the current rendered screen or nil if they aren't aiming at it.
--- @param ply player to get cursor position from (default: player())
--- @param screen An explicit screen to get the cursor pos of (default: The current rendering screen using 'render' hook)
--- @return x position
--- @return y position
+-- @param player? ply player to get cursor position from. Default player()
+-- @param entity? screen An explicit screen to get the cursor pos of (default: The current rendering screen using 'render' hook)
+-- @return number X position
+-- @return number Y position
 function render_library.cursorPos(ply, screen)
 	if ply~=nil then
 		ply = getent(ply)
@@ -1737,8 +1736,8 @@ end
 
 --- Returns information about the screen, such as world offsets, dimentions, and rotation.
 -- Note: this does a table copy so move it out of your draw hook
--- @param e The screen to get info from.
--- @return A table describing the screen.
+-- @param entity e The screen to get info from.
+-- @return table A table describing the screen.
 function render_library.getScreenInfo(e)
 	local screen = getent(e)
 	if not screen.ScreenInfo then SF.Throw("Invalid screen", 2) end
@@ -1746,7 +1745,7 @@ function render_library.getScreenInfo(e)
 end
 
 --- Returns the entity currently being rendered to
--- @return Entity of the screen or hud being rendered
+-- @return entity Entity of the screen or hud being rendered
 function render_library.getScreenEntity()
 	return ewrap(renderdata.renderEnt)
 end
@@ -1762,9 +1761,9 @@ function render_library.capturePixels()
 end
 
 --- Reads the color of the specified pixel.
--- @param x Pixel x-coordinate.
--- @param y Pixel y-coordinate.
--- @return Color object with ( r, g, b, 255 ) from the specified pixel.
+-- @param number x Pixel x-coordinate.
+-- @param number y Pixel y-coordinate.
+-- @return color Color object with ( r, g, b, 255 ) from the specified pixel.
 function render_library.readPixel(x, y)
 	if not renderdata.isRendering then
 		SF.Throw("Not in rendering hook.", 2)
@@ -1776,8 +1775,8 @@ end
 
 --- Returns the render context's width and height. If a rendertarget is selected, will return 1024, 1024
 -- @class function
--- @return the X size of the current render context
--- @return the Y size of the current render context
+-- @return number the X size of the current render context
+-- @return number the Y size of the current render context
 function render_library.getResolution()
 	if renderdata.renderEnt and renderdata.renderEnt.GetResolution then
 		return renderdata.renderEnt:GetResolution()
@@ -1787,28 +1786,28 @@ end
 
 --- Returns width and height of the game window
 -- @class function
--- @return the X size of the game window
--- @return the Y size of the game window
+-- @return number the X size of the game window
+-- @return number the Y size of the game window
 function render_library.getGameResolution()
 	return renderdata.oldW, renderdata.oldH
 end
 
 --- Does a trace and returns the color of the textel the trace hits.
--- @param vec1 The starting vector
--- @param vec2 The ending vector
--- @return The color
+-- @param vector vec1 The starting vector
+-- @param vector vec2 The ending vector
+-- @return color The color
 function render_library.traceSurfaceColor(vec1, vec2)
-
 	return cwrap(render.GetSurfaceColor(vunwrap(vec1), vunwrap(vec2)):ToColor())
 end
 
 --- Checks if a hud component is connected to the Starfall Chip
+-- @return boolean Whether a hud component is connected to the SF Chip and active
 function render_library.isHUDActive()
 	return SF.IsHUDActive(instance.entity)
 end
 
 --- Renders the scene with the specified viewData to the current active render target.
--- @param tbl view The view data to be used in the rendering. See http://wiki.facepunch.com/gmod/Structures/ViewData. There's an additional key drawviewer used to tell the engine whether the local player model should be rendered.
+-- @param table tbl view The view data to be used in the rendering. See http://wiki.facepunch.com/gmod/Structures/ViewData. There's an additional key drawviewer used to tell the engine whether the local player model should be rendered.
 function render_library.renderView(tbl)
 	checkluatype(tbl, TYPE_TABLE)
 
@@ -1944,18 +1943,20 @@ function render_library.renderView(tbl)
 end
 
 --- Returns whether render.renderView is being executed.
+-- @return boolean Whether render.renderView is being executed
 function render_library.isInRenderView()
 	return renderingView
 end
 
 --- Returns how many render.renderView calls can be done in the current frame.
+-- @return number How many render.renderView calls are left
 function render_library.renderViewsLeft()
 	return cv_max_maxrenderviewsperframe:GetInt() - renderdata.renderedViews
 end
 
 --- Sets the status of the clip renderer, returning previous state.
--- @param state New clipping state.
--- @return Previous clipping state.
+-- @param boolean state New clipping state.
+-- @return boolean Previous clipping state.
 function render_library.enableClipping(state)
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	checkluatype(state, TYPE_BOOL)
@@ -1970,8 +1971,8 @@ function render_library.enableClipping(state)
 end
 
 --- Pushes a new clipping plane of the clip plane stack.
--- @param normal The normal of the clipping plane.
--- @param distance The normal of the clipping plane.
+-- @param vector normal The normal of the clipping plane.
+-- @param number distance The normal of the clipping plane.
 function render_library.pushCustomClipPlane(normal, distance)
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 
@@ -1980,7 +1981,7 @@ function render_library.pushCustomClipPlane(normal, distance)
 	end
 
 	checkluatype(distance, TYPE_NUMBER)
-	
+
 	render.PushCustomClipPlane(vunwrap(normal), distance)
 
 	pushedClippingPlanes = pushedClippingPlanes + 1
@@ -1990,88 +1991,88 @@ end
 function render_library.popCustomClipPlane()
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	if pushedClippingPlanes == 0 then SF.Throw("Popped too many clipping planes.", 2) end
-	
+
 	render.PopCustomClipPlane()
 
 	pushedClippingPlanes = pushedClippingPlanes - 1
 end
 
 --- Calculates the light color of a certain surface
--- @param pos Vector position to sample from
--- @param normal Normal vector of the surface
--- @return Vector representing color of the light
-function render_library.computeLighting(pos, normal) 
+-- @param vector pos Vector position to sample from
+-- @param vector normal Normal vector of the surface
+-- @return vector Vector representing color of the light
+function render_library.computeLighting(pos, normal)
 	return vwrap(render.ComputeLighting(vunwrap(pos), vunwrap(normal)))
 end
 
 --- Calculates the lighting caused by dynamic lights for the specified surface
--- @param pos Vector position to sample from
--- @param normal Normal vector of the surface
--- @return Vector representing color of the light
+-- @param vector pos Vector position to sample from
+-- @param vector normal Normal vector of the surface
+-- @return vector Vector representing color of the light
 function render_library.computeDynamicLighting(pos, normal)
 	return vwrap(render.ComputeDynamicLighting(vunwrap(pos), vunwrap(normal)))
 end
 
 --- Gets the light exposure on the specified position
--- @param pos Vector position to sample from
--- @return Vector representing color of the light
+-- @param vector pos Vector position to sample from
+-- @return vector Vector representing color of the light
 function render_library.getLightColor(pos)
 	return vwrap(render.GetLightColor(vunwrap(pos)))
 end
 
 --- Returns the ambient color of the map
--- @return Vector representing color of the light
+-- @return vector Vector representing color of the light
 function render_library.getAmbientLightColor()
 	return vwrap(render.GetAmbientLightColor())
 end
 
 --- Sets the fog mode. See: https://wiki.facepunch.com/gmod/Enums/MATERIAL_FOG
--- @param mode Fog mode
+-- @param number mode Fog mode
 function render_library.setFogMode(mode)
 	checkpermission(instance, nil, "render.fog")
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	checkluatype(mode, TYPE_NUMBER)
-	
+
 	render.FogMode(mode)
 end
 
 --- Changes color of the fog
--- @param color Color (alpha won't have any effect)
+-- @param color col Color (alpha won't have any effect)
 function render_library.setFogColor(color)
 	checkpermission(instance, nil, "render.fog")
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
-	
+
 	local col = cunwrap(color)
 	render.FogColor(col.r, col.g, col.b)
 end
 
 --- Changes density of the fog
--- @param density Number density between 0 and 1
+-- @param number density Density between 0 and 1
 function render_library.setFogDensity(density)
 	checkpermission(instance, nil, "render.fog")
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	checkluatype(density, TYPE_NUMBER)
-	
+
 	render.FogMaxDensity(density)
 end
 
 --- Sets distance at which the fog will start appearing
--- @param distance Start distance
+-- @param number distance Start distance
 function render_library.setFogStart(distance)
 	checkpermission(instance, nil, "render.fog")
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	checkluatype(distance, TYPE_NUMBER)
-	
+
 	render.FogStart(distance)
 end
 
 --- Sets distance at which the fog will reach it's target density
--- @param distance End distance
+-- @param number distance End distance
 function render_library.setFogEnd(distance)
 	checkpermission(instance, nil, "render.fog")
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	checkluatype(distance, TYPE_NUMBER)
-	
+
 	render.FogEnd(distance)
 end
 
@@ -2086,15 +2087,15 @@ end
 
 
 --- Checks whether the hardware supports HDR
--- @return True if supported
+-- @return boolean True if supported
 render_library.supportsHDR = render.SupportsHDR
 
 --- Checks whether HDR is enabled. Hardware support, map and client settings are all taken into account
--- @return True if available
+-- @return boolean True if available
 render_library.getHDREnabled = render.GetHDREnabled
 
 --- Sets the overlay of the chip to a user's rendertarget
--- @param name The name of the RT to use or nil to set it back to normal
+-- @param string? name The name of the RT to use or nil to set it back to normal
 function render_library.setChipOverlay(name)
 	local rt
 	if name~=nil then
@@ -2106,11 +2107,11 @@ function render_library.setChipOverlay(name)
 end
 
 --- Using the custom screen model, sets the screen offset and size as long as its within bounds of -1024 to 1024 units
--- @param screen The custom screen to be resized
--- @param x The x offset of the screen
--- @param y The y offset of the screen
--- @param w The width of the screen
--- @param h The height of the screen
+-- @param entity screen The custom screen to be resized
+-- @param number x The x offset of the screen
+-- @param number y The y offset of the screen
+-- @param number w The width of the screen
+-- @param number h The height of the screen
 function render_library.setScreenDimensions(screen, x, y, w, h)
 	checkluatype(x, TYPE_NUMBER)
 	checkluatype(y, TYPE_NUMBER)
@@ -2132,9 +2133,9 @@ function render_library.setScreenDimensions(screen, x, y, w, h)
 end
 
 --- Makes the screen shake, client must be connected to a HUD.
--- @param amplitude The strength of the effect
--- @param frequency The frequency of the effect in hertz
--- @param duration The duration of the effect in seconds, max 10.
+-- @param number amplitude The strength of the effect
+-- @param number frequency The frequency of the effect in hertz
+-- @param number duration The duration of the effect in seconds, max 10.
 function render_library.screenShake(amplitude, frequency, duration)
 	checkluatype (amplitude, TYPE_NUMBER)
 	checkluatype (frequency, TYPE_NUMBER)
@@ -2159,8 +2160,8 @@ end
 -- @name hudshoulddraw
 -- @class hook
 -- @client
--- @param string The name of the hud element trying to be drawn
--- @return Return false to not draw the element
+-- @param string str The name of the hud element trying to be drawn
+-- @return boolean Return false to not draw the element
 
 ---Called before drawing HUD (2D Context)
 -- @name predrawhud
@@ -2181,9 +2182,9 @@ end
 -- @name renderscene
 -- @class hook
 -- @client
--- @param origin View origin
--- @param angles View angles
--- @param fov View FOV
+-- @param vector origin View origin
+-- @param angle angles View angles
+-- @param number fov View FOV
 
 --- Called when the player connects to a HUD component linked to the Starfall Chip
 -- @name hudconnected
@@ -2204,39 +2205,39 @@ end
 -- @name predrawopaquerenderables
 -- @class hook
 -- @client
--- @param depth Boolean whether the current draw is writing depth
--- @param skybox Boolean whether the current draw is drawing the skybox
+-- @param boolean depth Whether the current draw is writing depth
+-- @param boolean skybox Whether the current draw is drawing the skybox
 
 --- Called after opaque entities are drawn. (Only works with HUD) (3D context)
 -- @name postdrawopaquerenderables
 -- @class hook
 -- @client
--- @param depth Boolean whether the current draw is writing depth
--- @param skybox Boolean whether the current draw is drawing the skybox
+-- @param boolean depth Whether the current draw is writing depth
+-- @param boolean skybox Whether the current draw is drawing the skybox
 
 --- Called before translucent entities are drawn. (Only works with HUD) (3D context)
 -- @name predrawtranslucentrenderables
 -- @class hook
 -- @client
--- @param depth Boolean whether the current draw is writing depth
--- @param skybox Boolean whether the current draw is drawing the skybox
+-- @param boolean depth Whether the current draw is writing depth
+-- @param boolean skybox Whether the current draw is drawing the skybox
 
 --- Called after translucent entities are drawn. (Only works with HUD) (3D context)
 -- @name postdrawtranslucentrenderables
 -- @class hook
 -- @client
--- @param depth Boolean whether the current draw is writing depth
--- @param skybox Boolean whether the current draw is drawing the skybox
+-- @param boolean depth Whether the current draw is writing depth
+-- @param boolean skybox Whether the current draw is drawing the skybox
 
 --- Called when the engine wants to calculate the player's view. Only works if connected to Starfall HUD
 -- @name calcview
 -- @class hook
 -- @client
--- @param pos Current position of the camera
--- @param ang Current angles of the camera
--- @param fov Current fov of the camera
--- @param znear Current near plane of the camera
--- @param zfar Current far plane of the camera
+-- @param vector pos Current position of the camera
+-- @param angle ang Current angles of the camera
+-- @param number fov Current fov of the camera
+-- @param number znear Current near plane of the camera
+-- @param number zfar Current far plane of the camera
 -- @return table Table containing information for the camera. {origin=camera origin, angles=camera angles, fov=camera fov, znear=znear, zfar=zfar, drawviewer=drawviewer, ortho=ortho table}
 
 --- Called when world fog is drawn.
@@ -2248,13 +2249,13 @@ end
 -- @name setupskyboxfog
 -- @class hook
 -- @client
--- @param scale Skybox scale
+-- @param number scale Skybox scale
 
 --- Called when a player uses the screen
 -- @name starfallUsed
 -- @class hook
--- @param activator Player who used the screen or chip
--- @param used The screen or chip entity that was used
+-- @param player activator Player who used the screen or chip
+-- @param entity used The screen or chip entity that was used
 
 ---
 -- @name render_library.Screen information table

--- a/lua/starfall/libs_cl/socket.lua
+++ b/lua/starfall/libs_cl/socket.lua
@@ -140,6 +140,7 @@ socket.source = socket.choose(sourcet)
 -- @libtbl socket_library
 SF.RegisterLibrary("socket")
 
+-- Socket lib doc sourced from: https://defold.com/ref/stable/socket
 
 return function(instance)
 
@@ -166,15 +167,101 @@ end)
 local socket_proxy = {}
 setmetatable(socket_proxy, { __index = socket })
 
+--- Creates and returns an IPv4 TCP master object.
+-- A master object can be transformed into a server object with the method listen (after a call to bind) or into a client object with the method connect.
+-- The only other method supported by a master object is the close method.
+-- @name socket_library.tcp
+-- @class function
+-- @return table New IPv4 TCP Master Object, or nil if error
+-- @return string? The error message, or nil if no error
 socket_proxy.tcp = create_proxy_function(socket.tcp)
+
+--- Creates and returns an IPv4 TCP master object.
+-- A master object can be transformed into a server object with the method listen (after a call to bind) or into a client object with the method connect.
+-- The only other method supported by a master object is the close method.
+-- @name socket_library.tcp4
+-- @class function
+-- @return table New IPv4 TCP Master Object, or nil if error
+-- @return string? The error message, or nil if no error
 socket_proxy.tcp4 = create_proxy_function(socket.tcp4)
+
+--- Creates and returns an IPv6 TCP master object.
+-- A master object can be transformed into a server object with the method listen (after a call to bind) or into a client object with the method connect.
+-- The only other method supported by a master object is the close method.
+-- Note: The TCP object returned will have the option "ipv6-v6only" set to true.
+-- @name socket_library.tcp6
+-- @class function
+-- @return table New IPv6 TCP Master Object, or nil if error
+-- @return string? The error message, or nil if no error
 socket_proxy.tcp6 = create_proxy_function(socket.tcp6)
+
+-- Creates and returns an unconnected IPv4 UDP object.
+-- Unconnected objects support the sendto, receive, receivefrom, getoption, getsockname, setoption, settimeout, setpeername, setsockname, and close methods.
+-- The setpeername method is used to connect the object.
+-- @name socket_library.udp
+-- @class function
+-- @return table New IPv4 TCP master object, or nil in case of error.
+-- @return string? The error string if errored, else nil
 socket_proxy.udp = create_proxy_function(socket.udp)
+
+-- Creates and returns an unconnected IPv4 UDP object.
+-- Unconnected objects support the sendto, receive, receivefrom, getoption, getsockname, setoption, settimeout, setpeername, setsockname, and close methods.
+-- The setpeername method is used to connect the object.
+-- @name socket_library.udp
+-- @class function
+-- @return table New IPv4 TCP master object, or nil in case of error.
+-- @return string? The error string if errored, else nil
 socket_proxy.udp4 = create_proxy_function(socket.udp4)
+
+-- Creates and returns an unconnected IPv4 UDP object.
+-- Unconnected objects support the sendto, receive, receivefrom, getoption, getsockname, setoption, settimeout, setpeername, setsockname, and close methods.
+-- The setpeername method is used to connect the object.
+-- Note: The UDP object returned will have the option "ipv6-v6only" set to true.
+-- @name socket_library.udp
+-- @class function
+-- @return table New IPv4 TCP master object, or nil in case of error.
+-- @return string? The error string if errored, else nil
 socket_proxy.udp6 = create_proxy_function(socket.udp6)
+
+--- This function is a shortcut that creates and returns a TCP client object connected to a remote address at a given port.
+-- Optionally, the user can also specify the local address and port to bind (locaddr and locport), or restrict the socket family to "inet" or "inet6".
+-- Without specifying family to connect, whether a tcp or tcp6 connection is created depends on your system configuration.
+-- @name socket_library.connect
+-- @class function
+-- @param number addr Address to connect to
+-- @param number port Port to connect to
+-- @param number? laddr Local address to bind to
+-- @param number? lport Local port to bind to
+-- @param string? family Socket family, either "inet" or "inet6".
+-- @return table client TCPClient object. Nil if error
+-- @return string? error Error string if the previous return was nil, else nil
 socket_proxy.connect = create_proxy_function(socket.connect)
+
+--- This function is a shortcut that creates and returns a TCP client object connected to a remote address at a given port.
+-- Optionally, the user can also specify the local address and port to bind (locaddr and locport)
+-- @name socket_library.connect4
+-- @class function
+-- @param number addr Address to connect to
+-- @param number port Port to connect to
+-- @param number? laddr Local address to bind to
+-- @param number? lport Local port to bind to
+-- @return table client TCPClient object. Nil if error
+-- @return string? error Error string if the previous return was nil, else nil
 socket_proxy.connect4 = create_proxy_function(socket.connect4)
+
+--- This function is a shortcut that creates and returns a TCP client object connected to a remote address at a given port.
+-- Optionally, the user can also specify the local address and port to bind (locaddr and locport)
+-- @name socket_library.connect6
+-- @class function
+-- @param number addr Address to connect to
+-- @param number port Port to connect to
+-- @param number? laddr Local address to bind to
+-- @param number? lport Local port to bind to
+-- @return table client TCPClient object. Nil if error
+-- @return string? error Error string if the previous return was nil, else nil
 socket_proxy.connect6 = create_proxy_function(socket.connect6)
+
+-- TODO: Docs for this. is this supposed to be the raw metamethod?
 socket_proxy.bind = create_proxy_function(socket.bind)
 
 instance.env.socket = socket_proxy

--- a/lua/starfall/libs_cl/sql.lua
+++ b/lua/starfall/libs_cl/sql.lua
@@ -15,8 +15,8 @@ local checkpermission = instance.player ~= SF.Superuser and SF.Permissions.check
 local sql_library = instance.Libraries.sql
 
 --- Performs a query on the local SQLite database.
--- @param query The query to execute.
--- @return Query results as a table, nil if the query returned no data.
+-- @param string query The query to execute.
+-- @return table? Query results as a table, nil if the query returned no data.
 function sql_library.query(query)
 	checkpermission(instance, nil, "sql")
 	checkluatype(query, TYPE_STRING)
@@ -30,8 +30,8 @@ function sql_library.query(query)
 end
 
 --- Checks if a table exists within the local SQLite database.
--- @param tabname The table to check for.
--- @return False if the table does not exist, true if it does.
+-- @param string tabname The table to check for.
+-- @return boolean False if the table does not exist, true if it does.
 function sql_library.tableExists(tabname)
 	checkpermission(instance, nil, "sql")
 	checkluatype(tabname, TYPE_STRING)
@@ -40,8 +40,8 @@ function sql_library.tableExists(tabname)
 end
 
 --- Removes a table within the local SQLite database.
--- @param tabname The table to remove.
--- @return True if the table was successfully removed, false if not.
+-- @param string tabname The table to remove.
+-- @return boolean True if the table was successfully removed, false if not.
 function sql_library.tableRemove(tabname)
 	checkpermission(instance, nil, "sql")
 	checkluatype(tabname, TYPE_STRING)
@@ -52,9 +52,9 @@ function sql_library.tableRemove(tabname)
 end
 
 --- Escapes dangerous characters and symbols from user input used in an SQLite SQL Query.
--- @param str The string to be escaped.
--- @param bNoQuotes Set this as true, and the function will not wrap the input string in apostrophes.
--- @return The escaped input.
+-- @param string str The string to be escaped.
+-- @param boolean bNoQuotes Set this as true, and the function will not wrap the input string in apostrophes.
+-- @return string The escaped input.
 function sql_library.SQLStr(str, bNoQuotes)
 	checkpermission(instance, nil, "sql")
 	checkluatype(str, TYPE_STRING)

--- a/lua/starfall/libs_cl/xinput.lua
+++ b/lua/starfall/libs_cl/xinput.lua
@@ -39,51 +39,52 @@ local xinput_library = instance.Libraries.xinput
 --- Gets the state of the controller.
 -- @name xinput_library.getState
 -- @class function
--- @param id Controller number. Starts at 0
--- @return Table containing all input data of the controller, or false if the controller is not connected. The table uses this struct: https://github.com/mitterdoo/garrysmod-xinput#xinput_gamepad
+-- @param number id Controller number. Starts at 0
+-- @return table Table containing all input data of the controller, or false if the controller is not connected. The table uses this struct: https://github.com/mitterdoo/garrysmod-xinput#xinput_gamepad
 xinput_library.getState = xinput.getState
 
 --- Gets whether the button on the controller is currently pushed down.
 -- @name xinput_library.getButton
 -- @class function
--- @param id Controller number. Starts at 0
--- @param button The button to check for. See https://github.com/mitterdoo/garrysmod-xinput#xinput_gamepad_
--- @return bool
+-- @param number id Controller number. Starts at 0
+-- @param number button The button to check for. See https://github.com/mitterdoo/garrysmod-xinput#xinput_gamepad_
+-- @return boolean
 xinput_library.getButton = xinput.getButton
 
 --- Gets the current position of the trigger on the controller.
 -- @name xinput_library.getTrigger
 -- @class function
--- @param id Controller number. Starts at 0
--- @param trigger Which trigger to use. 0 is left
--- @return 0-255 inclusive
+-- @param number id Controller number. Starts at 0
+-- @param number trigger Which trigger to use. 0 is left
+-- @return number 0-255 inclusive
 xinput_library.getTrigger = xinput.getTrigger
 
 --- Gets the current coordinates of the stick on the controller.
 -- @name xinput_library.getStick
 -- @class function
--- @param id Controller number. Starts at 0
--- @param stick Which stick to use. 0 is left
--- @return Two numbers for the X and Y coordinates, respectively, each being between -32768 - 32767 inclusive
+-- @param number id Controller number. Starts at 0
+-- @param number stick Which stick to use. 0 is left
+-- @return number X Coordinate, Between -32768 - 32767 inclusive
+-- @return number Y Coordinate, Between -32768 - 32767 inclusive
 xinput_library.getStick = xinput.getStick
 
 --- Attempts to check the battery level of the controller.
 -- @name xinput_library.getBatteryLevel
 -- @class function
--- @param id Controller number. Starts at 0
--- @return If successful: a number between 0.0-1.0 inclusive. If unsuccessful: false, and a string error message
+-- @param number id Controller number. Starts at 0
+-- @return any If successful: a number between 0.0-1.0 inclusive. If unsuccessful: false, and a string error message
 xinput_library.getBatteryLevel = xinput.getBatteryLevel
 
 --- Gets all of the connected controllers.
 -- @name xinput_library.getControllers
 -- @class function
--- @return A table where each key is the ID of the controller that is connected. Disconnected controllers are not placed in the table.
+-- @return table A table where each key is the ID of the controller that is connected. Disconnected controllers are not placed in the table.
 xinput_library.getControllers = xinput.getControllers
 
 --- Sets the rumble on the controller.
--- @param id Controller number. Starts at 0
--- @param softPercent A number between 0.0-1.0 for how much the soft rumble motor should vibrate.
--- @param hardPercent A number between 0.0-1.0 for how much the hard rumble motor should vibrate.
+-- @param number id Controller number. Starts at 0
+-- @param number softPercent A number between 0.0-1.0 for how much the soft rumble motor should vibrate.
+-- @param number hardPercent A number between 0.0-1.0 for how much the hard rumble motor should vibrate.
 function xinput_library.setRumble(id, softPercent, hardPercent)
 	-- This longer function makes sure that the rumble doesn't continue when the instance is gone.
 	checkluatype(id, TYPE_NUMBER)
@@ -99,47 +100,47 @@ end
 -- @client
 -- @name xinputConnected
 -- @class hook
--- @param id Controller number. Starts at 0
--- @param when The timer.realtime() at which this event occurred.
+-- @param number id Controller number. Starts at 0
+-- @param number when The timer.realtime() at which this event occurred.
 
 --- Called when a controller has been disconnected. Client must have XInput Lua binary installed.
 -- @client
 -- @name xinputDisconnected
 -- @class hook
--- @param id Controller number. Starts at 0
--- @param when The timer.realtime() at which this event occurred.
+-- @param number id Controller number. Starts at 0
+-- @param number when The timer.realtime() at which this event occurred.
 
 --- Called when a controller button has been pressed. Client must have XInput Lua binary installed.
 -- @client
 -- @name xinputPressed
 -- @class hook
--- @param id Controller number. Starts at 0
--- @param button The button that was pushed. See https://github.com/mitterdoo/garrysmod-xinput#xinput_gamepad_
--- @param when The timer.realtime() at which this event occurred.
+-- @param number id Controller number. Starts at 0
+-- @param number button The button that was pushed. See https://github.com/mitterdoo/garrysmod-xinput#xinput_gamepad_
+-- @param number when The timer.realtime() at which this event occurred.
 
 --- Called when a controller button has been released. Client must have XInput Lua binary installed.
 -- @client
 -- @name xinputReleased
 -- @class hook
--- @param id Controller number. Starts at 0
--- @param button The button that was released. See https://github.com/mitterdoo/garrysmod-xinput#xinput_gamepad_
--- @param when The timer.realtime() at which this event occurred.
+-- @param number id Controller number. Starts at 0
+-- @param number button The button that was released. See https://github.com/mitterdoo/garrysmod-xinput#xinput_gamepad_
+-- @param number when The timer.realtime() at which this event occurred.
 
 --- Called when a trigger on the controller has moved. Client must have XInput Lua binary installed.
 -- @client
 -- @name xinputTrigger
 -- @class hook
--- @param id Controller number. Starts at 0
--- @param value The position of the trigger. 0-255 inclusive
--- @param trigger The trigger that was moved. 0 is left
--- @param when The timer.realtime() at which this event occurred.
+-- @param number id Controller number. Starts at 0
+-- @param number value The position of the trigger. 0-255 inclusive
+-- @param number trigger The trigger that was moved. 0 is left
+-- @param number when The timer.realtime() at which this event occurred.
 
 --- Called when a stick on the controller has moved. Client must have XInput Lua binary installed.
 -- @client
 -- @name xinputStick
 -- @class hook
--- @param id Controller number. Starts at 0
--- @param x The X coordinate of the trigger. -32768 - 32767 inclusive
--- @param y The Y coordinate of the trigger. -32768 - 32767 inclusive
--- @param stick The stick that was moved. 0 is left
--- @param when The timer.realtime() at which this event occurred.
+-- @param number id Controller number. Starts at 0
+-- @param number x The X coordinate of the trigger. -32768 - 32767 inclusive
+-- @param number y The Y coordinate of the trigger. -32768 - 32767 inclusive
+-- @param number stick The stick that was moved. 0 is left
+-- @param number when The timer.realtime() at which this event occurred.

--- a/lua/starfall/libs_cl/xinput.lua
+++ b/lua/starfall/libs_cl/xinput.lua
@@ -72,7 +72,8 @@ xinput_library.getStick = xinput.getStick
 -- @name xinput_library.getBatteryLevel
 -- @class function
 -- @param number id Controller number. Starts at 0
--- @return any If successful: a number between 0.0-1.0 inclusive. If unsuccessful: false, and a string error message
+-- @return number|boolean If successful: a number between 0.0-1.0 inclusive.
+-- @return string? If last return was a false boolean (errored), this will be the error message.
 xinput_library.getBatteryLevel = xinput.getBatteryLevel
 
 --- Gets all of the connected controllers.

--- a/lua/starfall/libs_sh/angles.lua
+++ b/lua/starfall/libs_sh/angles.lua
@@ -30,10 +30,10 @@ end
 --- Creates an Angle struct.
 -- @name builtins_library.Angle
 -- @class function
--- @param p - Pitch
--- @param y - Yaw
--- @param r - Roll
--- @return Angle
+-- @param number p Pitch
+-- @param number y Yaw
+-- @param number r Roll
+-- @return angle Angle struct
 instance.env.Angle = function (p, y, r)
 	if p~=nil then checkluatype(p, TYPE_NUMBER) else p = 0 end
 	if y~=nil then checkluatype(y, TYPE_NUMBER) else y = p end
@@ -46,7 +46,10 @@ end
 -- String based indexing returns string, just a pass through.
 local pyr = { p = 1, y = 2, r = 3, pitch = 1, yaw = 2, roll = 3 }
 
---- __newindex metamethod
+--- Sets a value at a key in the angle
+-- @param angle Ang
+-- @param any Key
+-- @param number Value
 function ang_meta.__newindex(t, k, v)
 	if pyr[k] then
 		rawset(t, pyr[k], v)
@@ -55,8 +58,11 @@ function ang_meta.__newindex(t, k, v)
 	end
 end
 
---- __index metamethod
+--- Gets a value at a key in the color
 -- Can be indexed with: 1, 2, 3, p, y, r, pitch, yaw, roll. 1,2,3 is most efficient.
+-- @param angle Ang
+-- @param any Key
+-- @return number Value
 function ang_meta.__index(t, k)
 	local method = ang_methods[k]
 	if method then
@@ -68,15 +74,16 @@ end
 
 local table_concat = table.concat
 
---- tostring metamethod
--- @return string representing the angle.
+--- Turns an angle into a string.
+-- @return string String representing the angle.
 function ang_meta.__tostring(a)
 	return table_concat(a, ' ', 1, 3)
 end
 
---- __mul metamethod ang1 * b or ang1 * ang2.
--- @param b Number or Angle to multiply by.
--- @return resultant angle.
+--- Multiplication metamethod
+-- @param any a1 Number or Angle multiplicand.
+-- @param any a2 Number or Angle multiplier.
+-- @return angle Resultant angle.
 function ang_meta.__mul(a, b)
 	if isnumber(b) then
 		return wrap({ a[1] * b, a[2] * b, a[3] * b })
@@ -91,9 +98,10 @@ function ang_meta.__mul(a, b)
 	end
 end
 
---- __div metamethod ang1 / b or ang1 / ang2.
--- @param b Number or Angle to divided by.
--- @return resultant angle.
+--- Division metamethod
+-- @param any a1 Number or Angle dividend.
+-- @param any a2 Number or Angle divisor.
+-- @return angle Resultant angle.
 function ang_meta.__div(a, b)
 	if isnumber(b) then
 		return wrap({ a[1] / b, a[2] / b, a[3] / b })
@@ -108,64 +116,65 @@ function ang_meta.__div(a, b)
 	end
 end
 
---- __unm metamethod -ang.
--- @return resultant angle.
+--- Unary Minus metamethod (Negative)
+-- @return angle Negative angle.
 function ang_meta.__unm(a)
 	return wrap({ -a[1], -a[2], -a[3] })
 end
 
---- __eq metamethod ang1 == ang2.
--- @param a Angle to check against.
--- @return bool
+--- Equivalence metamethod
+-- @param angle a1 Initial angle.
+-- @param angle a2 Angle to check against.
+-- @return boolean Whether their fields are equal
 function ang_meta.__eq(a, b)
 	return a[1]==b[1] and a[2]==b[2] and a[3]==b[3]
 end
 
---- __add metamethod ang1 + ang2.
--- @param a Angle to add.
--- @return resultant angle.
+--- Addition metamethod
+-- @param angle a1 Initial angle.
+-- @param angle a2 Angle to add to the first.
+-- @return angle Resultant angle.
 function ang_meta.__add(a, b)
-
 	return wrap({ a[1] + b[1], a[2] + b[2], a[3] + b[3] })
 end
 
---- __sub metamethod ang1 - ang2.
--- @param a Angle to subtract.
--- @return resultant angle.
+--- Subtraction metamethod
+-- @param angle a1 Initial angle.
+-- @param angle a2 Angle to subtract.
+-- @return angle Resultant angle.
 function ang_meta.__sub(a, b)
-
 	return wrap({ a[1]-b[1], a[2]-b[2], a[3]-b[3] })
 end
 
 --- Returns if p,y,r are all 0.
--- @return boolean
+-- @return boolean If they are all zero
 function ang_methods:isZero()
 	return self[1]==0 and self[2]==0 and self[3]==0
 end
 
 --- Return the Forward Vector ( direction the angle points ).
--- @return vector normalised.
+-- @return vector Forward direction.
 function ang_methods:getForward()
 	return vwrap(unwrap(self):Forward())
 end
 
 --- Return the Right Vector relative to the angle dir.
--- @return vector normalised.
+-- @return vector Right direction.
 function ang_methods:getRight()
 	return vwrap(unwrap(self):Right())
 end
 
 --- Return the Up Vector relative to the angle dir.
--- @return vector normalised.
+-- @return vector Up direction.
 function ang_methods:getUp()
 	return vwrap(unwrap(self):Up())
 end
 
 --- Return Rotated angle around the specified axis.
--- @param v Vector axis
--- @param deg Number of degrees or nil if radians.
--- @param rad Number of radians or nil if degrees.
--- @return The modified angle
+-- @param vector v Vector axis
+-- @param number? deg Number of degrees or nil if radians.
+-- @param number? rad Number of radians or nil if degrees.
+-- @return angle The modified angle
 function ang_methods:rotateAroundAxis(v, deg, rad)
 
 	if rad then
@@ -183,9 +192,9 @@ function ang_methods:rotateAroundAxis(v, deg, rad)
 	return awrap(ret)
 end
 
---- Round the angle values. Self-Modifies.
--- @param idp (Default 0) The integer decimal place to round to. 
--- @return nil
+--- Round the angle values.
+-- Self-Modifies. Does not return anything
+-- @param number? idp (Default 0) The integer decimal place to round to.
 function ang_methods:round(idp)
 	self[1] = math.Round(self[1], idp)
 	self[2] = math.Round(self[2], idp)
@@ -199,8 +208,8 @@ function ang_methods:clone()
 end
 
 --- Copies p,y,r from angle to another.
+-- Self-Modifies. Does not return anything
 -- @param b The angle to copy from.
--- @return nil
 function ang_methods:set(b)
 	self[1] = b[1]
 	self[2] = b[2]
@@ -208,32 +217,32 @@ function ang_methods:set(b)
 end
 
 --- Sets p,y,r to 0. This is faster than doing it manually.
--- @return nil
+-- Self-Modifies. Does not return anything
 function ang_methods:setZero()
 	self[1] = 0
 	self[2] = 0
 	self[3] = 0
 end
 
---- Set's the angle's pitch and returns it.
--- @param p The pitch
--- @return The modified angle
+--- Set's the angle's pitch and returns self.
+-- @param number p The pitch
+-- @return angle Angle after modification
 function ang_methods:setP(p)
 	self[1] = p
 	return self
 end
 
---- Set's the angle's yaw and returns it.
--- @param y The yaw
--- @return The modified angle
+--- Set's the angle's yaw and returns self.
+-- @param number y The yaw
+-- @return angle Angle after modification
 function ang_methods:setY(y)
 	self[2] = y
 	return self
 end
 
---- Set's the angle's roll and returns it.
--- @param r The roll
--- @return The modified angle
+--- Set's the angle's roll and returns self.
+-- @param number r The roll
+-- @return angle Angle after modification
 function ang_methods:setR(r)
 	self[3] = r
 	return self

--- a/lua/starfall/libs_sh/angles.lua
+++ b/lua/starfall/libs_sh/angles.lua
@@ -202,14 +202,14 @@ function ang_methods:round(idp)
 end
 
 --- Copies p,y,r from angle and returns a new angle
--- @return The copy of the angle
+-- @return Angle The copy of the angle
 function ang_methods:clone()
 	return wrap({ self[1], self[2], self[3] })
 end
 
 --- Copies p,y,r from angle to another.
 -- Self-Modifies. Does not return anything
--- @param b The angle to copy from.
+-- @param Angle b The angle to copy from.
 function ang_methods:set(b)
 	self[1] = b[1]
 	self[2] = b[2]

--- a/lua/starfall/libs_sh/angles.lua
+++ b/lua/starfall/libs_sh/angles.lua
@@ -33,7 +33,7 @@ end
 -- @param number p Pitch
 -- @param number y Yaw
 -- @param number r Roll
--- @return angle Angle struct
+-- @return Angle Angle struct
 instance.env.Angle = function (p, y, r)
 	if p~=nil then checkluatype(p, TYPE_NUMBER) else p = 0 end
 	if y~=nil then checkluatype(y, TYPE_NUMBER) else y = p end
@@ -47,7 +47,7 @@ end
 local pyr = { p = 1, y = 2, r = 3, pitch = 1, yaw = 2, roll = 3 }
 
 --- Sets a value at a key in the angle
--- @param angle Ang
+-- @param Angle Ang
 -- @param any Key
 -- @param number Value
 function ang_meta.__newindex(t, k, v)
@@ -60,7 +60,7 @@ end
 
 --- Gets a value at a key in the color
 -- Can be indexed with: 1, 2, 3, p, y, r, pitch, yaw, roll. 1,2,3 is most efficient.
--- @param angle Ang
+-- @param Angle Ang
 -- @param any Key
 -- @return number Value
 function ang_meta.__index(t, k)
@@ -83,7 +83,7 @@ end
 --- Multiplication metamethod
 -- @param any a1 Number or Angle multiplicand.
 -- @param any a2 Number or Angle multiplier.
--- @return angle Resultant angle.
+-- @return Angle Resultant angle.
 function ang_meta.__mul(a, b)
 	if isnumber(b) then
 		return wrap({ a[1] * b, a[2] * b, a[3] * b })
@@ -101,7 +101,7 @@ end
 --- Division metamethod
 -- @param any a1 Number or Angle dividend.
 -- @param any a2 Number or Angle divisor.
--- @return angle Resultant angle.
+-- @return Angle Resultant angle.
 function ang_meta.__div(a, b)
 	if isnumber(b) then
 		return wrap({ a[1] / b, a[2] / b, a[3] / b })
@@ -117,31 +117,31 @@ function ang_meta.__div(a, b)
 end
 
 --- Unary Minus metamethod (Negative)
--- @return angle Negative angle.
+-- @return Angle Negative angle.
 function ang_meta.__unm(a)
 	return wrap({ -a[1], -a[2], -a[3] })
 end
 
 --- Equivalence metamethod
--- @param angle a1 Initial angle.
--- @param angle a2 Angle to check against.
+-- @param Angle a1 Initial angle.
+-- @param Angle a2 Angle to check against.
 -- @return boolean Whether their fields are equal
 function ang_meta.__eq(a, b)
 	return a[1]==b[1] and a[2]==b[2] and a[3]==b[3]
 end
 
 --- Addition metamethod
--- @param angle a1 Initial angle.
--- @param angle a2 Angle to add to the first.
--- @return angle Resultant angle.
+-- @param Angle a1 Initial angle.
+-- @param Angle a2 Angle to add to the first.
+-- @return Angle Resultant angle.
 function ang_meta.__add(a, b)
 	return wrap({ a[1] + b[1], a[2] + b[2], a[3] + b[3] })
 end
 
 --- Subtraction metamethod
--- @param angle a1 Initial angle.
--- @param angle a2 Angle to subtract.
--- @return angle Resultant angle.
+-- @param Angle a1 Initial angle.
+-- @param Angle a2 Angle to subtract.
+-- @return Angle Resultant angle.
 function ang_meta.__sub(a, b)
 	return wrap({ a[1]-b[1], a[2]-b[2], a[3]-b[3] })
 end
@@ -153,28 +153,28 @@ function ang_methods:isZero()
 end
 
 --- Return the Forward Vector ( direction the angle points ).
--- @return vector Forward direction.
+-- @return Vector Forward direction.
 function ang_methods:getForward()
 	return vwrap(unwrap(self):Forward())
 end
 
 --- Return the Right Vector relative to the angle dir.
--- @return vector Right direction.
+-- @return Vector Right direction.
 function ang_methods:getRight()
 	return vwrap(unwrap(self):Right())
 end
 
 --- Return the Up Vector relative to the angle dir.
--- @return vector Up direction.
+-- @return Vector Up direction.
 function ang_methods:getUp()
 	return vwrap(unwrap(self):Up())
 end
 
 --- Return Rotated angle around the specified axis.
--- @param vector v Vector axis
+-- @param Vector v Vector axis
 -- @param number? deg Number of degrees or nil if radians.
 -- @param number? rad Number of radians or nil if degrees.
--- @return angle The modified angle
+-- @return Angle The modified angle
 function ang_methods:rotateAroundAxis(v, deg, rad)
 
 	if rad then
@@ -226,7 +226,7 @@ end
 
 --- Set's the angle's pitch and returns self.
 -- @param number p The pitch
--- @return angle Angle after modification
+-- @return Angle Angle after modification
 function ang_methods:setP(p)
 	self[1] = p
 	return self
@@ -234,7 +234,7 @@ end
 
 --- Set's the angle's yaw and returns self.
 -- @param number y The yaw
--- @return angle Angle after modification
+-- @return Angle Angle after modification
 function ang_methods:setY(y)
 	self[2] = y
 	return self
@@ -242,7 +242,7 @@ end
 
 --- Set's the angle's roll and returns self.
 -- @param number r The roll
--- @return angle Angle after modification
+-- @return Angle Angle after modification
 function ang_methods:setR(r)
 	self[3] = r
 	return self

--- a/lua/starfall/libs_sh/angles.lua
+++ b/lua/starfall/libs_sh/angles.lua
@@ -48,7 +48,7 @@ local pyr = { p = 1, y = 2, r = 3, pitch = 1, yaw = 2, roll = 3 }
 
 --- Sets a value at a key in the angle
 -- @param Angle Ang
--- @param any Key
+-- @param number|string Key
 -- @param number Value
 function ang_meta.__newindex(t, k, v)
 	if pyr[k] then
@@ -61,7 +61,7 @@ end
 --- Gets a value at a key in the color
 -- Can be indexed with: 1, 2, 3, p, y, r, pitch, yaw, roll. 1,2,3 is most efficient.
 -- @param Angle Ang
--- @param any Key
+-- @param number|string Key
 -- @return number Value
 function ang_meta.__index(t, k)
 	local method = ang_methods[k]
@@ -81,8 +81,8 @@ function ang_meta.__tostring(a)
 end
 
 --- Multiplication metamethod
--- @param any a1 Number or Angle multiplicand.
--- @param any a2 Number or Angle multiplier.
+-- @param number|Angle a1 Number or Angle multiplicand.
+-- @param number|Angle a2 Number or Angle multiplier.
 -- @return Angle Resultant angle.
 function ang_meta.__mul(a, b)
 	if isnumber(b) then
@@ -99,8 +99,8 @@ function ang_meta.__mul(a, b)
 end
 
 --- Division metamethod
--- @param any a1 Number or Angle dividend.
--- @param any a2 Number or Angle divisor.
+-- @param number|Angle a1 Number or Angle dividend.
+-- @param number|Angle a2 Number or Angle divisor.
 -- @return Angle Resultant angle.
 function ang_meta.__div(a, b)
 	if isnumber(b) then

--- a/lua/starfall/libs_sh/bit.lua
+++ b/lua/starfall/libs_sh/bit.lua
@@ -604,7 +604,7 @@ bit_library.tohex = bit.tohex
 -- @param string stream String to set the initial buffer to (default "")
 -- @param number i The initial buffer pointer (default 1)
 -- @param string endian The endianness of number types. "big" or "little" (default "little")
--- @return stringstream StringStream object
+-- @return StringStream StringStream object
 bit_library.stringstream = SF.StringStream
 
 --- Converts a table to string serializing data types as best as it can

--- a/lua/starfall/libs_sh/bit.lua
+++ b/lua/starfall/libs_sh/bit.lua
@@ -526,7 +526,7 @@ bit_library.arshift = bit.arshift
 --- Performs the bitwise "and" for all values specified.
 -- @class function
 -- @param number value The value to be manipulated.
--- @param number otherValues Values bit to perform bitwise "and" with. Optional.
+-- @param ...number otherValues Values bit to perform bitwise "and" with. Optional.
 -- @return number Result of bitwise "and" operation.
 bit_library.band = bit.band
 
@@ -593,7 +593,7 @@ bit_library.tobit = bit.tobit
 --- Returns the hexadecimal representation of the number with the specified digits.
 -- @class function
 -- @param number value The value to be normalized.
--- @param number digits The number of digits. Optional. (default 8)
+-- @param number? digits The number of digits. Optional. (default 8)
 -- @return string Hex string.
 bit_library.tohex = bit.tohex
 

--- a/lua/starfall/libs_sh/bit.lua
+++ b/lua/starfall/libs_sh/bit.lua
@@ -177,7 +177,7 @@ local function UnpackIEEE754Double(b8, b7, b6, b5, b4, b3, b2, b1)
 end
 
 --- Sets the endianness of the string stream
---@param endian The endianness of number types. "big" or "little" (default "little")
+-- @param string endian The endianness of number types. "big" or "little" (default "little")
 function ss_methods:setEndian(endian)
 	if endian == "little" then
 		debug.setmetatable(self, ss_meta)
@@ -189,7 +189,7 @@ function ss_methods:setEndian(endian)
 end
 
 --- Writes the given string and advances the buffer pointer.
---@param data A string of data to write
+-- @param string data A string of data to write
 function ss_methods:write(data)
 	if self.index > #self then -- Most often case
 		self[self.index] = data
@@ -222,8 +222,8 @@ function ss_methods:write(data)
 end
 
 --- Reads the specified number of bytes from the buffer and advances the buffer pointer.
---@param length How many bytes to read
---@return A string containing the bytes
+-- @param number length How many bytes to read
+-- @return string A string containing the bytes
 function ss_methods:read(length)
 	local ret = {}
 	while length > 0 do
@@ -251,8 +251,8 @@ function ss_methods:read(length)
 	return table.concat(ret)
 end
 
---- Sets internal pointer to i. The position will be clamped to [1, buffersize+1]
---@param i The position
+--- Sets internal pointer to pos. The position will be clamped to [1, buffersize+1]
+-- @param number pos Position to seek to
 function ss_methods:seek(pos)
 	if pos < 1 then error("Index must be 1 or greater", 2) end
 	self.index = #self+1
@@ -270,7 +270,7 @@ function ss_methods:seek(pos)
 end
 
 --- Move the internal pointer by amount i
---@param length The offset
+-- @param number length The offset
 function ss_methods:skip(length)
 	while length>0 do
 		local cur = self[self.index]
@@ -307,7 +307,7 @@ function ss_methods:skip(length)
 end
 
 --- Returns the internal position of the byte reader.
---@return The buffer position
+-- @return number The buffer position
 function ss_methods:tell()
 	local length = 0
 	for i=1, self.index-1 do
@@ -317,7 +317,7 @@ function ss_methods:tell()
 end
 
 --- Tells the size of the byte stream.
---@return The buffer size
+-- @return number The buffer size
 function ss_methods:size()
 	local length = 0
 	for i, v in ipairs(self) do
@@ -327,7 +327,7 @@ function ss_methods:size()
 end
 
 --- Reads an unsigned 8-bit (one byte) integer from the byte stream and advances the buffer pointer.
---@return The uint8 at this position
+-- @return number UInt8 at this position
 function ss_methods:readUInt8()
 	return string.byte(self:read(1))
 end
@@ -336,7 +336,7 @@ function ss_methods_big:readUInt8()
 end
 
 --- Reads an unsigned 16 bit (two byte) integer from the byte stream and advances the buffer pointer.
---@return The uint16 at this position
+-- @return number UInt16 at this position
 function ss_methods:readUInt16()
 	local a,b = string.byte(self:read(2), 1, 2)
 	return b * 0x100 + a
@@ -347,7 +347,7 @@ function ss_methods_big:readUInt16()
 end
 
 --- Reads an unsigned 32 bit (four byte) integer from the byte stream and advances the buffer pointer.
---@return The uint32 at this position
+-- @return number UInt32 at this position
 function ss_methods:readUInt32()
 	local a,b,c,d = string.byte(self:read(4), 1, 4)
 	return d * 0x1000000 + c * 0x10000 + b * 0x100 + a
@@ -358,7 +358,7 @@ function ss_methods_big:readUInt32()
 end
 
 --- Reads a signed 8-bit (one byte) integer from the byte stream and advances the buffer pointer.
---@return The int8 at this position
+-- @return number Int8 at this position
 function ss_methods:readInt8()
 	local x = self:readUInt8()
 	if x>=0x80 then x = x - 0x100 end
@@ -366,7 +366,7 @@ function ss_methods:readInt8()
 end
 
 --- Reads a signed 16-bit (two byte) integer from the byte stream and advances the buffer pointer.
---@return The int16 at this position
+-- @return number Int16 at this position
 function ss_methods:readInt16()
 	local x = self:readUInt16()
 	if x>=0x8000 then x = x - 0x10000 end
@@ -374,7 +374,7 @@ function ss_methods:readInt16()
 end
 
 --- Reads a signed 32-bit (four byte) integer from the byte stream and advances the buffer pointer.
---@return The int32 at this position
+-- @return number Int32 at this position
 function ss_methods:readInt32()
 	local x = self:readUInt32()
 	if x>=0x80000000 then x = x - 0x100000000 end
@@ -382,7 +382,7 @@ function ss_methods:readInt32()
 end
 
 --- Reads a 4 byte IEEE754 float from the byte stream and advances the buffer pointer.
---@return The float32 at this position
+-- @return number Float32 at this position
 function ss_methods:readFloat()
 	return UnpackIEEE754Float(string.byte(self:read(4), 1, 4))
 end
@@ -392,7 +392,7 @@ function ss_methods_big:readFloat()
 end
 
 --- Reads a 8 byte IEEE754 double from the byte stream and advances the buffer pointer.
---@return The double at this position
+-- @return number Double at this position
 function ss_methods:readDouble()
 	return UnpackIEEE754Double(string.byte(self:read(8), 1, 8))
 end
@@ -402,8 +402,8 @@ function ss_methods_big:readDouble()
 end
 
 --- Reads until the given byte and advances the buffer pointer.
---@param byte The byte to read until (in number form)
---@return The string of bytes read
+-- @param number byte The byte to read until (in number form)
+-- @return string The string of bytes read
 function ss_methods:readUntil(byte)
 	byte = string.char(byte)
 	local ret = {}
@@ -431,15 +431,15 @@ function ss_methods:readUntil(byte)
 	return table.concat(ret)
 end
 
---- returns a null terminated string, reads until "\x00" and advances the buffer pointer.
---@return The string of bytes read
+--- Returns a null terminated string, reads until "\x00" and advances the buffer pointer.
+-- @return string The string of bytes read
 function ss_methods:readString()
 	local s = self:readUntil(0)
 	return string.sub(s, 1, #s-1)
 end
 
 --- Writes a byte to the buffer and advances the buffer pointer.
---@param x An int8 to write
+-- @param number x Int8 to write
 function ss_methods:writeInt8(x)
 	if x==math_huge or x==-math_huge or x~=x then error("Can't convert error float to integer!", 2) end
 	if x < 0 then x = x + 0x100 end
@@ -447,7 +447,7 @@ function ss_methods:writeInt8(x)
 end
 
 --- Writes a short to the buffer and advances the buffer pointer.
---@param x An int16 to write
+-- @param number x Int16 to write
 function ss_methods:writeInt16(x)
 	if x==math_huge or x==-math_huge or x~=x then error("Can't convert error float to integer!", 2) end
 	if x < 0 then x = x + 0x10000 end
@@ -460,7 +460,7 @@ function ss_methods_big:writeInt16(x)
 end
 
 --- Writes an int to the buffer and advances the buffer pointer.
---@param x An int32 to write
+-- @param number x Int32 to write
 function ss_methods:writeInt32(x)
 	if x==math_huge or x==-math_huge or x~=x then error("Can't convert error float to integer!", 2) end
 	if x < 0 then x = x + 0x100000000 end
@@ -473,7 +473,7 @@ function ss_methods_big:writeInt32(x)
 end
 
 --- Writes a 4 byte IEEE754 float to the byte stream and advances the buffer pointer.
---@param x The float to write
+-- @param number x The float to write
 function ss_methods:writeFloat(x)
 	self:write(string.char(PackIEEE754Float(x)))
 end
@@ -483,7 +483,7 @@ function ss_methods_big:writeFloat(x)
 end
 
 --- Writes a 8 byte IEEE754 double to the byte stream and advances the buffer pointer.
---@param x The double to write
+-- @param number x The double to write
 function ss_methods:writeDouble(x)
 	self:write(string.char(PackIEEE754Double(x)))
 end
@@ -493,14 +493,14 @@ function ss_methods_big:writeDouble(x)
 end
 
 --- Writes a string to the buffer putting a null at the end and advances the buffer pointer.
---@param string The string of bytes to write
-function ss_methods:writeString(string)
-	self:write(string)
+-- @param string str The string of bytes to write
+function ss_methods:writeString(str)
+	self:write(str)
 	self:write("\0")
 end
 
 --- Returns the buffer as a string
---@return The buffer as a string
+-- @return string The buffer as a string
 function ss_methods:getString()
 	return table.concat(self)
 end
@@ -516,79 +516,124 @@ SF.RegisterLibrary("bit")
 return function(instance)
 
 local bit_library = instance.Libraries.bit
----
+--- Returns the arithmetically shifted value.
 -- @class function
+-- @param number value The value to be manipulated.
+-- @param number shiftCount Amount of bits to shift
+-- @return number shiftedValue
 bit_library.arshift = bit.arshift
----
+
+--- Performs the bitwise "and" for all values specified.
 -- @class function
+-- @param number value The value to be manipulated.
+-- @param number otherValues Values bit to perform bitwise "and" with. Optional.
+-- @return number Result of bitwise "and" operation.
 bit_library.band = bit.band
----
+
+--- Returns the bitwise not of the value.
 -- @class function
+-- @param number value The value to be inverted.
+-- @return number Return value of bitwise not operation
 bit_library.bnot = bit.bnot
----
+
+--- Returns the bitwise OR of all values specified.
 -- @class function
+-- @param number value1 The first value.
+-- @param ...number Extra values to be evaluated. (must all be numbers)
+-- @return number The bitwise OR result between all numbers.
 bit_library.bor = bit.bor
----
+
+--- Swaps the byte order.
 -- @class function
+-- @param number value The value to be byte swapped.
+-- @return number Bit swapped value
 bit_library.bswap = bit.bswap
----
+
+--- Returns the bitwise xor of all values specified.
 -- @class function
+-- @param number value The value to be manipulated.
+-- @param ...number otherValues Values to bit xor with. Optional.
+-- @return number Return value of bitwiseXOr operation
 bit_library.bxor = bit.bxor
----
+
+--- Returns the left shifted value.
 -- @class function
+-- @param number value The value to be manipulated.
+-- @param number shiftCount Amounts of bits to shift left by.
+-- @return number Return of bitwise lshift operation
 bit_library.lshift = bit.lshift
----
+
+--- Returns the left rotated value.
 -- @class function
+-- @param number value The value to be manipulated.
+-- @param number shiftCount Amounts of bits to rotate left by.
+-- @return number Left rotated value
 bit_library.rol = bit.rol
----
+
+--- Returns the right rotated value.
 -- @class function
+-- @param number value The value to be manipulated.
+-- @param number shiftCount Amounts of bits to rotate right by.
+-- @return number Right rotated value
 bit_library.ror = bit.ror
----
+
+--- Returns the right shifted value.
 -- @class function
+-- @param number value The value to be manipulated.
+-- @param number shiftCount Amounts of bits to shift right by.
+-- @return number Right shifted value
 bit_library.rshift = bit_rshift
----
+
+--- Normalizes the specified value and clamps it in the range of a signed 32bit integer.
 -- @class function
+-- @param number value The value to be normalized.
+-- @return number Bit swapped value
 bit_library.tobit = bit.tobit
----
+
+--- Returns the hexadecimal representation of the number with the specified digits.
 -- @class function
+-- @param number value The value to be normalized.
+-- @param number digits The number of digits. Optional. (default 8)
+-- @return string Hex string.
 bit_library.tohex = bit.tohex
 
 
 --- Creates a StringStream object
---@name bit_library.stringstream
---@class function
---@param stream A string to set the initial buffer to (default "")
---@param i The initial buffer pointer (default 1)
---@param endian The endianness of number types. "big" or "little" (default "little")
+-- @name bit_library.stringstream
+-- @class function
+-- @param string stream String to set the initial buffer to (default "")
+-- @param number i The initial buffer pointer (default 1)
+-- @param string endian The endianness of number types. "big" or "little" (default "little")
+-- @return stringstream StringStream object
 bit_library.stringstream = SF.StringStream
 
 --- Converts a table to string serializing data types as best as it can
--- @param t The table to serialize
--- @return The serialized data
+-- @param table t The table to serialize
+-- @return string Serialized data
 function bit_library.tableToString(t)
 	checkluatype(t, TYPE_TABLE)
 	return SF.TableToString(t, instance)
 end
 
 --- Converts serialized string data to table
--- @param s The serialized string data
--- @return The deserialized table
+-- @param string s The serialized string data
+-- @return table The deserialized table
 function bit_library.stringToTable(s)
 	checkluatype(s, TYPE_STRING)
 	return SF.StringToTable(s, instance)
 end
 
 --- Compresses a string
---@param s String to compress
---@return Compressed string
+-- @param string s String to compress
+-- @return string Compressed string
 function bit_library.compress(s)
 	checkluatype(s, TYPE_STRING)
 	return util.Compress(s)
 end
 
 --- Decompresses a string
--- @param s Compressed string to decode
--- @return Decompressed string or nil if the input was invalid
+-- @param string s Compressed string to decode
+-- @return string Decompressed string or nil if the input was invalid
 function bit_library.decompress(s)
 	checkluatype(s, TYPE_STRING)
 	return util.Decompress(s)

--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -339,7 +339,7 @@ os_library.clock = os.clock
 -- @class function
 -- @param string format The format string. If starts with an '!', it will use UTC timezone rather than the local timezone
 -- @param number? time Time to use for the format. Default os.time()
--- @return any If format is equal to '*t' or '!*t' then it will return a table with DateData structure, otherwise a string
+-- @return string|table If format is equal to '*t' or '!*t' then it will return a table with DateData structure, otherwise a string
 os_library.date = function(format, time)
 	if format~=nil then
 		for v in string.gmatch(format, "%%(.?)") do if not string.match(v, "[%%aAbBcCdDSHeUmMjIpwxXzZyY]") then SF.Throw("Bad date format", 2) end end
@@ -787,7 +787,7 @@ instance.whitelistedEnvs = whitelistedEnvs
 --- Lua's setfenv
 -- Sets the environment of either the stack level or the function specified.
 -- Note that this function will throw an error if you try to use it on anything outside of your sandbox.
--- @param any funcOrStackLevel Function or stack level to set the environment of
+-- @param function|number funcOrStackLevel Function or stack level to set the environment of
 -- @param table tbl New environment
 -- @return function Function with environment set to tbl
 function builtins_library.setfenv(location, environment)
@@ -808,7 +808,7 @@ end
 --- Lua's getfenv
 -- Returns the environment of either the stack level or the function specified.
 -- Note that this function will return nil if the return value would be anything other than builtins_library or an environment you have passed to setfenv.
--- @param any funcOrStackLevel Function or stack level to get the environment of
+-- @param function|number funcOrStackLevel Function or stack level to get the environment of
 -- @return table? Environment table (or nil, if restricted)
 function builtins_library.getfenv(location)
 	if location == nil then
@@ -837,7 +837,7 @@ end
 
 --- GLua's debug.getinfo()
 -- Returns a DebugInfo structure containing the passed function's info https://wiki.facepunch.com/gmod/Structures/DebugInfo
--- @param any funcOrStackLevel Function or stack level to get info about. Defaults to stack level 0.
+-- @param function|number funcOrStackLevel Function or stack level to get info about. Defaults to stack level 0.
 -- @param string? fields A string that specifies the information to be retrieved. Defaults to all (flnSu).
 -- @return table DebugInfo table
 function builtins_library.debugGetInfo(funcOrStackLevel, fields)
@@ -853,7 +853,7 @@ end
 
 --- GLua's debug.getlocal()
 -- Returns the name of a function or stack's locals
--- @param any funcOrStackLevel Function or stack level to get info about. Defaults to stack level 0.
+-- @param function|number funcOrStackLevel Function or stack level to get info about. Defaults to stack level 0.
 -- @param number index The index of the local to get
 -- @return string The name of the local
 function builtins_library.debugGetLocal(funcOrStackLevel, index)

--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -41,19 +41,20 @@ end)
 -- @libtbl builtins_library
 
 --- Returns the entity representing a processor that this script is running on.
--- @return Starfall entity
+-- @return entity Starfall chip entity
 function builtins_library.chip()
 	return ewrap(instance.entity)
 end
 
 --- Returns whoever created the chip
--- @return Owner entity
+-- @return entity Owner entity
 function builtins_library.owner()
 	return instance.Types.Player.Wrap(instance.player)
 end
 
 --- Same as owner() on the server. On the client, returns the local player
--- @return Returns player with given UserID or if none specified then returns either the owner (server) or the local player (client)
+-- @param number? num UserID to get the player with.
+-- @return player Returns player with given UserID or if none specified then returns either the owner (server) or the local player (client)
 function builtins_library.player(num)
 	if num~=nil then
 		checkluatype(num, TYPE_NUMBER)
@@ -65,8 +66,8 @@ end
 
 
 --- Returns the entity with index 'num'
--- @param num Entity index
--- @return entity
+-- @param number num Entity index
+-- @return entity Entity at the index
 function builtins_library.entity(num)
 	checkluatype(num, TYPE_NUMBER)
 	return owrap(Entity(num))
@@ -76,47 +77,47 @@ end
 --- Used to select single values from a vararg or get the count of values in it.
 -- @name builtins_library.select
 -- @class function
--- @param parameter
--- @param vararg
--- @return Returns a number or vararg, depending on the select method.
+-- @param any parameter
+-- @param ... vararg Args to select from
+-- @return any Returns a number or vararg, depending on the select method.
 builtins_library.select = select
 
 --- Attempts to convert the value to a string.
 -- @name builtins_library.tostring
 -- @class function
--- @param obj
--- @return obj as string
+-- @param any obj Object to turn into a string
+-- @return string Object as a string
 builtins_library.tostring = tostring
 
 --- Attempts to convert the value to a number.
 -- @name builtins_library.tonumber
 -- @class function
--- @param obj
--- @return obj as number
+-- @param any obj Object to turn into a number
+-- @return number? The object as a number or nil if it couldn't be converted
 builtins_library.tonumber = tonumber
 
 --- Returns an iterator function for a for loop, to return ordered key-value pairs from a table.
 -- @name builtins_library.ipairs
 -- @class function
--- @param tbl Table to iterate over
--- @return Iterator function
--- @return Table tbl
--- @return 0 as current index
+-- @param table tbl Table to iterate over
+-- @return function Iterator function
+-- @return table Table being iterated over
+-- @return number Origin index. Equals 0.
 builtins_library.ipairs = ipairs
 
 --- Returns an iterator function for a for loop that will return the values of the specified table in an arbitrary order.
 -- @name builtins_library.pairs
 -- @class function
--- @param tbl Table to iterate over
--- @return Iterator function
--- @return Table tbl
--- @return nil as current index
+-- @param table tbl Table to iterate over
+-- @return function Iterator function
+-- @return table Table being iterated over
+-- @return any Nil as current index (for the constructor)
 builtins_library.pairs = pairs
 
 --- Returns a string representing the name of the type of the passed object.
 -- @name builtins_library.type
--- @param obj Object to get type of
--- @return The name of the object's type.
+-- @param any obj Object to get type of
+-- @return string The name of the object's type.
 function builtins_library.type(obj)
 	local tp = getmetatable(obj)
 	return isstring(tp) and tp or type(obj)
@@ -125,30 +126,30 @@ end
 --- Returns the next key and value pair in a table.
 -- @name builtins_library.next
 -- @class function
--- @param tbl Table to get the next key-value pair of
--- @param k Previous key (can be nil)
--- @return Key or nil
--- @return Value or nil
+-- @param table tbl Table to get the next key-value pair of
+-- @param any? k Previous key (can be nil)
+-- @return any? Key or nil
+-- @return any? Value or nil
 builtins_library.next = next
 
 --- This function takes a numeric indexed table and return all the members as a vararg.
 -- @name builtins_library.unpack
 -- @class function
--- @param tbl
--- @return Elements of tbl
+-- @param table tbl To get elements out of
+-- @return ... elements Elements of tbl
 builtins_library.unpack = unpack
 
 --- Sets, changes or removes a table's metatable. Doesn't work on most internal metatables
 -- @name builtins_library.setmetatable
 -- @class function
--- @param tbl The table to set the metatable of
--- @param meta The metatable to use
--- @return tbl with metatable set to meta
+-- @param table tbl The table to set the metatable of
+-- @param table meta The metatable to use
+-- @return table tbl with metatable set to meta
 builtins_library.setmetatable = setmetatable
 
 --- Returns the metatable of an object. Doesn't work on most internal metatables
--- @param tbl Table to get metatable of
--- @return The metatable of tbl
+-- @param table tbl Table to get metatable of
+-- @return table The metatable of tbl
 builtins_library.getmetatable = function(tbl)
 	checkluatype(tbl, TYPE_TABLE)
 	return getmetatable(tbl)
@@ -157,8 +158,8 @@ end
 --- Generates the CRC checksum of the specified string. (https://en.wikipedia.org/wiki/Cyclic_redundancy_check)
 -- @name builtins_library.crc
 -- @class function
--- @param stringToHash The string to calculate the checksum of
--- @return The unsigned 32 bit checksum as a string
+-- @param string stringToHash The string to calculate the checksum of
+-- @return string The unsigned 32 bit checksum as a string
 builtins_library.crc = util.CRC
 
 --- Constant that denotes whether the code is executed on the client
@@ -174,43 +175,43 @@ builtins_library.SERVER = SERVER
 --- Returns if this is the first time this hook was predicted.
 -- @name builtins_library.isFirstTimePredicted
 -- @class function
--- @return Boolean
+-- @return boolean Whether this is the first time this hook was predicted
 builtins_library.isFirstTimePredicted = IsFirstTimePredicted
 
 --- Returns the current count for this Think's CPU Time.
 -- This value increases as more executions are done, may not be exactly as you want.
 -- If used on screens, will show 0 if only rendering is done. Operations must be done in the Think loop for them to be counted.
--- @return Current quota used this Think
+-- @return number Current quota used this Think
 function builtins_library.quotaUsed()
 	return instance.cpu_total
 end
 
 --- Gets the Average CPU Time in the buffer
--- @return Average CPU Time of the buffer.
+-- @return number Average CPU Time of the buffer.
 function builtins_library.quotaAverage()
 	return instance:movingCPUAverage()
 end
 
 --- Gets the current ram usage of the gmod lua environment
--- @return The ram used in kilobytes
+-- @return number The ram used in kilobytes
 function builtins_library.ramUsed()
 	return SF.Instance.Ram
 end
 
 --- Gets the moving average of ram usage of the gmod lua environment
--- @return The ram used in kilobytes
+-- @return number The ram used in kilobytes
 function builtins_library.ramAverage()
 	return SF.Instance.RamAvg
 end
 
 --- Gets the max allowed ram usage of the gmod lua environment
--- @return The max ram usage in kilobytes
+-- @return number The max ram usage in kilobytes
 function builtins_library.ramMax()
 	return SF.RamCap:GetInt()
 end
 
 --- Gets the starfall version
--- @return Starfall version
+-- @return string Starfall version
 function builtins_library.version()
 	if SERVER then
 		return SF.Version
@@ -220,7 +221,7 @@ function builtins_library.version()
 end
 
 --- Returns the total used time for all chips by the player.
--- @return Total used CPU time of all your chips.
+-- @return number Total used CPU time of all your chips.
 function builtins_library.quotaTotalUsed()
 	local total = 0
 	for instance, _ in pairs(SF.playerInstances[instance.player]) do
@@ -230,7 +231,7 @@ function builtins_library.quotaTotalUsed()
 end
 
 --- Returns the total average time for all chips by the player.
--- @return Total average CPU Time of all your chips.
+-- @return number Total average CPU Time of all your chips.
 function builtins_library.quotaTotalAverage()
 	local total = 0
 	for instance, _ in pairs(SF.playerInstances[instance.player]) do
@@ -241,21 +242,21 @@ end
 
 --- Gets the CPU Time max.
 -- CPU Time is stored in a buffer of N elements, if the average of this exceeds quotaMax, the chip will error.
--- @return Max SysTime allowed to take for execution of the chip in a Think.
+-- @return number Max SysTime allowed to take for execution of the chip in a Think.
 function builtins_library.quotaMax()
 	return instance.cpuQuota
 end
 
 --- Sets a CPU soft quota which will trigger a catchable error if the cpu goes over a certain amount.
--- @param quota The threshold where the soft error will be thrown. Ratio of current cpu to the max cpu usage. 0.5 is 50%
+-- @param number quota The threshold where the soft error will be thrown. Ratio of current cpu to the max cpu usage. 0.5 is 50%
 function builtins_library.setSoftQuota(quota)
 	checkluatype(quota, TYPE_NUMBER)
 	instance.cpu_softquota = quota
 end
 
 --- Checks if the chip is capable of performing an action.
---@param perm The permission id to check
---@param obj Optional object to pass to the permission system.
+-- @param string perm The permission id to check
+-- @param any? obj Optional object to pass to the permission system.
 function builtins_library.hasPermission(perm, obj)
 	checkluatype(perm, TYPE_STRING)
 	if not SF.Permissions.permissionchecks[perm] then SF.Throw("Permission doesn't exist", 2) end
@@ -270,10 +271,10 @@ if CLIENT then
 	-- @client
 
 	--- Setups request for overriding permissions.
-	--@param perms Table of overridable permissions' names.
-	--@param desc Description attached to request.
-	--@param showOnUse Whether request will popup when player uses chip or linked screen.
-	--@client
+	-- @param table perms Table of overridable permissions' names.
+	-- @param string desc Description attached to request.
+	-- @param boolean showOnUse Whether request will popup when player uses chip or linked screen.
+	-- @client
 	function builtins_library.setupPermissionRequest( perms, desc, showOnUse )
 		checkluatype( desc, TYPE_STRING )
 		checkluatype( perms, TYPE_TABLE )
@@ -303,15 +304,15 @@ if CLIENT then
 	end
 
 	--- Is permission request fully satisfied.
-	--@return Boolean of whether the client gave all permissions specified in last request or not.
-	--@client
+	-- @return boolean Whether the client gave all permissions specified in last request or not.
+	-- @client
 	function builtins_library.permissionRequestSatisfied()
 		return SF.Permissions.permissionRequestSatisfied( instance )
 	end
 
 	local sentPermRequest = false
 	--- Opens the permission request dialogue if the player is connected to HUD. setupPermissionRequest must be called first
-	--@client
+	-- @client
 	function builtins_library.sendPermissionRequest()
 		if not SF.IsHUDActive(instance.entity) then SF.Throw("Player isn't connected to HUD!", 2) end
 		if sentPermRequest then SF.Throw("Can only send the permission request once!", 2) end
@@ -330,15 +331,15 @@ local os_library = instance.Libraries.os
 --- Returns the approximate cpu time the application ran.
 -- This function has different precision on Linux (1/100).
 -- @class function
--- @return The runtime
+-- @return number The runtime
 os_library.clock = os.clock
 
 --- Returns the date/time as a formatted string or in a table.
 -- See https://wiki.facepunch.com/gmod/Structures/DateData for the table structure
 -- @class function
--- @param format The format string. If starts with an '!', it will use UTC timezone rather than the local timezone
--- @param time Time to use for the format
--- @return If format is equal to '*t' or '!*t' then it will return a table with DateData structure, otherwise a string
+-- @param string format The format string. If starts with an '!', it will use UTC timezone rather than the local timezone
+-- @param number? time Time to use for the format. Default os.time()
+-- @return any If format is equal to '*t' or '!*t' then it will return a table with DateData structure, otherwise a string
 os_library.date = function(format, time)
 	if format~=nil then
 		for v in string.gmatch(format, "%%(.?)") do if not string.match(v, "[%%aAbBcCdDSHeUmMjIpwxXzZyY]") then SF.Throw("Bad date format", 2) end end
@@ -348,31 +349,31 @@ end
 
 --- Subtracts the second of the first value and rounds the result
 -- @class function
--- @param timeA The first value
--- @param timeB The value to subtract
--- @return Time difference
+-- @param number timeA The first value
+-- @param number timeB The value to subtract
+-- @return number Time difference
 os_library.difftime = os.difftime
 
 --- Returns the system time in seconds past the unix epoch.
 -- If a table is supplied, the function attempts to build a system time with the specified table members
 -- @class function
--- @param dateData Optional table to generate the time from. This table's data is interpreted as being in the local timezone
--- @return Seconds passed since Unix epoch
+-- @param table? dateData Optional table to generate the time from. This table's data is interpreted as being in the local timezone
+-- @return number Seconds passed since Unix epoch
 os_library.time = os.time
 
 
 -- ------------------------- Functions ------------------------- --
 
 --- Gets all libraries
--- @return Table where each key is the library name and value is table of the library
+-- @return table Table where each key is the library name and value is table of the library
 function builtins_library.getLibraries()
 	return instance.Libraries
 end
 
 --- Set the value of a table index without invoking a metamethod
---@param table The table to modify
---@param key The index of the table
---@param value The value to set the index equal to
+-- @param table The table to modify
+-- @param any key The index of the table
+-- @param any value The value to set the index equal to
 function builtins_library.rawset(table, key, value)
     checkluatype(table, TYPE_TABLE)
 
@@ -380,9 +381,9 @@ function builtins_library.rawset(table, key, value)
 end
 
 --- Gets the value of a table index without invoking a metamethod
---@param table The table to get the value from
---@param key The index of the table
---@return The value of the index
+-- @param table table The table to get the value from
+-- @param any key The index of the table
+-- @return any The value of the index
 function builtins_library.rawget(table, key, value)
     checkluatype(table, TYPE_TABLE)
 
@@ -466,7 +467,7 @@ if SERVER then
 
 	--- Prints a message to the player's chat.
 	-- @shared
-	-- @param ... Values to print. Colors before text will set the text color
+	-- @param ... printArgs Values to print. Colors before text will set the text color
 	function builtins_library.print(...)
 		local data, strlen, size = argsToChat(...)
 		printBurst:use(instance.player, size)
@@ -475,8 +476,8 @@ if SERVER then
 
 	--- Prints a message to a target player's chat as long as they're connected to a hud.
 	-- @shared
-	-- @param ply The target player. If in CLIENT, then ply is the client player and this param is omitted
-	-- @param ... Values to print. Colors before text will set the text color
+	-- @param player ply The target player. If in CLIENT, then ply is the client player and this param is omitted
+	-- @param ... printArgs Values to print. Colors before text will set the text color
 	function builtins_library.printHud(ply, ...)
 		ply = getply(ply)
 		if not ply:IsPlayer() then SF.Throw("Expected a target player!", 2) end
@@ -494,7 +495,7 @@ if SERVER then
 	end
 
 	--- Prints a table to player's chat
-	-- @param tbl Table to print
+	-- @param table tbl Table to print
 	function builtins_library.printTable(tbl)
 		checkluatype(tbl, TYPE_TABLE)
 		printTableX(tbl, 0, { tbl = true })
@@ -502,7 +503,7 @@ if SERVER then
 
 	--- Execute a console command
 	-- @shared
-	-- @param cmd Command to execute
+	-- @param string cmd Command to execute
 	function builtins_library.concmd(cmd)
 		checkluatype(cmd, TYPE_STRING)
 		if #cmd > 512 then SF.Throw("Console command is too long!", 2) end
@@ -512,7 +513,7 @@ if SERVER then
 
 	--- Sets the chip's userdata that the duplicator tool saves. max 1MiB; can be changed with convar sf_userdata_max
 	-- @server
-	-- @param str String data
+	-- @param string str String data
 	function builtins_library.setUserdata(str)
 		checkluatype(str, TYPE_STRING)
 		local max = userdataLimit:GetInt()
@@ -524,14 +525,14 @@ if SERVER then
 
 	--- Gets the chip's userdata that the duplicator tool loads
 	-- @server
-	-- @return String data
+	-- @return string String data
 	function builtins_library.getUserdata()
 		return instance.entity.starfalluserdata or ""
 	end
 else
 	--- Sets the chip's display name
 	-- @client
-	-- @param name Name
+	-- @param string name Name to set the chip's name to
 	function builtins_library.setName(name)
 		checkluatype(name, TYPE_STRING)
 		local e = instance.entity
@@ -542,7 +543,7 @@ else
 
 	--- Sets clipboard text. Only works on the owner of the chip.
 	-- @client
-	-- @param txt Text to set to the clipboard
+	-- @param string txt Text to set to the clipboard
 	function builtins_library.setClipboardText(txt)
 		if instance.player ~= LocalPlayer() then return end
 		checkluatype(txt, TYPE_STRING)
@@ -551,8 +552,8 @@ else
 
 	--- Prints a message to your chat, console, or the center of your screen.
 	-- @client
-	-- @param mtype How the message should be displayed. See http://wiki.facepunch.com/gmod/Enums/HUD
-	-- @param text The message text.
+	-- @param number mtype How the message should be displayed. See http://wiki.facepunch.com/gmod/Enums/HUD
+	-- @param string text The message text.
 	function builtins_library.printMessage(mtype, text)
 		if instance.player ~= LocalPlayer() then return end
 		checkluatype(text, TYPE_STRING)
@@ -592,36 +593,36 @@ else
 
 	--- Returns the local player's camera angles
 	-- @client
-	-- @return The local player's camera angles
+	-- @return angle The local player's camera angles
 	function builtins_library.eyeAngles()
 		return awrap(LocalPlayer():EyeAngles())
 	end
 
 	--- Returns the local player's camera position
 	-- @client
-	-- @return The local player's camera position
+	-- @return vector The local player's camera position
 	function builtins_library.eyePos()
 		return vwrap(LocalPlayer():EyePos())
 	end
 
 	--- Returns the local player's camera forward vector
 	-- @client
-	-- @return The local player's camera forward vector
+	-- @return vector The local player's camera forward vector
 	function builtins_library.eyeVector()
 		return vwrap(LocalPlayer():GetAimVector())
 	end
 end
 
 --- Returns the table of scripts used by the chip
--- @return Table of scripts used by the chip
+-- @return table Table of scripts used by the chip
 function builtins_library.getScripts()
 	return instance.Sanitize(instance.source)
 end
 
 --- Runs an included script and caches the result.
 -- Works pretty much like standard Lua require()
--- @param file The file to include. Make sure to --@include it
--- @return Return value of the script
+-- @param string file The file to include. Make sure to --@include it
+-- @return ... Return value(s) of the script
 function builtins_library.require(file)
 	checkluatype(file, TYPE_STRING)
 	local loaded = instance.requires
@@ -662,9 +663,9 @@ end
 
 --- Runs an included script and caches the result.
 -- Works pretty much like standard Lua require()
--- @param dir The directory to include. Make sure to --@includedir it
--- @param loadpriority Table of files that should be loaded before any others in the directory
--- @return Table of return values of the scripts
+-- @param string dir The directory to include. Make sure to --@includedir it
+-- @param table loadpriority Table of files that should be loaded before any others in the directory
+-- @return table Table of return values of the scripts
 function builtins_library.requiredir(dir, loadpriority)
 	checkluatype(dir, TYPE_STRING)
 	if loadpriority~=nil then checkluatype(loadpriority, TYPE_TABLE) end
@@ -712,8 +713,8 @@ end
 
 --- Runs an included script, but does not cache the result.
 -- Pretty much like standard Lua dofile()
--- @param file The file to include. Make sure to --@include it
--- @return Return value of the script
+-- @param string file The file to include. Make sure to --@include it
+-- @return ... Return value(s) of the script
 function builtins_library.dofile(file)
 	checkluatype(file, TYPE_STRING)
 	local path
@@ -731,9 +732,9 @@ function builtins_library.dofile(file)
 end
 
 --- Runs an included directory, but does not cache the result.
--- @param dir The directory to include. Make sure to --@includedir it
--- @param loadpriority Table of files that should be loaded before any others in the directory
--- @return Table of return values of the scripts
+-- @param string dir The directory to include. Make sure to --@includedir it
+-- @param table loadpriority Table of files that should be loaded before any others in the directory
+-- @return table Table of return values of the scripts
 function builtins_library.dodir(dir, loadpriority)
 	checkluatype(dir, TYPE_STRING)
 	if loadpriority~=nil then checkluatype(loadpriority, TYPE_TABLE) end
@@ -763,8 +764,8 @@ end
 
 --- GLua's loadstring
 -- Works like loadstring, except that it executes by default in the main builtins_library
--- @param str String to execute
--- @return Function of str
+-- @param string str String to execute
+-- @return function Function of str
 function builtins_library.loadstring(str, name)
 	name = "SF:" .. (name or tostring(instance.env))
 	local func = SF.CompileString(str, name, false)
@@ -786,9 +787,9 @@ instance.whitelistedEnvs = whitelistedEnvs
 --- Lua's setfenv
 -- Sets the environment of either the stack level or the function specified.
 -- Note that this function will throw an error if you try to use it on anything outside of your sandbox.
--- @param funcOrStackLevel Function or stack level to set the environment of
--- @param tbl New environment
--- @return Function with environment set to tbl
+-- @param any funcOrStackLevel Function or stack level to set the environment of
+-- @param table tbl New environment
+-- @return function Function with environment set to tbl
 function builtins_library.setfenv(location, environment)
 	if location == nil then
 		location = 2
@@ -807,8 +808,8 @@ end
 --- Lua's getfenv
 -- Returns the environment of either the stack level or the function specified.
 -- Note that this function will return nil if the return value would be anything other than builtins_library or an environment you have passed to setfenv.
--- @param funcOrStackLevel Function or stack level to get the environment of
--- @return Environment table (or nil, if restricted)
+-- @param any funcOrStackLevel Function or stack level to get the environment of
+-- @return table? Environment table (or nil, if restricted)
 function builtins_library.getfenv(location)
 	if location == nil then
 		location = 2
@@ -824,8 +825,8 @@ function builtins_library.getfenv(location)
 end
 
 --- Gets an SF type's methods table
--- @param sfType Name of SF type
--- @return Table of the type's methods which can be edited or iterated
+-- @param string sfType Name of SF type
+-- @return table Table of the type's methods which can be edited or iterated
 function builtins_library.getMethods(sfType)
 	checkluatype(sfType, TYPE_STRING)
 	local typemeta = instance.Types[sfType]
@@ -836,9 +837,9 @@ end
 
 --- GLua's debug.getinfo()
 -- Returns a DebugInfo structure containing the passed function's info https://wiki.facepunch.com/gmod/Structures/DebugInfo
--- @param funcOrStackLevel Function or stack level to get info about. Defaults to stack level 0.
--- @param fields A string that specifies the information to be retrieved. Defaults to all (flnSu).
--- @return DebugInfo table
+-- @param any funcOrStackLevel Function or stack level to get info about. Defaults to stack level 0.
+-- @param string? fields A string that specifies the information to be retrieved. Defaults to all (flnSu).
+-- @return table DebugInfo table
 function builtins_library.debugGetInfo(funcOrStackLevel, fields)
 	if not isfunction(funcOrStackLevel) and not isnumber(funcOrStackLevel) then SF.ThrowTypeError("function or number", SF.GetType(TfuncOrStackLevel), 2) end
 	if fields~=nil then checkluatype(fields, TYPE_STRING) end
@@ -852,9 +853,9 @@ end
 
 --- GLua's debug.getlocal()
 -- Returns the name of a function or stack's locals
--- @param funcOrStackLevel Function or stack level to get info about. Defaults to stack level 0.
--- @param index The index of the local to get
--- @return The name of the local
+-- @param any funcOrStackLevel Function or stack level to get info about. Defaults to stack level 0.
+-- @param number index The index of the local to get
+-- @return string The name of the local
 function builtins_library.debugGetLocal(funcOrStackLevel, index)
 	if not isfunction(funcOrStackLevel) and not isnumber(funcOrStackLevel) then SF.ThrowTypeError("function or number", SF.GetType(TfuncOrStackLevel), 2) end
 	checkluatype(index, TYPE_NUMBER)
@@ -871,10 +872,10 @@ local uncatchable = {
 
 --- Lua's pcall with SF throw implementation
 -- Calls a function and catches an error that can be thrown while the execution of the call.
--- @param func Function to be executed and of which the errors should be caught of
--- @param arguments Arguments to call the function with.
--- @return If the function had no errors occur within it.
--- @return If an error occurred, this will be a string containing the error message. Otherwise, this will be the return values of the function passed in.
+-- @param function func Function to be executed and of which the errors should be caught of
+-- @param ... arguments Arguments to call the function with.
+-- @return boolean If the function had no errors occur within it.
+-- @return ... If an error occurred, this will be a string containing the error message. Otherwise, this will be the return values of the function passed in.
 function builtins_library.pcall(func, ...)
 	local vret = { pcall(func, ...) }
 	local ok, err = vret[1], vret[2]
@@ -901,11 +902,11 @@ end
 --- Lua's xpcall with SF throw implementation, and a traceback for debugging.
 -- Attempts to call the first function. If the execution succeeds, this returns true followed by the returns of the function.
 -- If execution fails, this returns false and the second function is called with the error message, and the stack trace.
--- @param func The function to call initially.
--- @param callback The function to be called if execution of the first fails; the error message and stack trace are passed.
--- @param ... Varargs to pass to the initial function.
--- @return Status of the execution; true for success, false for failure.
--- @return The returns of the first function if execution succeeded, otherwise the return values of the error callback.
+-- @param function func The function to call initially.
+-- @param function callback The function to be called if execution of the first fails; the error message and stack trace are passed.
+-- @param ... passArgs Varargs to pass to the initial function.
+-- @return boolean Status of the execution; true for success, false for failure.
+-- @return ... The returns of the first function if execution succeeded, otherwise the return values of the error callback.
 function builtins_library.xpcall(func, callback, ...)
 	local vret = { xpcall(func, xpcall_Callback, ...) }
 	local ok, errData = vret[1], vret[2]
@@ -928,8 +929,8 @@ end
 
 --- Try to execute a function and catch possible exceptions
 -- Similar to xpcall, but a bit more in-depth
--- @param func Function to execute
--- @param catch Optional function to execute in case func fails
+-- @param function func Function to execute
+-- @param function? catch Optional function to execute in case func fails
 function builtins_library.try(func, catch)
 	local ok, err = pcall(func)
 	if ok then return end
@@ -948,9 +949,9 @@ end
 
 
 --- Throws an exception
--- @param msg Message string
--- @param level Which level in the stacktrace to blame. Defaults to 1
--- @param uncatchable Makes this exception uncatchable
+-- @param string msg Message string
+-- @param number? level Which level in the stacktrace to blame. Defaults to 1
+-- @param boolean uncatchable Makes this exception uncatchable
 function builtins_library.throw(msg, level, uncatchable)
 	SF.Throw(msg, 1 + (level or 1), uncatchable)
 end
@@ -958,8 +959,8 @@ end
 --- Throws an error. Similar to 'throw' but throws whatever you want instead of an SF Error.
 -- @name builtins_library.error
 -- @class function
--- @param msg Message string
--- @param level Which level in the stacktrace to blame. Defaults to 1. 0 for no stacktrace.
+-- @param string msg Message string
+-- @param number? level Which level in the stacktrace to blame. Defaults to 1. 0 for no stacktrace.
 function builtins_library.error(msg, level)
 	SF.Throw(msg, 1 + (level or 1), false, msg)
 end
@@ -967,13 +968,14 @@ end
 --- If the result of the first argument is false or nil, an error is thrown with the second argument as the message.
 -- @name builtins_library.assert
 -- @class function
--- @param condition
--- @param msg
+-- @param any expression
+-- @param string? msg Error message. Default "assertion failed!"
+-- @param ... args Any arguments to return if the assertion is successful
 builtins_library.assert = assert
 
 --- Returns if the table has an isValid function and isValid returns true.
---@param object Table to check
---@return If it is valid
+-- @param any object Table to check
+-- @return boolean If it is valid
 function builtins_library.isValid(object)
 
 	if (not object) then return false end
@@ -984,12 +986,12 @@ function builtins_library.isValid(object)
 end
 
 --- Translates the specified position and angle into the specified coordinate system
--- @param pos The position that should be translated from the current to the new system
--- @param ang The angles that should be translated from the current to the new system
--- @param newSystemOrigin The origin of the system to translate to
--- @param newSystemAngles The angles of the system to translate to
--- @return localPos
--- @return localAngles
+-- @param vector pos The position that should be translated from the current to the new system
+-- @param angle ang The angles that should be translated from the current to the new system
+-- @param vector newSystemOrigin The origin of the system to translate to
+-- @param angle newSystemAngles The angles of the system to translate to
+-- @return vector localPos
+-- @return angle localAngles
 function builtins_library.worldToLocal(pos, ang, newSystemOrigin, newSystemAngles)
 
 	local localPos, localAngles = WorldToLocal(
@@ -1003,12 +1005,12 @@ function builtins_library.worldToLocal(pos, ang, newSystemOrigin, newSystemAngle
 end
 
 --- Translates the specified position and angle from the specified local coordinate system
--- @param localPos The position vector that should be translated to world coordinates
--- @param localAng The angle that should be converted to a world angle
--- @param originPos The origin point of the source coordinate system, in world coordinates
--- @param originAngle The angles of the source coordinate system, as a world angle
--- @return worldPos
--- @return worldAngles
+-- @param vector localPos The position vector that should be translated to world coordinates
+-- @param angle localAng The angle that should be converted to a world angle
+-- @param vector originPos The origin point of the source coordinate system, in world coordinates
+-- @param angle originAngle The angles of the source coordinate system, as a world angle
+-- @return vector worldPos
+-- @return angle worldAngles
 function builtins_library.localToWorld(localPos, localAng, originPos, originAngle)
 
 	local worldPos, worldAngles = LocalToWorld(
@@ -1023,8 +1025,8 @@ end
 
 --- Sets the current instance to allow HUD drawing. Only works if player is in your vehicle or
 -- if it's ran on yourself or if the player is connected to your hud and you want to disconnect them
---@param ply The player to enable the hud on. If CLIENT, will be forced to player()
---@param active Whether hud hooks should be active. true to force on, false to force off.
+-- @param player ply The player to enable the hud on. If CLIENT, will be forced to player()
+-- @param boolean active Whether hud hooks should be active. true to force on, false to force off.
 function builtins_library.enableHud(ply, active)
 	ply = SERVER and getply(ply) or LocalPlayer()
 	checkluatype(active, TYPE_BOOL)
@@ -1044,8 +1046,8 @@ end
 --- Creates a 'middleclass' class object that can be used similarly to Java/C++ classes. See https://github.com/kikito/middleclass for examples.
 -- @name builtins_library.class
 -- @class function
--- @param name The string name of the class
--- @param super The (optional) parent class to inherit from
+-- @param string name The string name of the class
+-- @param table? super The (optional) parent class to inherit from
 builtins_library.class = SF.Class
 
 end

--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -967,7 +967,7 @@ end
 --- If the result of the first argument is false or nil, an error is thrown with the second argument as the message.
 -- @name builtins_library.assert
 -- @class function
--- @param any expression
+-- @param any expression Anything that will be evaluated to be true or false
 -- @param string? msg Error message. Default "assertion failed!"
 -- @param ... args Any arguments to return if the assertion is successful
 builtins_library.assert = assert

--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -371,7 +371,7 @@ function builtins_library.getLibraries()
 end
 
 --- Set the value of a table index without invoking a metamethod
--- @param table The table to modify
+-- @param table tbl The table to modify
 -- @param any key The index of the table
 -- @param any value The value to set the index equal to
 function builtins_library.rawset(table, key, value)

--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -127,9 +127,9 @@ end
 -- @name builtins_library.next
 -- @class function
 -- @param table tbl Table to get the next key-value pair of
--- @param any? k Previous key (can be nil)
--- @return any? Key or nil
--- @return any? Value or nil
+-- @param any k Previous key (can be nil)
+-- @return any Key or nil
+-- @return any Value or nil
 builtins_library.next = next
 
 --- This function takes a numeric indexed table and return all the members as a vararg.
@@ -256,7 +256,7 @@ end
 
 --- Checks if the chip is capable of performing an action.
 -- @param string perm The permission id to check
--- @param any? obj Optional object to pass to the permission system.
+-- @param any obj Optional object to pass to the permission system.
 function builtins_library.hasPermission(perm, obj)
 	checkluatype(perm, TYPE_STRING)
 	if not SF.Permissions.permissionchecks[perm] then SF.Throw("Permission doesn't exist", 2) end

--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -41,20 +41,20 @@ end)
 -- @libtbl builtins_library
 
 --- Returns the entity representing a processor that this script is running on.
--- @return entity Starfall chip entity
+-- @return Entity Starfall chip entity
 function builtins_library.chip()
 	return ewrap(instance.entity)
 end
 
 --- Returns whoever created the chip
--- @return entity Owner entity
+-- @return Entity Owner entity
 function builtins_library.owner()
 	return instance.Types.Player.Wrap(instance.player)
 end
 
 --- Same as owner() on the server. On the client, returns the local player
 -- @param number? num UserID to get the player with.
--- @return player Returns player with given UserID or if none specified then returns either the owner (server) or the local player (client)
+-- @return Player Returns player with given UserID or if none specified then returns either the owner (server) or the local player (client)
 function builtins_library.player(num)
 	if num~=nil then
 		checkluatype(num, TYPE_NUMBER)
@@ -67,7 +67,7 @@ end
 
 --- Returns the entity with index 'num'
 -- @param number num Entity index
--- @return entity Entity at the index
+-- @return Entity Entity at the index
 function builtins_library.entity(num)
 	checkluatype(num, TYPE_NUMBER)
 	return owrap(Entity(num))
@@ -476,7 +476,7 @@ if SERVER then
 
 	--- Prints a message to a target player's chat as long as they're connected to a hud.
 	-- @shared
-	-- @param player ply The target player. If in CLIENT, then ply is the client player and this param is omitted
+	-- @param Player ply The target player. If in CLIENT, then ply is the client player and this param is omitted
 	-- @param ... printArgs Values to print. Colors before text will set the text color
 	function builtins_library.printHud(ply, ...)
 		ply = getply(ply)
@@ -593,21 +593,21 @@ else
 
 	--- Returns the local player's camera angles
 	-- @client
-	-- @return angle The local player's camera angles
+	-- @return Angle The local player's camera angles
 	function builtins_library.eyeAngles()
 		return awrap(LocalPlayer():EyeAngles())
 	end
 
 	--- Returns the local player's camera position
 	-- @client
-	-- @return vector The local player's camera position
+	-- @return Vector The local player's camera position
 	function builtins_library.eyePos()
 		return vwrap(LocalPlayer():EyePos())
 	end
 
 	--- Returns the local player's camera forward vector
 	-- @client
-	-- @return vector The local player's camera forward vector
+	-- @return Vector The local player's camera forward vector
 	function builtins_library.eyeVector()
 		return vwrap(LocalPlayer():GetAimVector())
 	end
@@ -986,12 +986,12 @@ function builtins_library.isValid(object)
 end
 
 --- Translates the specified position and angle into the specified coordinate system
--- @param vector pos The position that should be translated from the current to the new system
--- @param angle ang The angles that should be translated from the current to the new system
--- @param vector newSystemOrigin The origin of the system to translate to
--- @param angle newSystemAngles The angles of the system to translate to
--- @return vector localPos
--- @return angle localAngles
+-- @param Vector pos The position that should be translated from the current to the new system
+-- @param Angle ang The angles that should be translated from the current to the new system
+-- @param Vector newSystemOrigin The origin of the system to translate to
+-- @param Angle newSystemAngles The angles of the system to translate to
+-- @return Vector localPos
+-- @return Angle localAngles
 function builtins_library.worldToLocal(pos, ang, newSystemOrigin, newSystemAngles)
 
 	local localPos, localAngles = WorldToLocal(
@@ -1005,12 +1005,12 @@ function builtins_library.worldToLocal(pos, ang, newSystemOrigin, newSystemAngle
 end
 
 --- Translates the specified position and angle from the specified local coordinate system
--- @param vector localPos The position vector that should be translated to world coordinates
--- @param angle localAng The angle that should be converted to a world angle
--- @param vector originPos The origin point of the source coordinate system, in world coordinates
--- @param angle originAngle The angles of the source coordinate system, as a world angle
--- @return vector worldPos
--- @return angle worldAngles
+-- @param Vector localPos The position vector that should be translated to world coordinates
+-- @param Angle localAng The angle that should be converted to a world angle
+-- @param Vector originPos The origin point of the source coordinate system, in world coordinates
+-- @param Angle originAngle The angles of the source coordinate system, as a world angle
+-- @return Vector worldPos
+-- @return Angle worldAngles
 function builtins_library.localToWorld(localPos, localAng, originPos, originAngle)
 
 	local worldPos, worldAngles = LocalToWorld(
@@ -1025,7 +1025,7 @@ end
 
 --- Sets the current instance to allow HUD drawing. Only works if player is in your vehicle or
 -- if it's ran on yourself or if the player is connected to your hud and you want to disconnect them
--- @param player ply The player to enable the hud on. If CLIENT, will be forced to player()
+-- @param Player ply The player to enable the hud on. If CLIENT, will be forced to player()
 -- @param boolean active Whether hud hooks should be active. true to force on, false to force off.
 function builtins_library.enableHud(ply, active)
 	ply = SERVER and getply(ply) or LocalPlayer()

--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -374,10 +374,9 @@ end
 -- @param table tbl The table to modify
 -- @param any key The index of the table
 -- @param any value The value to set the index equal to
-function builtins_library.rawset(table, key, value)
-    checkluatype(table, TYPE_TABLE)
-
-    rawset(table, key, value)
+function builtins_library.rawset(tbl, key, value)
+    checkluatype(tbl, TYPE_TABLE)
+    rawset(tbl, key, value)
 end
 
 --- Gets the value of a table index without invoking a metamethod

--- a/lua/starfall/libs_sh/color.lua
+++ b/lua/starfall/libs_sh/color.lua
@@ -125,25 +125,25 @@ function color_meta.__concat(a, b)
 end
 
 --- Equivalence metamethod
--- @param color c1 Initial color.
--- @param color c2 Color to check against.
+-- @param Color c1 Initial color.
+-- @param Color c2 Color to check against.
 -- @return boolean Whether their fields are equal
 function color_meta.__eq(a, b)
 	return a[1]==b[1] and a[2]==b[2] and a[3]==b[3] and a[4]==b[4]
 end
 
 --- Addition metamethod
--- @param color c1 Initial color.
--- @param color c2 Color to add to the first.
--- @return color Resultant color.
+-- @param Color c1 Initial color.
+-- @param Color c2 Color to add to the first.
+-- @return Color Resultant color.
 function color_meta.__add(a, b)
 	return wrap({ a[1] + b[1], a[2] + b[2], a[3] + b[3], a[4] + b[4] })
 end
 
 --- Subtraction metamethod
--- @param color c1 Initial color.
--- @param color c2 Color to subtract.
--- @return color Resultant color.
+-- @param Color c1 Initial color.
+-- @param Color c2 Color to subtract.
+-- @return Color Resultant color.
 function color_meta.__sub(a, b)
 	return wrap({ a[1]-b[1], a[2]-b[2], a[3]-b[3], a[4]-b[4] })
 end
@@ -151,7 +151,7 @@ end
 --- Multiplication metamethod
 -- @param any a Number or Color multiplicant
 -- @param any b Number or Color multiplier
--- @return color Multiplied color.
+-- @return Color Multiplied color.
 function color_meta.__mul(a, b)
 	if isnumber(b) then
 		return wrap({ a[1] * b, a[2] * b, a[3] * b, a[4] * b })
@@ -186,7 +186,7 @@ end
 
 --- Converts the color from RGB to HSV.
 -- @shared
--- @return color A triplet of numbers representing HSV.
+-- @return Color A triplet of numbers representing HSV.
 function color_methods:rgbToHSV()
 	local h, s, v = ColorToHSV(self)
 	return wrap({ h, s, v, 255 })
@@ -194,7 +194,7 @@ end
 
 --- Converts the color from HSV to RGB.
 -- @shared
--- @return color A triplet of numbers representing HSV.
+-- @return Color A triplet of numbers representing HSV.
 function color_methods:hsvToRGB()
 	local rgb = HSVToColor(math.Clamp(self[1] % 360, 0, 360), math.Clamp(self[2], 0, 1), math.Clamp(self[3], 0, 1))
 	return wrap({ rgb.r, rgb.g, rgb.b, (rgb.a or 255) })
@@ -223,14 +223,14 @@ function color_methods:round(idp)
 end
 
 --- Copies r,g,b,a from color and returns a new color
--- @return color The copy of the color
+-- @return Color The copy of the color
 function color_methods:clone()
 	return wrap({ self[1], self[2], self[3], self[4] })
 end
 
 --- Copies r,g,b,a from color to another.
 -- Self-Modifies. Does not return anything
--- @param color b The color to copy from.
+-- @param Color b The color to copy from.
 function color_methods:set(b)
 	self[1] = b[1]
 	self[2] = b[2]
@@ -240,7 +240,7 @@ end
 
 --- Set's the color's red channel and returns self.
 -- @param number r The red
--- @return color Color after modification
+-- @return Color Color after modification
 function color_methods:setR(r)
 	self[1] = r
 	return self
@@ -248,7 +248,7 @@ end
 
 --- Set's the color's green and returns self.
 -- @param number g The green
--- @return color Color after modification
+-- @return Color Color after modification
 function color_methods:setG(g)
 	self[2] = g
 	return self
@@ -256,7 +256,7 @@ end
 
 --- Set's the color's blue and returns self.
 -- @param number b The blue
--- @return color Color after modification
+-- @return Color Color after modification
 function color_methods:setB(b)
 	self[3] = b
 	return self
@@ -264,7 +264,7 @@ end
 
 --- Set's the color's alpha and returns it.
 -- @param number a The alpha
--- @return color Color after modification
+-- @return Color Color after modification
 function color_methods:setA(a)
 	self[4] = a
 	return self

--- a/lua/starfall/libs_sh/color.lua
+++ b/lua/starfall/libs_sh/color.lua
@@ -60,11 +60,11 @@ end
 --- Creates a table struct that resembles a Color
 -- @name builtins_library.Color
 -- @class function
--- @param r - Red or string hexadecimal color
--- @param g - Green
--- @param b - Blue
--- @param a - Alpha
--- @return New color
+-- @param number r Red or string hexadecimal color
+-- @param number g Green
+-- @param number b Blue
+-- @param number a Alpha
+-- @return Color New color
 function instance.env.Color(r, g, b, a)
 	if isstring(r) then
 		local hex = string.match(r, "^#?(%x+)$") or SF.Throw("Invalid hexadecimal color", 2)
@@ -90,8 +90,8 @@ end
 local rgb = { r = 1, g = 2, b = 3, a = 4, h = 1, s = 2, v = 3, l = 3 }
 
 --- Sets a value at a key in the color
--- @param any k Key. Number or string
--- @param any v Value.
+-- @param number|string k Key. Number or string
+-- @param number v Value.
 function color_meta.__newindex(t, k, v)
 	if rgb[k] then
 		rawset(t, rgb[k], v)
@@ -101,7 +101,7 @@ function color_meta.__newindex(t, k, v)
 end
 
 --- Gets a value at a key in the color
--- @param any k Key. Number or string
+-- @param number|string k Key. Number or string
 -- @return number Value at the index
 function color_meta.__index(t, k)
 	local method = color_methods[k]
@@ -149,8 +149,8 @@ function color_meta.__sub(a, b)
 end
 
 --- Multiplication metamethod
--- @param any a Number or Color multiplicant
--- @param any b Number or Color multiplier
+-- @param number|Color a Number or Color multiplicant
+-- @param number|Color b Number or Color multiplier
 -- @return Color Multiplied color.
 function color_meta.__mul(a, b)
 	if isnumber(b) then
@@ -167,8 +167,8 @@ function color_meta.__mul(a, b)
 end
 
 --- Division metamethod
--- @param any b Number or Color dividend
--- @param any b Number or Color divisor
+-- @param number|Color b Number or Color dividend
+-- @param number|Color b Number or Color divisor
 -- @return Scaled color.
 function color_meta.__div(a, b)
 	if isnumber(b) then
@@ -214,7 +214,7 @@ end
 
 --- Round the color values.
 -- Self-Modifies. Does not return anything
--- @param number idp (Default 0) The integer decimal place to round to.
+-- @param number? idp (Default 0) The integer decimal place to round to.
 function color_methods:round(idp)
 	self[1] = math.Round(self[1], idp)
 	self[2] = math.Round(self[2], idp)

--- a/lua/starfall/libs_sh/color.lua
+++ b/lua/starfall/libs_sh/color.lua
@@ -89,7 +89,9 @@ end
 -- Think of rgb as a template for members of Color that are expected.
 local rgb = { r = 1, g = 2, b = 3, a = 4, h = 1, s = 2, v = 3, l = 3 }
 
---- __newindex metamethod
+--- Sets a value at a key in the color
+-- @param any k Key. Number or string
+-- @param any v Value.
 function color_meta.__newindex(t, k, v)
 	if rgb[k] then
 		rawset(t, rgb[k], v)
@@ -98,7 +100,9 @@ function color_meta.__newindex(t, k, v)
 	end
 end
 
---- __index metamethod
+--- Gets a value at a key in the color
+-- @param any k Key. Number or string
+-- @return number Value at the index
 function color_meta.__index(t, k)
 	local method = color_methods[k]
 	if method then
@@ -108,43 +112,46 @@ function color_meta.__index(t, k)
 	end
 end
 
---- __tostring metamethod
+--- Turns the color into a string
+-- @return string String representation of the color
 function color_meta.__tostring(c)
 	return c[1] .. " " .. c[2] .. " " .. c[3] .. " " .. c[4]
 end
 
---- __concat metamethod
-function color_meta.__concat(...)
-	local t = { ... }
-	return tostring(t[1]) .. tostring(t[2])
+--- Concatenation metamethod
+-- @return string Adds two colors into one string-representation
+function color_meta.__concat(a, b)
+	return tostring(a) .. tostring(b)
 end
 
---- __eq metamethod
+--- Equivalence metamethod
+-- @param color c1 Initial color.
+-- @param color c2 Color to check against.
+-- @return boolean Whether their fields are equal
 function color_meta.__eq(a, b)
 	return a[1]==b[1] and a[2]==b[2] and a[3]==b[3] and a[4]==b[4]
 end
 
---- addition metamethod
--- @param lhs Left side of equation
--- @param rhs Right side of equation
--- @return Added color.
+--- Addition metamethod
+-- @param color c1 Initial color.
+-- @param color c2 Color to add to the first.
+-- @return color Resultant color.
 function color_meta.__add(a, b)
-
 	return wrap({ a[1] + b[1], a[2] + b[2], a[3] + b[3], a[4] + b[4] })
 end
 
---- subtraction metamethod
--- @param lhs Left side of equation
--- @param rhs Right side of equation
--- @return Subtracted color.
+--- Subtraction metamethod
+-- @param color c1 Initial color.
+-- @param color c2 Color to subtract.
+-- @return color Resultant color.
 function color_meta.__sub(a, b)
-
 	return wrap({ a[1]-b[1], a[2]-b[2], a[3]-b[3], a[4]-b[4] })
 end
 
---- multiplication metamethod
--- @param b Number or Color to multiply by
--- @return Scaled color.
+--- Multiplication metamethod
+-- @param any a Number or Color multiplicant
+-- @param any b Number or Color multiplier
+-- @return color Multiplied color.
 function color_meta.__mul(a, b)
 	if isnumber(b) then
 		return wrap({ a[1] * b, a[2] * b, a[3] * b, a[4] * b })
@@ -159,8 +166,9 @@ function color_meta.__mul(a, b)
 	end
 end
 
---- division metamethod
--- @param b Number or Color to multiply by
+--- Division metamethod
+-- @param any b Number or Color dividend
+-- @param any b Number or Color divisor
 -- @return Scaled color.
 function color_meta.__div(a, b)
 	if isnumber(b) then
@@ -177,24 +185,24 @@ function color_meta.__div(a, b)
 end
 
 --- Converts the color from RGB to HSV.
---@shared
---@return A triplet of numbers representing HSV.
+-- @shared
+-- @return color A triplet of numbers representing HSV.
 function color_methods:rgbToHSV()
 	local h, s, v = ColorToHSV(self)
 	return wrap({ h, s, v, 255 })
 end
 
 --- Converts the color from HSV to RGB.
---@shared
---@return A triplet of numbers representing HSV.
+-- @shared
+-- @return color A triplet of numbers representing HSV.
 function color_methods:hsvToRGB()
 	local rgb = HSVToColor(math.Clamp(self[1] % 360, 0, 360), math.Clamp(self[2], 0, 1), math.Clamp(self[3], 0, 1))
 	return wrap({ rgb.r, rgb.g, rgb.b, (rgb.a or 255) })
 end
 
 --- Returns a hexadecimal string representation of the color
--- @param alpha Optional boolean whether to include the alpha channel, False by default
--- @return String hexadecimal color
+-- @param boolean? alpha Optional boolean whether to include the alpha channel, False by default
+-- @return string String hexadecimal color
 function color_methods:toHex(alpha)
 	if alpha~=nil then checkluatype(alpha, TYPE_BOOL) end
 	if alpha then
@@ -204,9 +212,9 @@ function color_methods:toHex(alpha)
 	end
 end
 
---- Round the color values. Self-Modifies.
--- @param idp (Default 0) The integer decimal place to round to. 
--- @return nil
+--- Round the color values.
+-- Self-Modifies. Does not return anything
+-- @param number idp (Default 0) The integer decimal place to round to.
 function color_methods:round(idp)
 	self[1] = math.Round(self[1], idp)
 	self[2] = math.Round(self[2], idp)
@@ -215,14 +223,14 @@ function color_methods:round(idp)
 end
 
 --- Copies r,g,b,a from color and returns a new color
--- @return The copy of the color
+-- @return color The copy of the color
 function color_methods:clone()
 	return wrap({ self[1], self[2], self[3], self[4] })
 end
 
 --- Copies r,g,b,a from color to another.
--- @param b The color to copy from.
--- @return nil
+-- Self-Modifies. Does not return anything
+-- @param color b The color to copy from.
 function color_methods:set(b)
 	self[1] = b[1]
 	self[2] = b[2]
@@ -230,33 +238,33 @@ function color_methods:set(b)
 	self[4] = b[4]
 end
 
---- Set's the color's red channel and returns it.
--- @param r The red
--- @return The modified color
+--- Set's the color's red channel and returns self.
+-- @param number r The red
+-- @return color Color after modification
 function color_methods:setR(r)
 	self[1] = r
 	return self
 end
 
---- Set's the color's green and returns it.
--- @param g The green
--- @return The modified color
+--- Set's the color's green and returns self.
+-- @param number g The green
+-- @return color Color after modification
 function color_methods:setG(g)
 	self[2] = g
 	return self
 end
 
---- Set's the color's blue and returns it.
--- @param b The blue
--- @return The modified color
+--- Set's the color's blue and returns self.
+-- @param number b The blue
+-- @return color Color after modification
 function color_methods:setB(b)
 	self[3] = b
 	return self
 end
 
 --- Set's the color's alpha and returns it.
--- @param a The alpha
--- @return The modified color
+-- @param number a The alpha
+-- @return color Color after modification
 function color_methods:setA(a)
 	self[4] = a
 	return self

--- a/lua/starfall/libs_sh/coroutine.lua
+++ b/lua/starfall/libs_sh/coroutine.lua
@@ -58,8 +58,8 @@ local function createCoroutine(func)
 end
 
 --- Creates a new coroutine.
--- @param func Function of the coroutine
--- @return coroutine
+-- @param function func Function of the coroutine
+-- @return thread Created coroutine
 function coroutine_library.create(func)
 	checkluatype (func, TYPE_FUNCTION)
 	local wrappedFunc, wrappedThread = createCoroutine(func)
@@ -67,8 +67,8 @@ function coroutine_library.create(func)
 end
 
 --- Creates a new coroutine.
--- @param func Function of the coroutine
--- @return A function that, when called, resumes the created coroutine. Any parameters to that function will be passed to the coroutine.
+-- @param function func Function of the coroutine
+-- @return function A function that, when called, resumes the created coroutine. Any parameters to that function will be passed to the coroutine.
 function coroutine_library.wrap(func)
 	checkluatype (func, TYPE_FUNCTION)
 	local wrappedFunc, wrappedThread = createCoroutine(func)
@@ -77,16 +77,16 @@ end
 
 --- Resumes a suspended coroutine. Note that, in contrast to Lua's native coroutine.resume function, it will not run in protected mode and can throw an error.
 -- @param thread coroutine to resume
--- @param ... optional parameters that will be passed to the coroutine
--- @return Any values the coroutine is returning to the main thread
+-- @param ... args Optional parameters that will be passed to the coroutine
+-- @return ... Any values the coroutine is returning to the main thread
 function coroutine_library.resume(thread, ...)
 	local func = unwrap(thread).func
 	return func(...)
 end
 
 --- Suspends the currently running coroutine. May not be called outside a coroutine.
--- @param ... optional parameters that will be returned to the main thread
--- @return Any values passed to the coroutine
+-- @param ... Optional parameters that will be returned to the main thread
+-- @return ... Any values passed to the coroutine
 function coroutine_library.yield(...)
 	local curthread = coroutine.running()
 	if curthread and coroutines[curthread] then
@@ -97,22 +97,22 @@ function coroutine_library.yield(...)
 end
 
 --- Returns the status of the coroutine.
--- @param thread The coroutine
--- @return Either "suspended", "running", "normal" or "dead"
+-- @param thread coroutine The coroutine
+-- @return string Either "suspended", "running", "normal" or "dead"
 function coroutine_library.status(thread)
 	local thread = unwrap(thread).thread
 	return coroutine.status(thread)
 end
 
 --- Returns the coroutine that is currently running.
--- @return Currently running coroutine
+-- @return thread Currently running coroutine
 function coroutine_library.running()
 	local thread = coroutine.running()
 	return coroutines[thread]
 end
 
 --- Suspends the coroutine for a number of seconds. Note that the coroutine will not resume automatically, but any attempts to resume the coroutine while it is waiting will not resume the coroutine and act as if the coroutine suspended itself immediately.
--- @param time Time in seconds to suspend the coroutine
+-- @param number time Time in seconds to suspend the coroutine
 function coroutine_library.wait(time)
 	local curthread = coroutine.running()
 	if curthread and coroutines[curthread] then

--- a/lua/starfall/libs_sh/effect.lua
+++ b/lua/starfall/libs_sh/effect.lua
@@ -43,13 +43,13 @@ instance:AddHook("initialize", function()
 end)
 
 --- Creates an effect data structure
--- @return Effect Object
+-- @return effect Effect Object
 function effect_library.create()
 	return wrap(EffectData())
 end
 
 --- Returns number of effects able to be created
--- @return number of effects able to be created
+-- @return number Number of effects able to be created
 function effect_library.effectsLeft()
 	return plyEffectBurst:check(instance.player)
 end
@@ -61,216 +61,219 @@ function effect_library.canCreate()
 end
 
 --- Plays the effect
--- @param eff The effect type to play
+-- @param effect eff The effect type to play
 function effect_methods:play(eff)
 	checkluatype(eff, TYPE_STRING)
-	
+
 	checkpermission(instance, nil, "effect.play")
 	plyEffectBurst:use(instance.player, 1)
-	
+
 	if effect_blacklist[eff] then SF.Throw("Effect ("..eff..") is blacklisted", 2) end
 
 	util.Effect(eff,unwrap(self))
 end
 
 --- Returns the effect's angle
--- @return the effect's angle
+-- @return angle The effect's angle
 function effect_methods:getAngles()
 	return awrap(unwrap(self):GetAngles())
 end
 
 --- Returns the effect's attachment
--- @return the effect's attachment
+-- @return number The effect's attachment ID
 function effect_methods:getAttachment()
 	return unwrap(self):GetAttachment()
 end
 
---- Returns the effect's color
--- @return the effect's color
+--- Returns byte which represents the color of the effect.
+-- @return number The effect's color as a byte
 function effect_methods:getColor()
 	return unwrap(self):GetColor()
 end
 
 --- Returns the effect's damagetype
--- @return the effect's damagetype
+-- @return number The effect's damagetype
 function effect_methods:getDamageType()
 	return unwrap(self):GetDamageType()
 end
 
 --- Returns the effect's entindex
--- @return the effect's entindex
+-- @return number The effect's entindex
 function effect_methods:getEntIndex()
 	return unwrap(self):GetEntIndex()
 end
 
 --- Returns the effect's entity
--- @return the effect's entity
+-- @return entity The effect's entity
 function effect_methods:getEntity()
 	return ewrap(unwrap(self):GetEntity())
 end
 
 --- Returns the effect's flags
--- @return the effect's flags
+-- @return number The effect's flags
 function effect_methods:getFlags()
 	return unwrap(self):GetFlags()
 end
 
---- Returns the effect's hitbox
--- @return the effect's hitbox
+--- Returns the effect's hitbox ID
+-- @return number The effect's hitbox ID
 function effect_methods:getHitBox()
 	return unwrap(self):GetHitBox()
 end
 
 --- Returns the effect's magnitude
--- @return the effect's magnitude
+-- @return number The effect's magnitude
 function effect_methods:getMagnitude()
 	return unwrap(self):GetMagnitude()
 end
 
 --- Returns the effect's material index
--- @return the effect's material index
+-- @return number The effect's material index
 function effect_methods:getMaterialIndex()
 	return unwrap(self):GetMaterialIndex()
 end
 
 --- Returns the effect's normal
--- @return the effect's normal
+-- @return vector The effect's normal
 function effect_methods:getNormal()
 	return vwrap(unwrap(self):GetNormal())
 end
 
 --- Returns the effect's origin
--- @return the effect's origin
+-- @return vector The effect's origin
 function effect_methods:getOrigin()
 	return vwrap(unwrap(self):GetOrigin())
 end
 
 --- Returns the effect's radius
--- @return the effect's radius
+-- @return number The effect's radius
 function effect_methods:getRadius()
 	return unwrap(self):GetRadius()
 end
 
 --- Returns the effect's scale
--- @return the effect's scale
+-- @return number The effect's scale
 function effect_methods:getScale()
 	return unwrap(self):GetScale()
 end
 
 --- Returns the effect's start position
--- @return the effect's start position
+-- @return vector The effect's start position
 function effect_methods:getStart()
 	return vwrap(unwrap(self):GetStart())
 end
 
 --- Returns the effect's surface prop
--- @return the effect's surface prop
+-- @return number The effect's surface property index
 function effect_methods:getSurfaceProp()
 	return unwrap(self):GetSurfaceProp()
 end
 
 --- Sets the effect's angles
--- @param ang The angles
+-- @param angle ang The angles
 function effect_methods:setAngles(ang)
 	unwrap(self):SetAngles(aunwrap(ang))
 end
 
 --- Sets the effect's attachment
--- @param attachment The attachment
+-- @param number attachment The new attachment ID of the effect
 function effect_methods:setAttachment(attachment)
 	checkluatype(attachment, TYPE_NUMBER)
 	unwrap(self):SetAttachment(attachment)
 end
 
 --- Sets the effect's color
--- @param color The color represented by a byte 0-255. wtf?
+-- Internally stored as an integer, but only first 8 bits are networked, effectively limiting this function to 0-255 range.
+-- @param number color The color represented by a byte 0-255.
 function effect_methods:setColor(color)
 	checkluatype(color, TYPE_NUMBER)
 	unwrap(self):SetColor(color)
 end
 
 --- Sets the effect's damage type
--- @param dmgtype The damage type
+-- @param number dmgtype The damage type, see the DMG enums
 function effect_methods:setDamageType(dmgtype)
 	checkluatype(dmgtype, TYPE_NUMBER)
 	unwrap(self):SetDamageType(dmgtype)
 end
 
 --- Sets the effect's entity index
--- @param index The entity index
+-- @param number index The entity index
 function effect_methods:setEntIndex(index)
 	checkluatype(index, TYPE_NUMBER)
 	unwrap(self):SetEntIndex(index)
 end
 
 --- Sets the effect's entity
--- @param ent The entity
+-- @param entity ent The entity
 function effect_methods:setEntity(ent)
 	unwrap(self):SetEntity(getent(ent))
 end
 
 --- Sets the effect's flags
--- @param flags The flags
+-- @param number flags The flags
 function effect_methods:setFlags(flags)
 	checkluatype(flags, TYPE_NUMBER)
 	unwrap(self):SetFlags(flags)
 end
 
 --- Sets the effect's hitbox
--- @param hitbox The hitbox
+-- @param number hitbox The hitbox
 function effect_methods:setHitBox(hitbox)
 	checkluatype(hitbox, TYPE_NUMBER)
 	unwrap(self):SetHitBox(hitbox)
 end
 
 --- Sets the effect's magnitude
--- @param magnitude The magnitude
+-- @param number magnitude The magnitude
 function effect_methods:setMagnitude(magnitude)
 	checkluatype(magnitude, TYPE_NUMBER)
 	unwrap(self):SetMagnitude(magnitude)
 end
 
 --- Sets the effect's material index
--- @param mat The material index
+-- @param number mat The material index
 function effect_methods:setMaterialIndex(mat)
 	checkluatype(mat, TYPE_NUMBER)
 	unwrap(self):SetMaterialIndex(mat)
 end
 
 --- Sets the effect's normal
--- @param normal The vector normal
+-- @param vector normal The vector normal
 function effect_methods:setNormal(normal)
 	unwrap(self):SetNormal(vunwrap(normal))
 end
 
 --- Sets the effect's origin
--- @param origin The vector origin
+-- @param vector origin The vector origin
 function effect_methods:setOrigin(origin)
 	unwrap(self):SetOrigin(vunwrap(origin))
 end
 
 --- Sets the effect's radius
--- @param radius The radius
+-- @param number radius The radius
 function effect_methods:setRadius(radius)
 	checkluatype(radius, TYPE_NUMBER)
 	unwrap(self):SetRadius(radius)
 end
 
 --- Sets the effect's scale
--- @param scale The number scale
+-- @param number scale The number scale
 function effect_methods:setScale(scale)
 	checkluatype(scale, TYPE_NUMBER)
 	unwrap(self):SetScale(scale)
 end
 
---- Sets the effect's start
--- @param start The vector start
+--- Sets the effect's start pos
+-- Limited to world bounds (+-16386 on every axis) and has horrible networking precision. (17 bit float per component)
+-- @param vector start The vector start
 function effect_methods:setStart(start)
 	unwrap(self):SetStart(vunwrap(start))
 end
 
 --- Sets the effect's surface property
--- @param prop The surface property
+-- Internally stored as an integer, but only first 8 bits are networked, effectively limiting this function to -1-254 range.(yes, that's not a mistake)
+-- @param number prop The surface property index
 function effect_methods:setSurfaceProp(prop)
 	checkluatype(prop, TYPE_NUMBER)
 	unwrap(self):SetSurfaceProp(prop)

--- a/lua/starfall/libs_sh/effect.lua
+++ b/lua/starfall/libs_sh/effect.lua
@@ -43,7 +43,7 @@ instance:AddHook("initialize", function()
 end)
 
 --- Creates an effect data structure
--- @return effect Effect Object
+-- @return Effect Effect Object
 function effect_library.create()
 	return wrap(EffectData())
 end
@@ -61,7 +61,7 @@ function effect_library.canCreate()
 end
 
 --- Plays the effect
--- @param effect eff The effect type to play
+-- @param Effect eff The effect type to play
 function effect_methods:play(eff)
 	checkluatype(eff, TYPE_STRING)
 
@@ -74,7 +74,7 @@ function effect_methods:play(eff)
 end
 
 --- Returns the effect's angle
--- @return angle The effect's angle
+-- @return Angle The effect's angle
 function effect_methods:getAngles()
 	return awrap(unwrap(self):GetAngles())
 end
@@ -104,7 +104,7 @@ function effect_methods:getEntIndex()
 end
 
 --- Returns the effect's entity
--- @return entity The effect's entity
+-- @return Entity The effect's entity
 function effect_methods:getEntity()
 	return ewrap(unwrap(self):GetEntity())
 end
@@ -134,13 +134,13 @@ function effect_methods:getMaterialIndex()
 end
 
 --- Returns the effect's normal
--- @return vector The effect's normal
+-- @return Vector The effect's normal
 function effect_methods:getNormal()
 	return vwrap(unwrap(self):GetNormal())
 end
 
 --- Returns the effect's origin
--- @return vector The effect's origin
+-- @return Vector The effect's origin
 function effect_methods:getOrigin()
 	return vwrap(unwrap(self):GetOrigin())
 end
@@ -158,7 +158,7 @@ function effect_methods:getScale()
 end
 
 --- Returns the effect's start position
--- @return vector The effect's start position
+-- @return Vector The effect's start position
 function effect_methods:getStart()
 	return vwrap(unwrap(self):GetStart())
 end
@@ -170,7 +170,7 @@ function effect_methods:getSurfaceProp()
 end
 
 --- Sets the effect's angles
--- @param angle ang The angles
+-- @param Angle ang The angles
 function effect_methods:setAngles(ang)
 	unwrap(self):SetAngles(aunwrap(ang))
 end
@@ -205,7 +205,7 @@ function effect_methods:setEntIndex(index)
 end
 
 --- Sets the effect's entity
--- @param entity ent The entity
+-- @param Entity ent The entity
 function effect_methods:setEntity(ent)
 	unwrap(self):SetEntity(getent(ent))
 end
@@ -239,13 +239,13 @@ function effect_methods:setMaterialIndex(mat)
 end
 
 --- Sets the effect's normal
--- @param vector normal The vector normal
+-- @param Vector normal The vector normal
 function effect_methods:setNormal(normal)
 	unwrap(self):SetNormal(vunwrap(normal))
 end
 
 --- Sets the effect's origin
--- @param vector origin The vector origin
+-- @param Vector origin The vector origin
 function effect_methods:setOrigin(origin)
 	unwrap(self):SetOrigin(vunwrap(origin))
 end
@@ -266,7 +266,7 @@ end
 
 --- Sets the effect's start pos
 -- Limited to world bounds (+-16386 on every axis) and has horrible networking precision. (17 bit float per component)
--- @param vector start The vector start
+-- @param Vector start The vector start
 function effect_methods:setStart(start)
 	unwrap(self):SetStart(vunwrap(start))
 end

--- a/lua/starfall/libs_sh/entities.lua
+++ b/lua/starfall/libs_sh/entities.lua
@@ -1469,7 +1469,7 @@ end
 --- Gets a networked variable of an entity
 -- @shared
 -- @param string key The string key to get
--- @return any The object associated with that key or nil if it's not set
+-- @return any? The object associated with that key or nil if it's not set
 function ents_methods:getNWVar(key)
 	checkluatype(key, TYPE_STRING)
 	-- GetNW* returns whatever the key is tied to regardless of the function name

--- a/lua/starfall/libs_sh/entities.lua
+++ b/lua/starfall/libs_sh/entities.lua
@@ -1469,7 +1469,7 @@ end
 --- Gets a networked variable of an entity
 -- @shared
 -- @param string key The string key to get
--- @return any? The object associated with that key or nil if it's not set
+-- @return any The object associated with that key or nil if it's not set
 function ents_methods:getNWVar(key)
 	checkluatype(key, TYPE_STRING)
 	-- GetNW* returns whatever the key is tied to regardless of the function name

--- a/lua/starfall/libs_sh/entities.lua
+++ b/lua/starfall/libs_sh/entities.lua
@@ -40,7 +40,8 @@ local function getent(self)
 end
 instance.Types.Entity.GetEntity = getent
 
---- To string
+--- Gets the string representation of the entity
+-- @return string String representation of the entity
 function ent_meta:__tostring()
 	local ent = eunwrap(self)
 	if not ent then return "(null entity)"
@@ -50,7 +51,7 @@ end
 -- ------------------------- Methods ------------------------- --
 
 --- Gets the owner of the entity
--- @return Owner
+-- @return Entity Owner
 function ents_methods:getOwner()
 	local ent = getent(self)
 
@@ -62,8 +63,8 @@ end
 if CLIENT then
 	--- Allows manipulation of an entity's bones' positions
 	-- @client
-	-- @param bone The bone ID
-	-- @param vec The position it should be manipulated to
+	-- @param number bone The bone ID
+	-- @param Vector vec The position it should be manipulated to
 	function ents_methods:manipulateBonePosition(bone, vec)
 		checkluatype(bone, TYPE_NUMBER)
 		local ent = getent(self)
@@ -73,8 +74,8 @@ if CLIENT then
 
 	--- Allows manipulation of an entity's bones' scale
 	-- @client
-	-- @param bone The bone ID
-	-- @param vec The scale it should be manipulated to
+	-- @param number bone The bone ID
+	-- @param Vector vec The scale it should be manipulated to
 	function ents_methods:manipulateBoneScale(bone, vec)
 		checkluatype(bone, TYPE_NUMBER)
 		local ent = getent(self)
@@ -84,8 +85,8 @@ if CLIENT then
 
 	--- Allows manipulation of an entity's bones' angles
 	-- @client
-	-- @param bone The bone ID
-	-- @param ang The angle it should be manipulated to
+	-- @param number bone The bone ID
+	-- @param Angle ang The angle it should be manipulated to
 	function ents_methods:manipulateBoneAngles(bone, ang)
 		checkluatype(bone, TYPE_NUMBER)
 		local ent = getent(self)
@@ -95,8 +96,8 @@ if CLIENT then
 
 	--- Allows manipulation of an entity's bones' jiggle status
 	-- @client
-	-- @param bone The bone ID
-	-- @param enabled Whether to make the bone jiggly or not
+	-- @param number bone The bone ID
+	-- @param boolean enabled Whether to make the bone jiggly or not
 	function ents_methods:manipulateBoneJiggle(bone, state)
 		checkluatype(bone, TYPE_NUMBER)
 		local ent = getent(self)
@@ -106,7 +107,7 @@ if CLIENT then
 
 	--- Sets a hologram or custom_prop model to a custom Mesh
 	-- @client
-	-- @param mesh The mesh to set it to or nil to set back to normal
+	-- @param mesh? mesh The mesh to set it to or nil to set back to normal
 	function ents_methods:setMesh(mesh)
 		local ent = getent(self)
 		if not ent.IsSFHologram and not ent.IsSFProp then SF.Throw("The entity isn't a hologram or custom-prop", 2) end
@@ -123,7 +124,7 @@ if CLIENT then
 
 	--- Sets a hologram or custom_prop's custom mesh material
 	-- @client
-	-- @param material The material to set it to or nil to set back to default
+	-- @param Material? material The material to set it to or nil to set back to default
 	function ents_methods:setMeshMaterial(material)
 		local ent = getent(self)
 		if not ent.IsSFHologram and not ent.IsSFProp then SF.Throw("The entity isn't a hologram or custom-prop", 2) end
@@ -139,8 +140,8 @@ if CLIENT then
 
 	--- Sets a hologram or custom_prop's renderbounds
 	-- @client
-	-- @param mins The lower bounding corner coordinate local to the hologram
-	-- @param maxs The upper bounding corner coordinate local to the hologram
+	-- @param Vector mins The lower bounding corner coordinate local to the hologram
+	-- @param Vector maxs The upper bounding corner coordinate local to the hologram
 	function ents_methods:setRenderBounds(mins, maxs)
 		local ent = getent(self)
 		if not ent.IsSFHologram and not ent.IsSFProp then SF.Throw("The entity isn't a hologram or custom-prop", 2) end
@@ -152,7 +153,7 @@ if CLIENT then
 		ent:SetRenderBounds(mins, maxs)
 		ent.sf_userrenderbounds = {mins, maxs}
 	end
-	
+
 	local canDrawEntity = SF.CanDrawEntity
 	--- Returns whether or not the entity can be drawn using Entity.draw function
 	-- Checks Entity against a predefined class whitelist
@@ -161,14 +162,14 @@ if CLIENT then
 	function ents_methods:canDraw()
 		return canDrawEntity(getent(self))
 	end
-	
+
 	--- Draws the entity, requires 3D rendering context
 	-- Only certain, whitelisted entities can be drawn. They can't be parented or have RenderOverride defined
 	-- Use Entity.canDraw to check if you can draw the entity
 	-- @client
 	function ents_methods:draw()
 		if not instance.data.render.isRendering then SF.Throw("Not in rendering hook.", 2) end
-		
+
 		local ent = getent(self)
 		if not canDrawEntity(ent) then SF.Throw("Can't draw this entity.", 2) end
 		ent:SetupBones()
@@ -183,11 +184,11 @@ local soundsByEntity = SF.EntityTable("emitSoundsByEntity", function(e, t)
 end, true)
 
 --- Plays a sound on the entity
--- @param snd string Sound path
--- @param lvl number soundLevel=75
--- @param pitch pitchPercent=100
--- @param volume volume=1
--- @param channel channel=CHAN_AUTO
+-- @param string snd Sound path
+-- @param number soundLevel Default 75
+-- @param number pitchPercent Default 100
+-- @param number volume Default 1
+-- @param number channel Default CHAN_AUTO or CHAN_WEAPON for weapons
 function ents_methods:emitSound(snd, lvl, pitch, volume, channel)
 	checkluatype(snd, TYPE_STRING)
 
@@ -201,7 +202,7 @@ function ents_methods:emitSound(snd, lvl, pitch, volume, channel)
 end
 
 --- Stops a sound on the entity
--- @param snd string Soundscript path. See http://wiki.facepunch.com/gmod/Entity:StopSound
+-- @param string snd string Soundscript path. See http://wiki.facepunch.com/gmod/Entity:StopSound
 function ents_methods:stopSound(snd)
 	checkluatype(snd, TYPE_STRING)
 
@@ -216,7 +217,7 @@ function ents_methods:stopSound(snd)
 end
 
 --- Returns a list of components linked to a processor. Can also return vehicles linked to a HUD, but only through the server.
--- @return A list of components linked to the entity
+-- @return table A list of components linked to the entity
 function ents_methods:getLinkedComponents()
 	local ent = getent(self)
 	local list = {}
@@ -242,7 +243,7 @@ end
 
 --- Sets the color of the entity
 -- @shared
--- @param clr New color
+-- @param Color clr New color
 function ents_methods:setColor(clr)
 
 	local ent = getent(self)
@@ -260,7 +261,7 @@ end
 
 --- Sets the whether an entity should be drawn or not
 -- @shared
--- @param draw Whether to draw the entity or not.
+-- @param boolean draw Whether to draw the entity or not.
 function ents_methods:setNoDraw(draw)
 	local ent = getent(self)
 	checkpermission(instance, ent, "entities.setRenderProperty")
@@ -270,7 +271,7 @@ end
 
 --- Sets the material of the entity
 -- @shared
--- @param material, string, New material name.
+-- @param string material New material name.
 function ents_methods:setMaterial(material)
 	checkluatype(material, TYPE_STRING)
 	if SF.CheckMaterial(material) == false then SF.Throw("This material is invalid", 2) end
@@ -288,12 +289,12 @@ end
 
 --- Sets the submaterial of the entity
 -- @shared
--- @param index, number, submaterial index.
--- @param material, string, New material name.
+-- @param number index Submaterial index.
+-- @param string material New material name.
 function ents_methods:setSubMaterial(index, material)
 	checkluatype(material, TYPE_STRING)
 	if SF.CheckMaterial(material) == false then SF.Throw("This material is invalid", 2) end
-	
+
 	index = math.Clamp(index, 0, 255)
 	local ent = getent(self)
 	if SERVER and ent == instance.player then
@@ -310,8 +311,8 @@ end
 
 --- Sets the bodygroup of the entity
 -- @shared
--- @param bodygroup Number, The ID of the bodygroup you're setting.
--- @param value Number, The value you're setting the bodygroup to.
+-- @param number bodygroup The ID of the bodygroup you're setting.
+-- @param number value The value you're setting the bodygroup to.
 function ents_methods:setBodygroup(bodygroup, value)
 	checkluatype(bodygroup, TYPE_NUMBER)
 	checkluatype(value, TYPE_NUMBER)
@@ -328,8 +329,8 @@ end
 
 --- Returns the bodygroup value of the entity with given index
 -- @shared
--- @param id The bodygroup's number index
--- @return The bodygroup value
+-- @param number id The bodygroup's number index
+-- @return number The bodygroup value
 function ents_methods:getBodygroup(id)
 	checkluatype(id, TYPE_NUMBER)
 	return getent(self):GetBodygroup(id)
@@ -337,15 +338,15 @@ end
 
 --- Returns a list of all bodygroups of the entity
 -- @shared
--- @return Bodygroups as a table of BodyGroupDatas. https://wiki.facepunch.com/gmod/Structures/BodyGroupData
+-- @return table Bodygroups as a table of BodyGroupDatas. https://wiki.facepunch.com/gmod/Structures/BodyGroupData
 function ents_methods:getBodygroups()
 	return getent(self):GetBodyGroups()
 end
 
 --- Returns the bodygroup index of the entity with given name
 -- @shared
--- @param name The bodygroup's string name
--- @return The bodygroup index
+-- @param string name The bodygroup's string name
+-- @return number The bodygroup index
 function ents_methods:lookupBodygroup(name)
 	checkluatype(name, TYPE_STRING)
 	return getent(self):FindBodygroupByName(name)
@@ -353,8 +354,8 @@ end
 
 --- Returns the bodygroup name of the entity with given index
 -- @shared
--- @param id The bodygroup's number index
--- @return The bodygroup name
+-- @param number id The bodygroup's number index
+-- @return string The bodygroup name
 function ents_methods:getBodygroupName(id)
 	checkluatype(id, TYPE_NUMBER)
 	return getent(self):GetBodygroupName(id)
@@ -362,7 +363,7 @@ end
 
 --- Sets the skin of the entity
 -- @shared
--- @param skinIndex Number, Index of the skin to use.
+-- @param number skinIndex Index of the skin to use.
 function ents_methods:setSkin(skinIndex)
 	checkluatype(skinIndex, TYPE_NUMBER)
 
@@ -378,14 +379,14 @@ end
 
 --- Gets the skin number of the entity
 -- @shared
--- @return Skin number
+-- @return number Skin number
 function ents_methods:getSkin()
 	return getent(self):GetSkin()
 end
 
 --- Returns the amount of skins of the entity
 -- @shared
--- @return The amount of skins
+-- @return number The amount of skins
 function ents_methods:getSkinCount()
 	return getent(self):SkinCount()
 end
@@ -393,7 +394,7 @@ end
 --- Sets the render mode of the entity
 -- @shared
 -- @class function
--- @param rendermode Number, rendermode to use. http://wiki.facepunch.com/gmod/Enums/RENDERMODE
+-- @param number rendermode Rendermode to use. http://wiki.facepunch.com/gmod/Enums/RENDERMODE
 function ents_methods:setRenderMode(rendermode)
 	checkluatype(rendermode, TYPE_NUMBER)
 
@@ -411,7 +412,7 @@ end
 --- Gets the render mode of the entity
 -- @shared
 -- @class function
--- @return Number render mode, https://wiki.facepunch.com/gmod/Enums/RENDERMODE
+-- @return number rendermode https://wiki.facepunch.com/gmod/Enums/RENDERMODE
 function ents_methods:getRenderMode()
 	return getent(self):GetRenderMode()
 end
@@ -419,7 +420,7 @@ end
 --- Sets the renderfx of the entity, most effects require entity's alpha to be less than 255 to take effect
 -- @shared
 -- @class function
--- @param renderfx Number, renderfx to use. http://wiki.facepunch.com/gmod/Enums/kRenderFx
+-- @param number renderfx Renderfx to use. http://wiki.facepunch.com/gmod/Enums/kRenderFx
 function ents_methods:setRenderFX(renderfx)
 	checkluatype(renderfx, TYPE_NUMBER)
 
@@ -437,44 +438,45 @@ end
 --- Gets the renderfx of the entity
 -- @shared
 -- @class function
--- @return Number renderfx, https://wiki.facepunch.com/gmod/Enums/kRenderFx
+-- @return number Renderfx, https://wiki.facepunch.com/gmod/Enums/kRenderFx
 function ents_methods:getRenderFX()
 	return getent(self):GetRenderFX()
 end
 
 --- Gets the parent of an entity
 -- @shared
--- @return Entity's parent or nil
+-- @return Entity? Entity's parent or nil if not parented
 function ents_methods:getParent()
 	return ewrap(getent(self):GetParent())
 end
 
 --- Gets the children (the parented entities) of an entity
 -- @shared
--- @return table of parented children
+-- @return table Table of parented children
 function ents_methods:getChildren()
 	return instance.Sanitize(getent(self):GetChildren())
 end
 
 --- Gets the attachment index the entity is parented to
 -- @shared
--- @return number index of the attachment the entity is parented to or 0
+-- @return number Index of the attachment the entity is parented to or 0
 function ents_methods:getAttachmentParent()
 	return getent(self):GetParentAttachment()
 end
 
 --- Gets the attachment index via the entity and it's attachment name
 -- @shared
--- @param name
--- @return number of the attachment index, or 0 if it doesn't exist
+-- @param string name of the attachment to lookup
+-- @return number Number of the attachment index, or 0 if it doesn't exist
 function ents_methods:lookupAttachment(name)
 	return getent(self):LookupAttachment(name)
 end
 
 --- Gets the position and angle of an attachment
 -- @shared
--- @param index The index of the attachment
--- @return vector position, and angle orientation or nil if the attachment doesn't exist
+-- @param number index The index of the attachment
+-- @return Vector? Position, nil if the attachment doesn't exist
+-- @return Angle? Orientation, nil if the attachment doesn't exist
 function ents_methods:getAttachment(index)
 	local t = getent(self):GetAttachment(index)
 	if t then
@@ -484,45 +486,45 @@ end
 
 --- Returns a table of attachments
 -- @shared
--- @return table of attachment id and attachment name or nil
+-- @return table? Table of attachment id and attachment name or nil
 function ents_methods:getAttachments()
 	return getent(self):GetAttachments()
 end
 
 --- Gets the collision group enum of the entity
--- @return The collision group enum of the entity. https://wiki.facepunch.com/gmod/Enums/COLLISION_GROUP
+-- @return number The collision group enum of the entity. https://wiki.facepunch.com/gmod/Enums/COLLISION_GROUP
 function ents_methods:getCollisionGroup()
 	return getent(self):GetCollisionGroup()
 end
 
 --- Gets the movetype enum of the entity
--- @return The movetype enum of the entity. https://wiki.facepunch.com/gmod/Enums/MOVETYPE
+-- @return number The movetype enum of the entity. https://wiki.facepunch.com/gmod/Enums/MOVETYPE
 function ents_methods:getMoveType()
 	return getent(self):GetMoveType()
 end
 
 --- Converts a ragdoll bone id to the corresponding physobject id
--- @param boneid The ragdoll boneid
--- @return The physobj id
+-- @param number boneid The ragdoll boneid
+-- @return number The physobj id
 function ents_methods:translateBoneToPhysBone(boneid)
 	return getent(self):TranslateBoneToPhysBone(boneid)
 end
 
 --- Converts a physobject id to the corresponding ragdoll bone id
--- @param boneid The physobject id
--- @return The ragdoll bone id
+-- @param number boneid The physobject id
+-- @return number The ragdoll bone id
 function ents_methods:translatePhysBoneToBone(boneid)
 	return getent(self):TranslatePhysBoneToBone(boneid)
 end
 
 --- Gets the number of physicsobjects of an entity
--- @return The number of physics objects on the entity
+-- @return PhysObj The number of physics objects on the entity
 function ents_methods:getPhysicsObjectCount()
 	return getent(self):GetPhysicsObjectCount()
 end
 
 --- Gets the main physics objects of an entity
--- @return The main physics object of the entity
+-- @return PhysObj The main physics object of the entity
 function ents_methods:getPhysicsObject()
 	local ent = getent(self)
 	if ent:IsWorld() then SF.Throw("Cannot get the world physobj.", 2) end
@@ -530,39 +532,39 @@ function ents_methods:getPhysicsObject()
 end
 
 --- Gets a physics objects of an entity
--- @param id The physics object id (starts at 0)
--- @return The physics object of the entity
+-- @param number id The physics object id (starts at 0)
+-- @return PhysObj The physics object of the entity
 function ents_methods:getPhysicsObjectNum(id)
 	checkluatype(id, TYPE_NUMBER)
 	return pwrap(getent(self):GetPhysicsObjectNum(id))
 end
 
 --- Returns the elasticity of the entity
--- @return number elasticity
+-- @return number Elasticity
 function ents_methods:getElasticity()
 	return getent(self):GetElasticity()
 end
 
 --- Gets the color of an entity
 -- @shared
--- @return Color
+-- @return Color Color
 function ents_methods:getColor()
 	return cwrap(getent(self):GetColor())
 end
 
 --- Gets the clipping of an entity
 -- @shared
--- @return Table containing the clipdata
+-- @return table Table containing the clipdata
 function ents_methods:getClipping()
 	local ent = getent(self)
-	
+
 	local clips = {}
-	
+
 	-- Clips from visual clip tool
 	if ent.ClipData then
 		for i, clip in pairs(ent.ClipData) do
 			local normal = (clip[1] or clip.n):Forward()
-			
+
 			table.insert(clips, {
 				local_ent = self,
 				origin = vwrap((clip[4] or Vector()) + normal * (clip[2] or clip.d)),
@@ -570,19 +572,19 @@ function ents_methods:getClipping()
 			})
 		end
 	end
-	
+
 	-- Clips from Starfall and E2 holograms
 	if ent.clips then
 		for i, clip in pairs(ent.clips) do
 			if clip.enabled ~= false then
 				local local_ent = false
-				
+
 				if clip.localentid then
 					local_ent = ewrap(Entity(clip.localentid))
 				elseif clip.entity then
 					local_ent = ewrap(clip.entity)
 				end
-				
+
 				table.insert(clips, {
 					local_ent = local_ent,
 					origin = vwrap(clip.origin),
@@ -591,7 +593,7 @@ function ents_methods:getClipping()
 			end
 		end
 	end
-	
+
 	-- Clips from Lemongate and ExpAdv holograms
 	if ent.CLIPS then
 		for i, clip in pairs(ent.CLIPS) do
@@ -604,13 +606,13 @@ function ents_methods:getClipping()
 			end
 		end
 	end
-	
+
 	return clips
 end
 
 --- Checks if an entity is valid.
 -- @shared
--- @return True if valid, false if not
+-- @return boolean True if valid, false if not
 function ents_methods:isValid()
 	local ent = eunwrap(self)
 	if ent and ent:IsValid() then
@@ -622,48 +624,48 @@ end
 
 --- Checks if an entity is a player.
 -- @shared
--- @return True if player, false if not
+-- @return boolean True if player, false if not
 function ents_methods:isPlayer()
 	return getent(self):IsPlayer()
 end
 
 --- Checks if an entity is a weapon.
 -- @shared
--- @return True if weapon, false if not
+-- @return boolean True if weapon, false if not
 function ents_methods:isWeapon()
 	return getent(self):IsWeapon()
 end
 
 --- Checks if an entity is a vehicle.
 -- @shared
--- @return True if vehicle, false if not
+-- @return boolean True if vehicle, false if not
 function ents_methods:isVehicle()
 	return getent(self):IsVehicle()
 end
 
 --- Checks if an entity is an npc.
 -- @shared
--- @return True if npc, false if not
+-- @return boolean True if npc, false if not
 function ents_methods:isNPC()
 	return getent(self):IsNPC()
 end
 
 --- Checks if the entity ONGROUND flag is set
 -- @shared
--- @return Boolean if it's flag is set or not
+-- @return boolean If it's flag is set or not
 function ents_methods:isOnGround()
 	return getent(self):IsOnGround()
 end
 
 --- Returns if the entity is ignited
 -- @shared
--- @return Boolean if the entity is on fire or not
+-- @return boolean If the entity is on fire or not
 function ents_methods:isOnFire()
 	return getent(self):IsOnFire()
 end
 
 --- Returns the starfall or expression2's name
--- @return The name of the chip
+-- @return string The name of the chip
 function ents_methods:getChipName()
 	local ent = getent(self)
 	if ent.GetGateName then
@@ -675,11 +677,11 @@ end
 
 --- Gets the author of the specified starfall.
 -- @shared
--- @return The author of the starfall chip.
+-- @return Entity The author of the starfall chip.
 function ents_methods:getChipAuthor()
 	local ent = getent(self)
 	if not ent.Starfall then SF.Throw("The entity isn't a starfall chip", 2) end
-	
+
 	return ent.author
 end
 
@@ -687,7 +689,7 @@ end
 -- This value increases as more executions are done, may not be exactly as you want.
 -- If used on screens, will show 0 if only rendering is done. Operations must be done in the Think loop for them to be counted.
 -- @shared
--- @return Current quota used this Think
+-- @return number Current quota used this Think
 function ents_methods:getQuotaUsed()
 	local ent = getent(self)
 	if not ent.Starfall then SF.Throw("The entity isn't a starfall chip", 2) end
@@ -697,7 +699,7 @@ end
 
 --- Gets the Average CPU Time in the buffer of the specified starfall or expression2.
 -- @shared
--- @return Average CPU Time of the buffer of the specified starfall or expression2.
+-- @return number Average CPU Time of the buffer of the specified starfall or expression2.
 function ents_methods:getQuotaAverage()
 	local ent = getent(self)
 	if ent.Starfall then
@@ -712,7 +714,7 @@ end
 --- Gets the CPU Time max of the specified starfall of the specified starfall or expression2.
 -- CPU Time is stored in a buffer of N elements, if the average of this exceeds quotaMax, the chip will error.
 -- @shared
--- @return Max SysTime allowed to take for execution of the chip in a Think.
+-- @return number Max SysTime allowed to take for execution of the chip in a Think.
 function ents_methods:getQuotaMax()
 	local ent = getent(self)
 	if ent.Starfall then
@@ -728,54 +730,54 @@ if SERVER then
 	--- Gets all players the specified starfall errored for.
 	-- This excludes the owner of the starfall chip.
 	-- @server
-	-- @return A table containg the errored players.
+	-- @return table A table containg the errored players.
 	function ents_methods:getErroredPlayers()
 		local ent = getent(self)
 		if not ent.Starfall then SF.Throw("The entity isn't a starfall chip", 2) end
-		
+
 		local plys = {}
 		for ply, _ in pairs(ent.ErroredPlayers) do
 			if ply:IsValid() then
 				table.insert(plys, plywrap(ply))
 			end
 		end
-		
+
 		return plys
 	end
 end
 
 --- Returns the EntIndex of the entity
 -- @shared
--- @return The numerical index of the entity
+-- @return number The numerical index of the entity
 function ents_methods:entIndex()
 	return getent(self):EntIndex()
 end
 
 --- Returns the class of the entity
 -- @shared
--- @return The string class name
+-- @return string The string class name
 function ents_methods:getClass()
 	return getent(self):GetClass()
 end
 
 --- Returns the position of the entity
 -- @shared
--- @return The position vector
+-- @return Vector The position vector
 function ents_methods:getPos()
 	return vwrap(getent(self):GetPos())
 end
 
 --- Returns how submerged the entity is in water
 -- @shared
--- @return The water level. 0 none, 1 slightly, 2 at least halfway, 3 all the way
+-- @return number The water level. 0 none, 1 slightly, 2 at least halfway, 3 all the way
 function ents_methods:getWaterLevel()
 	return getent(self):WaterLevel()
 end
 
 --- Returns the ragdoll bone index given a bone name
 -- @shared
--- @param name The bone's string name
--- @return The bone index
+-- @param string name The bone's string name
+-- @return number The bone index
 function ents_methods:lookupBone(name)
 	checkluatype(name, TYPE_STRING)
 	return getent(self):LookupBone(name)
@@ -783,8 +785,8 @@ end
 
 --- Returns the matrix of the entity's bone. Note: this method is slow/doesnt work well if the entity isn't animated.
 -- @shared
--- @param bone Bone index. (def 0)
--- @return The matrix
+-- @param number? bone Bone index. (def 0)
+-- @return VMatrix The matrix
 function ents_methods:getBoneMatrix(bone)
 	if bone == nil then bone = 0 else checkluatype(bone, TYPE_NUMBER) end
 
@@ -793,22 +795,22 @@ end
 
 --- Returns the world transform matrix of the entity
 -- @shared
--- @return The matrix
+-- @return VMatrix The matrix
 function ents_methods:getMatrix()
 	return mwrap(getent(self):GetWorldTransformMatrix())
 end
 
 --- Returns the number of an entity's bones
 -- @shared
--- @return Number of bones
+-- @return number Number of bones
 function ents_methods:getBoneCount()
 	return getent(self):GetBoneCount()
 end
 
 --- Returns the name of an entity's bone
 -- @shared
--- @param bone Bone index. (def 0)
--- @return Name of the bone
+-- @param number? bone Bone index. (def 0)
+-- @return string Name of the bone
 function ents_methods:getBoneName(bone)
 	if bone == nil then bone = 0 else checkluatype(bone, TYPE_NUMBER) end
 	return getent(self):GetBoneName(bone)
@@ -816,8 +818,8 @@ end
 
 --- Returns the parent index of an entity's bone
 -- @shared
--- @param bone Bone index. (def 0)
--- @return Parent index of the bone
+-- @param number? bone Bone index. (def 0)
+-- @return number Parent index of the bone. Returns -1 on error
 function ents_methods:getBoneParent(bone)
 	if bone == nil then bone = 0 else checkluatype(bone, TYPE_NUMBER) end
 	return getent(self):GetBoneParent(bone)
@@ -825,9 +827,9 @@ end
 
 --- Returns the bone's position and angle in world coordinates
 -- @shared
--- @param bone Bone index. (def 0)
--- @return Position of the bone
--- @return Angle of the bone
+-- @param number? bone Bone index. (def 0)
+-- @return Vector Position of the bone
+-- @return Angle Angle of the bone
 function ents_methods:getBonePosition(bone)
 	if bone == nil then bone = 0 else checkluatype(bone, TYPE_NUMBER) end
 	local pos, ang = getent(self):GetBonePosition(bone)
@@ -837,8 +839,8 @@ end
 
 --- Returns the manipulate angle of the bone (relative to its default angle)
 -- @shared
--- @param bone Bone index. (def 0)
--- @return Manipulate angle of the bone
+-- @param number bone Bone index. (def 0)
+-- @return Angle Manipulate angle of the bone
 function ents_methods:getManipulateBoneAngles(bone)
 	if bone == nil then bone = 0 else checkluatype(bone, TYPE_NUMBER) end
 	return awrap(getent(self):GetManipulateBoneAngles(bone))
@@ -846,8 +848,8 @@ end
 
 --- Returns the number manipulate jiggle of the bone (0 - 255)
 -- @shared
--- @param bone Bone index. (def 0)
--- @return Manipulate jiggle of the bone
+-- @param number? bone Bone index. (def 0)
+-- @return number Manipulate jiggle of the bone
 function ents_methods:getManipulateBoneJiggle(bone)
 	if bone == nil then bone = 0 else checkluatype(bone, TYPE_NUMBER) end
 	return getent(self):GetManipulateBoneJiggle(bone)
@@ -855,17 +857,17 @@ end
 
 --- Returns the vector manipulate position of the bone (relative to its default position)
 -- @shared
--- @param bone Bone index. (def 0)
--- @return Manipulate position of the bone
+-- @param number bone Bone index. (def 0)
+-- @return Vector Manipulate position of the bone
 function ents_methods:getManipulateBonePosition(bone)
 	if bone == nil then bone = 0 else checkluatype(bone, TYPE_NUMBER) end
 	return vwrap(getent(self):GetManipulateBonePosition(bone))
 end
 
---- Returns the vector manipulate scale of the bone 
+--- Returns the vector manipulate scale of the bone
 -- @shared
--- @param bone Bone index. (def 0)
--- @return Manipulate scale of the bone
+-- @param number bone Bone index. (def 0)
+-- @return Vector Manipulate scale of the bone
 function ents_methods:getManipulateBoneScale(bone)
 	if bone == nil then bone = 0 else checkluatype(bone, TYPE_NUMBER) end
 	return vwrap(getent(self):GetManipulateBoneScale(bone))
@@ -873,7 +875,7 @@ end
 
 --- Returns the x, y, z size of the entity's outer bounding box (local to the entity)
 -- @shared
--- @return The outer bounding box size
+-- @return Vector The outer bounding box size
 function ents_methods:obbSize()
 	local ent = getent(self)
 	return vwrap(ent:OBBMaxs() - ent:OBBMins())
@@ -881,14 +883,14 @@ end
 
 --- Returns the local position of the entity's outer bounding box
 -- @shared
--- @return The position vector of the outer bounding box center
+-- @return Vector The position vector of the outer bounding box center
 function ents_methods:obbCenter()
 	return vwrap(getent(self):OBBCenter())
 end
 
 --- Returns the world position of the entity's outer bounding box
 -- @shared
--- @return The position vector of the outer bounding box center
+-- @return Vector The position vector of the outer bounding box center
 function ents_methods:obbCenterW()
 	local ent = getent(self)
 	return vwrap(ent:LocalToWorld(ent:OBBCenter()))
@@ -896,30 +898,30 @@ end
 
 --- Returns min local bounding box vector of the entity
 -- @shared
--- @return The min bounding box vector
+-- @return Vector The min bounding box vector
 function ents_methods:obbMins()
 	return vwrap(getent(self):OBBMins())
 end
 
 --- Returns max local bounding box vector of the entity
 -- @shared
--- @return The max bounding box vector
+-- @return Vector The max bounding box vector
 function ents_methods:obbMaxs()
 	return vwrap(getent(self):OBBMaxs())
 end
 
 --- Returns Entity axis aligned bounding box in world coordinates
 -- @shared
--- @return The min bounding box vector
--- @return The max bounding box vector
+-- @return Vector The min bounding box vector
+-- @return Vector The max bounding box vector
 function ents_methods:worldSpaceAABB()
-	local a, b = getent(self):WorldSpaceAABB() 
+	local a, b = getent(self):WorldSpaceAABB()
 	return vwrap(a), vwrap(b)
 end
 
 --- Returns the local position of the entity's mass center
 -- @shared
--- @return The position vector of the mass center
+-- @return Vector The position vector of the mass center
 function ents_methods:getMassCenter()
 	local ent = getent(self)
 	local phys = ent:GetPhysicsObject()
@@ -929,7 +931,7 @@ end
 
 --- Returns the world position of the entity's mass center
 -- @shared
--- @return The position vector of the mass center
+-- @return Vector The position vector of the mass center
 function ents_methods:getMassCenterW()
 	local ent = getent(self)
 	local phys = ent:GetPhysicsObject()
@@ -939,14 +941,14 @@ end
 
 --- Returns the angle of the entity
 -- @shared
--- @return The angle
+-- @return Angle The angle
 function ents_methods:getAngles()
 	return awrap(getent(self):GetAngles())
 end
 
 --- Returns the mass of the entity
 -- @shared
--- @return The numerical mass
+-- @return number The numerical mass
 function ents_methods:getMass()
 	local ent = getent(self)
 	local phys = ent:GetPhysicsObject()
@@ -957,7 +959,7 @@ end
 
 --- Returns the principle moments of inertia of the entity
 -- @shared
--- @return The principle moments of inertia as a vector
+-- @return Vector The principle moments of inertia as a vector
 function ents_methods:getInertia()
 	local ent = getent(self)
 	local phys = ent:GetPhysicsObject()
@@ -968,14 +970,14 @@ end
 
 --- Returns the velocity of the entity
 -- @shared
--- @return The velocity vector
+-- @return Vector The velocity vector
 function ents_methods:getVelocity()
 	return vwrap(getent(self):GetVelocity())
 end
 
 --- Returns the angular velocity of the entity
 -- @shared
--- @return The angular velocity as a vector
+-- @return Vector The angular velocity as a vector
 function ents_methods:getAngleVelocity()
 	local ent = getent(self)
 	local phys = ent:GetPhysicsObject()
@@ -985,7 +987,7 @@ end
 
 --- Returns the angular velocity of the entity
 -- @shared
--- @return The angular velocity as an angle
+-- @return Angle The angular velocity as an angle
 function ents_methods:getAngleVelocityAngle()
 	local ent = getent(self)
 	local phys = ent:GetPhysicsObject()
@@ -996,39 +998,39 @@ end
 
 --- Converts a vector in entity local space to world space
 -- @shared
--- @param data Local space vector
--- @return data as world space vector
+-- @param Vector data Local space vector
+-- @return Vector data as world space vector
 function ents_methods:localToWorld(data)
 	return vwrap(getent(self):LocalToWorld(vunwrap(data)))
 end
 
 --- Converts an angle in entity local space to world space
 -- @shared
--- @param data Local space angle
--- @return data as world space angle
+-- @param Angle data Local space angle
+-- @return Angle data as world space angle
 function ents_methods:localToWorldAngles(data)
 	return awrap(getent(self):LocalToWorldAngles(aunwrap(data)))
 end
 
 --- Converts a vector in world space to entity local space
 -- @shared
--- @param data World space vector
--- @return data as local space vector
+-- @param Vector data World space vector
+-- @return Vector data as local space vector
 function ents_methods:worldToLocal(data)
 	return vwrap(getent(self):WorldToLocal(vunwrap(data)))
 end
 
 --- Converts an angle in world space to entity local space
 -- @shared
--- @param data World space angle
--- @return data as local space angle
+-- @param Angle data World space angle
+-- @return Angle data as local space angle
 function ents_methods:worldToLocalAngles(data)
 	return awrap(getent(self):WorldToLocalAngles(aunwrap(data)))
 end
 
 --- Gets the animation number from the animation name
--- @param animation Name of the animation
--- @return Animation index or -1 if invalid
+-- @param string animation Name of the animation
+-- @return number Animation index or -1 if invalid
 function ents_methods:lookupSequence(animation)
 	checkluatype(animation, TYPE_STRING)
 
@@ -1036,14 +1038,14 @@ function ents_methods:lookupSequence(animation)
 end
 
 --- Gets the current playing sequence
--- @return The sequence number
+-- @return number The sequence number
 function ents_methods:getSequence()
 	return getent(self):GetSequence()
 end
 
 --- Get the length of an animation
--- @param id (Optional) The id of the sequence, or will default to the currently playing sequence
--- @return Length of the animation in seconds
+-- @param number? id (Optional) The id of the sequence, or will default to the currently playing sequence
+-- @return number Length of the animation in seconds
 function ents_methods:sequenceDuration(id)
 	local ent = getent(self)
 	if id~=nil then checkluatype(id, TYPE_NUMBER) end
@@ -1052,8 +1054,8 @@ function ents_methods:sequenceDuration(id)
 end
 
 --- Set the pose value of an animation. Turret/Head angles for example.
--- @param pose Name of the pose parameter
--- @param value Value to set it to.
+-- @param string pose Name of the pose parameter
+-- @param number value Value to set it to.
 function ents_methods:setPose(pose, value)
 	local ent = getent(self)
 	checkpermission(instance, ent, "entities.setRenderProperty")
@@ -1062,13 +1064,14 @@ function ents_methods:setPose(pose, value)
 end
 
 --- Get the pose value of an animation
--- @param pose Pose parameter name
--- @return Value of the pose parameter
+-- @param string pose Pose parameter name
+-- @return number Value of the pose parameter
 function ents_methods:getPose(pose)
 	return getent(self):GetPoseParameter(pose)
 end
 
 --- Returns a table of flexname -> flexid pairs for use in flex functions.
+-- @return table Table of flexes
 function ents_methods:getFlexes()
 	local ent = getent(self)
 	local flexes = {}
@@ -1079,8 +1082,8 @@ function ents_methods:getFlexes()
 end
 
 --- Gets the weight (value) of a flex.
--- @param flexid The id of the flex
--- @return The weight of the flex
+-- @param number flexid The id of the flex
+-- @return number The weight of the flex
 function ents_methods:getFlexWeight(flexid)
 	local ent = getent(self)
 
@@ -1095,21 +1098,21 @@ function ents_methods:getFlexWeight(flexid)
 end
 
 --- Sets the weight (value) of a flex.
--- @param flexid The id of the flex
--- @param weight The weight of the flex
+-- @param number flexid The id of the flex
+-- @param number weight The weight of the flex
 function ents_methods:setFlexWeight(flexid, weight)
 	local ent = getent(self)
 
 	checkluatype(flexid, TYPE_NUMBER)
 	checkluatype(weight, TYPE_NUMBER)
 	flexid = math.floor(flexid)
-	
+
 	if SERVER and ent == instance.player then
 		checkpermission(instance, ent, "entities.setPlayerRenderProperty")
 	else
 		checkpermission(instance, ent, "entities.setRenderProperty")
 	end
-	
+
 	if flexid < 0 or flexid >= ent:GetFlexNum() then
 		SF.Throw("Invalid flex: "..flexid, 2)
 	end
@@ -1118,29 +1121,29 @@ function ents_methods:setFlexWeight(flexid, weight)
 end
 
 --- Gets the scale of the entity flexes
--- @return The scale of the flexes
+-- @return number The scale of the flexes
 function ents_methods:getFlexScale()
 	return getent(self):GetFlexScale()
 end
 
 --- Sets the scale of the entity flexes
--- @param scale The scale of the flexes to set
+-- @param number scale The scale of the flexes to set
 function ents_methods:setFlexScale(scale)
 	local ent = getent(self)
 	checkluatype(scale, TYPE_NUMBER)
-	
+
 	if SERVER and ent == instance.player then
 		checkpermission(instance, ent, "entities.setPlayerRenderProperty")
 	else
 		checkpermission(instance, ent, "entities.setRenderProperty")
 	end
-	
+
 	ent:SetFlexScale(scale)
 end
 
 --- Gets the model of an entity
 -- @shared
--- @return Model of the entity
+-- @return string Model of the entity
 function ents_methods:getModel()
 	return getent(self):GetModel()
 end
@@ -1148,8 +1151,8 @@ end
 --- Returns the entity's model bounds. This is different than the collision bounds/hull.
 -- This is not scaled with Entity:SetModelScale and will return the model's original, unmodified mins and maxs.
 -- @shared
--- @return Minimum vector of the bounds
--- @return Maximum vector of the bounds
+-- @return Vector Minimum vector of the bounds
+-- @return Vector Maximum vector of the bounds
 function ents_methods:getModelBounds()
 	local minvec, maxvec = getent(self):GetModelBounds()
 	return vwrap(minvec), vwrap(maxvec)
@@ -1157,50 +1160,50 @@ end
 
 --- Returns the contents of the entity's current model
 -- @shared
--- @return number contents of the entity's model. https://wiki.facepunch.com/gmod/Enums/CONTENTS
+-- @return number Contents of the entity's model. https://wiki.facepunch.com/gmod/Enums/CONTENTS
 function ents_methods:getModelContents()
 	return getent(self):GetModelContents()
 end
 
 --- Returns the model's radius
 -- @shared
--- @return number radius of the model
+-- @return number Radius of the model
 function ents_methods:getModelRadius()
 	return getent(self):GetModelRadius()
 end
 
 --- Returns the model's scale
 -- @shared
--- @return number scale of the model
+-- @return number Scale of the model
 function ents_methods:getModelScale()
 	return getent(self):GetModelScale()
 end
 
 --- Gets the max health of an entity
 -- @shared
--- @return Max Health of the entity
+-- @return number Max Health of the entity
 function ents_methods:getMaxHealth()
 	return getent(self):GetMaxHealth()
 end
 
 --- Gets the health of an entity
 -- @shared
--- @return Health of the entity
+-- @return number Health of the entity
 function ents_methods:getHealth()
 	return getent(self):Health()
 end
 
---- Gets the entitiy's eye angles
+--- Gets the entity's eye angles
 -- @shared
--- @return Angles of the entity's eyes
+-- @return Angle Angles of the entity's eyes
 function ents_methods:getEyeAngles()
 	return awrap(getent(self):EyeAngles())
 end
 
 --- Gets the entity's eye position
 -- @shared
--- @return Eye position of the entity
--- @return In case of a ragdoll, the position of the second eye
+-- @return Vector Eye position of the entity
+-- @return Vector? In case of a ragdoll, the position of the second eye
 function ents_methods:getEyePos()
 	local pos1, pos2 = getent(self):EyePos()
 	if pos2 then
@@ -1212,7 +1215,7 @@ end
 --- Gets an entities' material
 -- @shared
 -- @class function
--- @return String material
+-- @return string String material
 function ents_methods:getMaterial()
 	return getent(self):GetMaterial() or ""
 end
@@ -1220,64 +1223,64 @@ end
 --- Gets an entities' submaterial
 -- @shared
 -- @class function
--- @param index Number index of the sub material
--- @return String material
+-- @param number index Number index of the sub material
+-- @return string String material
 function ents_methods:getSubMaterial(index)
 	checkluatype(index, TYPE_NUMBER)
 	if index<0 or index>31 then SF.Throw("Index must be an int in range 0 - 31") end
-	
+
 	return getent(self):GetSubMaterial(index) or ""
 end
 
 --- Gets an entities' material list
 -- @shared
 -- @class function
--- @return Material
+-- @return table Material
 function ents_methods:getMaterials()
 	return getent(self):GetMaterials() or {}
 end
 
 --- Gets the entity's up vector
 -- @shared
--- @return Vector up
+-- @return Vector Vector up
 function ents_methods:getUp()
 	return vwrap(getent(self):GetUp())
 end
 
 --- Gets the entity's right vector
 -- @shared
--- @return Vector right
+-- @return Vector Vector right
 function ents_methods:getRight()
 	return vwrap(getent(self):GetRight())
 end
 
 --- Gets the entity's forward vector
 -- @shared
--- @return Vector forward
+-- @return Vector Vector forward
 function ents_methods:getForward()
 	return vwrap(getent(self):GetForward())
 end
 
 --- Returns the timer.curtime() time the entity was created on
 -- @shared
--- @return Seconds relative to server map start
+-- @return number Seconds relative to server map start
 function ents_methods:getCreationTime()
 	return getent(self):GetCreationTime()
 end
 
 --- Checks if an engine effect is applied to the entity
 -- @shared
--- @param effect The effect to check. EF table values
--- @return True or false
+-- @param number effect The effect to check. EF table values
+-- @return boolean True or false
 function ents_methods:isEffectActive(effect)
 	checkluatype(effect, TYPE_NUMBER)
-	
+
 	return getent(self):IsEffectActive(effect)
 end
 
 --- Marks entity as persistent, disallowing players from physgunning it. Persistent entities save on server shutdown when sbox_persist is set
 -- @shared
--- @param persist True to make persistent
+-- @param boolean persist True to make persistent
 function ents_methods:setPersistent(persist)
 	checkluatype(persist, TYPE_BOOL)
 	local ent = getent(self)
@@ -1287,7 +1290,7 @@ end
 
 --- Checks if entity is marked as persistent
 -- @shared
--- @return True if the entity is persistent 
+-- @return boolean True if the entity is persistent
 function ents_methods:getPersistent()
 	return getent(self):GetPersistent()
 end
@@ -1295,17 +1298,17 @@ end
 --- Returns the game assigned owner of an entity. This doesn't take CPPI into account and will return nil for most standard entities.
 -- Used on entities with custom physics like held SWEPs and fired bullets in which case player entity should be returned.
 -- @shared
--- @return Owner
+-- @return Entity Owner
 function ents_methods:entOwner()
 	return owrap(getent(self):GetOwner())
 end
 
 --- Gets the bounds (min and max corners) of a hit box.
 -- @shared
--- @param hitbox The number of the hitbox.
--- @param group The number of the hitbox group, 0 in most cases.
--- @return Hitbox mins vector.
--- @return Hitbox maxs vector.
+-- @param number hitbox The number of the hitbox.
+-- @param number group The number of the hitbox group, 0 in most cases.
+-- @return Vector Hitbox mins vector.
+-- @return Vector Hitbox maxs vector.
 function ents_methods:getHitBoxBounds(hitbox, group)
 	checkluatype(hitbox, TYPE_NUMBER)
 	checkluatype(group, TYPE_NUMBER)
@@ -1317,8 +1320,8 @@ end
 
 --- Gets number of hitboxes in a group.
 -- @shared
--- @param group The number of the hitbox group.
--- @return Number of hitboxes
+-- @param number group The number of the hitbox group.
+-- @return number Number of hitboxes
 function ents_methods:getHitBoxCount(group)
 	checkluatype(group, TYPE_NUMBER)
 	return getent(self):GetHitBoxCount(group)
@@ -1326,9 +1329,9 @@ end
 
 --- Gets the bone the given hitbox is attached to.
 -- @shared
--- @param hitbox The number of the hitbox.
--- @param group The number of the hitbox group, 0 in most cases.
--- @return Bone ID
+-- @param number hitbox The number of the hitbox.
+-- @param number group The number of the hitbox group, 0 in most cases.
+-- @return number Bone ID
 function ents_methods:getHitBoxBone(hitbox, group)
 	checkluatype(hitbox, TYPE_NUMBER)
 	checkluatype(group, TYPE_NUMBER)
@@ -1337,24 +1340,24 @@ end
 
 --- Returns entity's current hit box set.
 -- @shared
--- @return Hitbox set number, nil if entity has no hitboxes.
--- @return Hitbox set name, nil if entity has no hitboxes.
+-- @return number? Hitbox set number, nil if entity has no hitboxes.
+-- @return string? Hitbox set name, nil if entity has no hitboxes.
 function ents_methods:getHitBoxSet()
 	return getent(self):GetHitboxSet()
 end
 
 --- Returns entity's number of hitbox sets.
 -- @shared
--- @return Number of hitbox sets.
+-- @return number Number of hitbox sets.
 function ents_methods:getHitBoxSetCount()
 	return getent(self):GetHitboxSetCount()
 end
 
 --- Gets the hit group of a given hitbox in a given hitbox set.
 -- @shared
--- @param hitbox The number of the hit box.
--- @param hitboxset The number of the hit box set. This should be 0 in most cases.
--- @return The hitbox group of given hitbox. See https://wiki.facepunch.com/gmod/Enums/HITGROUP
+-- @param number hitbox The number of the hit box.
+-- @param number hitboxset The number of the hit box set. This should be 0 in most cases.
+-- @return number The hitbox group of given hitbox. See https://wiki.facepunch.com/gmod/Enums/HITGROUP
 function ents_methods:getHitBoxHitGroup(hitbox, hitboxset)
 	checkluatype(hitbox, TYPE_NUMBER)
 	checkluatype(hitboxset, TYPE_NUMBER)
@@ -1363,7 +1366,7 @@ end
 
 --- Returns a table of brushes surfaces for brush model entities.
 -- @shared
--- @return Table of SurfaceInfos if the entity has a brush model, or no value otherwise.
+-- @return table Table of SurfaceInfos if the entity has a brush model, or no value otherwise.
 function ents_methods:getBrushSurfaces()
 	local t = getent(self):GetBrushSurfaces()
 	if not t then return end
@@ -1376,10 +1379,10 @@ end
 
 --- Returns info about the given brush plane
 -- @shared
--- @param id Plane index. Starts from 0
--- @return The origin of the plane
--- @return The normal of the plane
--- @return The distance to the plane
+-- @param number id Plane index. Starts from 0
+-- @return Vector The origin of the plane
+-- @return Vector The normal of the plane
+-- @return number The distance to the plane
 function ents_methods:getBrushPlane(id)
 	checkluatype(id, TYPE_NUMBER)
 	local origin, normal, distance = getent(self):GetBrushPlane(id)
@@ -1388,15 +1391,15 @@ end
 
 --- Returns the amount of planes of the brush entity
 -- @shared
--- @return The amount of brush planes
+-- @return number The amount of brush planes
 function ents_methods:getBrushPlaneCount()
 	return getent(self):GetBrushPlaneCount()
 end
 
 --- Gets a datatable angle
 -- @shared
--- @param key The number key. Valid keys are 0 - 31
--- @return The angle or nil if it doesn't exist
+-- @param number key The number key. Valid keys are 0 - 31
+-- @return Angle? The angle or nil if it doesn't exist
 function ents_methods:getDTAngle(key)
 	checkluatype(key, TYPE_NUMBER)
 	if key<0 or key>31 then SF.Throw("Key must be a int in range 0 - 31") end
@@ -1405,8 +1408,8 @@ end
 
 --- Gets a datatable boolean
 -- @shared
--- @param key The number key. Valid keys are 0 - 31
--- @return The boolean or nil if it doesn't exist
+-- @param number key The number key. Valid keys are 0 - 31
+-- @return boolean? The boolean or nil if it doesn't exist
 function ents_methods:getDTBool(key)
 	checkluatype(key, TYPE_NUMBER)
 	if key<0 or key>31 then SF.Throw("Key must be a int in range 0 - 31") end
@@ -1415,8 +1418,8 @@ end
 
 --- Gets a datatable entity
 -- @shared
--- @param key The number key. Valid keys are 0 - 31
--- @return The entity or nil if it doesn't exist
+-- @param number key The number key. Valid keys are 0 - 31
+-- @return Entity? The entity or nil if it doesn't exist
 function ents_methods:getDTEntity(key)
 	checkluatype(key, TYPE_NUMBER)
 	if key<0 or key>31 then SF.Throw("Key must be a int in range 0 - 31") end
@@ -1425,8 +1428,8 @@ end
 
 --- Gets a datatable float
 -- @shared
--- @param key The number key. Valid keys are 0 - 31
--- @return The float or nil if it doesn't exist
+-- @param number key The number key. Valid keys are 0 - 31
+-- @return number? The float or nil if it doesn't exist
 function ents_methods:getDTFloat(key)
 	checkluatype(key, TYPE_NUMBER)
 	if key<0 or key>31 then SF.Throw("Key must be a int in range 0 - 31") end
@@ -1435,8 +1438,8 @@ end
 
 --- Gets a datatable int
 -- @shared
--- @param key The number key. Valid keys are 0 - 31
--- @return The int or nil if it doesn't exist
+-- @param number key The number key. Valid keys are 0 - 31
+-- @return number? The int or nil if it doesn't exist
 function ents_methods:getDTInt(key)
 	checkluatype(key, TYPE_NUMBER)
 	if key<0 or key>31 then SF.Throw("Key must be a int in range 0 - 31") end
@@ -1445,8 +1448,8 @@ end
 
 --- Gets a datatable string
 -- @shared
--- @param key The number key. Valid keys are 0 - 31
--- @return The string or nil if it doesn't exist
+-- @param number key The number key. Valid keys are 0 - 31
+-- @return string? The string or nil if it doesn't exist
 function ents_methods:getDTString(key)
 	checkluatype(key, TYPE_NUMBER)
 	if key<0 or key>31 then SF.Throw("Key must be a int in range 0 - 31") end
@@ -1455,8 +1458,8 @@ end
 
 --- Gets a datatable vector
 -- @shared
--- @param key The number key. Valid keys are 0 - 31
--- @return The vector or nil if it doesn't exist
+-- @param number key The number key. Valid keys are 0 - 31
+-- @return Vector? The vector or nil if it doesn't exist
 function ents_methods:getDTVector(key)
 	checkluatype(key, TYPE_NUMBER)
 	if key<0 or key>31 then SF.Throw("Key must be a int in range 0 - 31") end
@@ -1465,8 +1468,8 @@ end
 
 --- Gets a networked variable of an entity
 -- @shared
--- @param key The string key to get
--- @return The object associated with that key or nil if it's not set
+-- @param string key The string key to get
+-- @return any The object associated with that key or nil if it's not set
 function ents_methods:getNWVar(key)
 	checkluatype(key, TYPE_STRING)
 	-- GetNW* returns whatever the key is tied to regardless of the function name
@@ -1477,7 +1480,7 @@ end
 
 --- Gets the table of all networked things on an entity
 -- @shared
--- @return The table of networked objects
+-- @return table The table of networked objects
 function ents_methods:getNWVarTable()
 	return instance.Sanitize(getent(self):GetNWVarTable())
 end

--- a/lua/starfall/libs_sh/find.lua
+++ b/lua/starfall/libs_sh/find.lua
@@ -41,8 +41,8 @@ local function convert(results, func)
 end
 
 --- Finds entities in a box
--- @param vector min Bottom corner
--- @param vector max Top corner
+-- @param Vector min Bottom corner
+-- @param Vector max Top corner
 -- @param function? filter Optional function to filter results
 -- @return table An array of found entities
 function find_library.inBox(min, max, filter)
@@ -54,7 +54,7 @@ function find_library.inBox(min, max, filter)
 end
 
 --- Finds entities in a sphere
--- @param vector center Center of the sphere
+-- @param Vector center Center of the sphere
 -- @param number radius Sphere radius
 -- @param function? filter Optional function to filter results
 -- @return table An array of found entities
@@ -68,8 +68,8 @@ function find_library.inSphere(center, radius, filter)
 end
 
 --- Finds entities in a cone
--- @param vector pos The cone vertex position
--- @param vector dir The direction to project the cone
+-- @param Vector pos The cone vertex position
+-- @param Vector dir The direction to project the cone
 -- @param number distance The length to project the cone
 -- @param number radius The cosine of angle of the cone. 1 makes a 0° cone, 0.707 makes approximately 90°, 0 makes 180°, and so on.
 -- @param function? filter Optional function to filter results
@@ -85,10 +85,10 @@ function find_library.inCone(pos, dir, distance, radius, filter)
 end
 
 --- Finds entities in a ray
--- @param vector startpos The ray start
--- @param vector endpos The ray end
--- @param vector? mins If not nil, will define a lower bound of the ray's hull
--- @param vector? maxs If not nil, will define a upper bound of the ray's hull
+-- @param Vector startpos The ray start
+-- @param Vector endpos The ray end
+-- @param Vector? mins If not nil, will define a lower bound of the ray's hull
+-- @param Vector? maxs If not nil, will define a upper bound of the ray's hull
 -- @param function? filter Optional function to filter results
 -- @return table An array of found entities
 function find_library.inRay(startpos, endpos, mins, maxs, filter)
@@ -141,7 +141,7 @@ end
 if SERVER then
 	--- Finds entities that are in the PVS (Potentially Visible Set). See: https://developer.valvesoftware.com/wiki/PVS
 	-- @server
-	-- @param vector pos Vector view point
+	-- @param Vector pos Vector view point
 	-- @param function? filter Optional function to filter results
 	-- @return table An array of found entities
 	function find_library.inPVS(pos, filter)
@@ -171,8 +171,8 @@ end
 
 --- Finds the closest entity to a point
 -- @param table ents The array of entities
--- @param vector pos The position
--- @return entity The closest entity
+-- @param Vector pos The position
+-- @return Entity The closest entity
 function find_library.closest(ents, pos)
 	local closest = math.huge
 	local closestent
@@ -190,7 +190,7 @@ end
 
 --- Returns a sorted array of entities by how close they are to a point
 -- @param table ents The array of entities
--- @param vector pos The position
+-- @param Vector pos The position
 -- @param boolean furthest Whether to have the further entities first
 -- @return table A table of the closest entities
 function find_library.sortByClosest(ents, pos, furthest)

--- a/lua/starfall/libs_sh/find.lua
+++ b/lua/starfall/libs_sh/find.lua
@@ -41,10 +41,10 @@ local function convert(results, func)
 end
 
 --- Finds entities in a box
--- @param min Bottom corner
--- @param max Top corner
--- @param filter Optional function to filter results
--- @return An array of found entities
+-- @param vector min Bottom corner
+-- @param vector max Top corner
+-- @param function? filter Optional function to filter results
+-- @return table An array of found entities
 function find_library.inBox(min, max, filter)
 	checkpermission(instance, nil, "find")
 
@@ -54,10 +54,10 @@ function find_library.inBox(min, max, filter)
 end
 
 --- Finds entities in a sphere
--- @param center Center of the sphere
--- @param radius Sphere radius
--- @param filter Optional function to filter results
--- @return An array of found entities
+-- @param vector center Center of the sphere
+-- @param number radius Sphere radius
+-- @param function? filter Optional function to filter results
+-- @return table An array of found entities
 function find_library.inSphere(center, radius, filter)
 	checkpermission(instance, nil, "find")
 	checkluatype (radius, TYPE_NUMBER)
@@ -68,12 +68,12 @@ function find_library.inSphere(center, radius, filter)
 end
 
 --- Finds entities in a cone
--- @param pos The cone vertex position
--- @param dir The direction to project the cone
--- @param distance The length to project the cone
--- @param radius The cosine of angle of the cone. 1 makes a 0° cone, 0.707 makes approximately 90°, 0 makes 180°, and so on.
--- @param filter Optional function to filter results
--- @return An array of found entities
+-- @param vector pos The cone vertex position
+-- @param vector dir The direction to project the cone
+-- @param number distance The length to project the cone
+-- @param number radius The cosine of angle of the cone. 1 makes a 0° cone, 0.707 makes approximately 90°, 0 makes 180°, and so on.
+-- @param function? filter Optional function to filter results
+-- @return table An array of found entities
 function find_library.inCone(pos, dir, distance, radius, filter)
 	checkpermission(instance, nil, "find")
 	checkluatype (distance, TYPE_NUMBER)
@@ -85,12 +85,12 @@ function find_library.inCone(pos, dir, distance, radius, filter)
 end
 
 --- Finds entities in a ray
--- @param startpos The ray start
--- @param endpos The ray end
--- @param mins If not null, will define a lower bound of the ray's hull
--- @param maxs If not null, will define a upper bound of the ray's hull
--- @param filter Optional function to filter results
--- @return An array of found entities
+-- @param vector startpos The ray start
+-- @param vector endpos The ray end
+-- @param vector? mins If not nil, will define a lower bound of the ray's hull
+-- @param vector? maxs If not nil, will define a upper bound of the ray's hull
+-- @param function? filter Optional function to filter results
+-- @return table An array of found entities
 function find_library.inRay(startpos, endpos, mins, maxs, filter)
 	checkpermission(instance, nil, "find")
 
@@ -106,9 +106,9 @@ function find_library.inRay(startpos, endpos, mins, maxs, filter)
 end
 
 --- Finds entities by class name
--- @param class The class name
--- @param filter Optional function to filter results
--- @return An array of found entities
+-- @param string class The class name
+-- @param function? filter Optional function to filter results
+-- @return table An array of found entities
 function find_library.byClass(class, filter)
 	checkpermission(instance, nil, "find")
 	checkluatype (class, TYPE_STRING)
@@ -117,9 +117,9 @@ function find_library.byClass(class, filter)
 end
 
 --- Finds entities by their targetname
--- @param name The targetname
--- @param filter Optional function to filter results
--- @return An array of found entities
+-- @param string name The targetname
+-- @param function? filter Optional function to filter results
+-- @return table An array of found entities
 function find_library.byName(name, filter)
 	checkpermission(instance, nil, "find")
 	checkluatype (name, TYPE_STRING)
@@ -128,9 +128,9 @@ function find_library.byName(name, filter)
 end
 
 --- Finds entities by model
--- @param model The model file
--- @param filter Optional function to filter results
--- @return An array of found entities
+-- @param string model The model file
+-- @param function? filter Optional function to filter results
+-- @return table An array of found entities
 function find_library.byModel(model, filter)
 	checkpermission(instance, nil, "find")
 	checkluatype (model, TYPE_STRING)
@@ -141,19 +141,19 @@ end
 if SERVER then
 	--- Finds entities that are in the PVS (Potentially Visible Set). See: https://developer.valvesoftware.com/wiki/PVS
 	-- @server
-	-- @param pos Vector view point
-	-- @param filter Optional function to filter results
-	-- @return An array of found entities
+	-- @param vector pos Vector view point
+	-- @param function? filter Optional function to filter results
+	-- @return table An array of found entities
 	function find_library.inPVS(pos, filter)
 		checkpermission(instance, nil, "find")
-		
+
 		return convert(ents.FindInPVS(vunwrap(pos)), filter)
 	end
 end
 
 --- Finds all players (including bots)
--- @param filter Optional function to filter results
--- @return An array of found entities
+-- @param function? filter Optional function to filter results
+-- @return table An array of found entities
 function find_library.allPlayers(filter)
 	checkpermission(instance, nil, "find")
 
@@ -161,8 +161,8 @@ function find_library.allPlayers(filter)
 end
 
 --- Finds all entitites
--- @param filter Optional function to filter results
--- @return An array of found entities
+-- @param function? filter Optional function to filter results
+-- @return table An array of found entities
 function find_library.all(filter)
 	checkpermission(instance, nil, "find")
 
@@ -170,9 +170,9 @@ function find_library.all(filter)
 end
 
 --- Finds the closest entity to a point
--- @param ents The array of entities
--- @param pos The position
--- @return The closest entity
+-- @param table ents The array of entities
+-- @param vector pos The position
+-- @return entity The closest entity
 function find_library.closest(ents, pos)
 	local closest = math.huge
 	local closestent
@@ -189,10 +189,10 @@ function find_library.closest(ents, pos)
 end
 
 --- Returns a sorted array of entities by how close they are to a point
--- @param ents The array of entities
--- @param pos The position
--- @param furthest Whether to have the further entities first
--- @return A table of the closest entities
+-- @param table ents The array of entities
+-- @param vector pos The position
+-- @param boolean furthest Whether to have the further entities first
+-- @return table A table of the closest entities
 function find_library.sortByClosest(ents, pos, furthest)
 	local distances = {}
 	for i=1, #ents do
@@ -213,10 +213,10 @@ function find_library.sortByClosest(ents, pos, furthest)
 end
 
 --- Finds the first player with the given name
--- @param name Name to search for
--- @param casesensitive Boolean should the match be case sensitive?
--- @param exact Boolean should the name match exactly
--- @return Table of found players
+-- @param string name Name to search for
+-- @param boolean? casesensitive Boolean should the match be case sensitive?
+-- @param boolean? exact Boolean should the name match exactly
+-- @return table Table of found players
 function find_library.playersByName(name, casesensitive, exact)
 	checkpermission(instance, nil, "find")
 	checkluatype(name, TYPE_STRING)

--- a/lua/starfall/libs_sh/game.lua
+++ b/lua/starfall/libs_sh/game.lua
@@ -79,7 +79,7 @@ function game_library.getAmmoData(id)
 end
 
 --- Returns the worldspawn entity
--- @return entity Worldspawn
+-- @return Entity Worldspawn
 function game_library.getWorld()
 	return ewrap(game.GetWorld())
 end
@@ -102,7 +102,7 @@ if SERVER then
 
 	--- Applies explosion damage to all entities in the specified radius
 	-- @server
-	-- @param vector damageOrigin The center of the explosion
+	-- @param Vector damageOrigin The center of the explosion
 	-- @param number damageRadius The radius in which entities will be damaged (0 - 1500)
 	-- @param number damage The amount of damage to be applied
 	function game_library.blastDamage(damageOrigin, damageRadius, damage)
@@ -121,7 +121,7 @@ else
 
 	--- Returns the direction and how obstructed the map's sun is or nil if it doesn't exist
 	-- @client
-	-- @return vector The direction of the sun
+	-- @return Vector The direction of the sun
 	-- @return number How obstructed the sun is 0 to 1.
 	function game_library.getSunInfo()
 		local info = util.GetSunInfo()
@@ -130,7 +130,7 @@ else
 
 	--- Check whether the skybox is visible from the point specified
 	-- @client
-	-- @param vector position The position to check the skybox visibility from
+	-- @param Vector position The position to check the skybox visibility from
 	-- @return boolean Whether the skybox is visible from the position
 	function game_library.isSkyboxVisibleFromPoint(position)
 		return util.IsSkyboxVisibleFromPoint(vunwrap(position))

--- a/lua/starfall/libs_sh/game.lua
+++ b/lua/starfall/libs_sh/game.lua
@@ -55,44 +55,44 @@ game_library.getMaxPlayers = game.MaxPlayers
 --- Checks whether the specified game is mounted
 -- @name game_library.isMounted
 -- @class function
--- @param str String identifier of the game, eg. 'cstrike'
--- @return True if the game is mounted
+-- @param string str String identifier of the game, eg. 'cstrike'
+-- @return boolean True if the game is mounted
 game_library.isMounted = IsMounted
 
 --- Returns the game time scale
 -- @name game_library.getTimeScale
 -- @class function
--- @return number time scale
+-- @return number Time scale
 game_library.getTimeScale = game.GetTimeScale
 
 --- Returns the number of seconds between each gametick
 -- @name game_library.getTickInterval
 -- @class function
--- @return number interval
+-- @return number Interval
 game_library.getTickInterval = engine.TickInterval
 
 --- Returns AmmoData for given id
--- @param number id, see https://wiki.facepunch.com/gmod/Default_Ammo_Types
+-- @param number id See https://wiki.facepunch.com/gmod/Default_Ammo_Types
 -- @return table AmmoData, see https://wiki.facepunch.com/gmod/Structures/AmmoData
 function game_library.getAmmoData(id)
 	return game.GetAmmoData(id)
 end
 
 --- Returns the worldspawn entity
--- @return entity world
+-- @return entity Worldspawn
 function game_library.getWorld()
 	return ewrap(game.GetWorld())
 end
 
 --- Given a 64bit SteamID will return a STEAM_0: style Steam ID
--- @param id The 64 bit Steam ID
+-- @param string id The 64 bit Steam ID
 -- @return string STEAM_0 style Steam ID
 function game_library.steamIDFrom64(id)
 	return util.SteamIDFrom64(id)
 end
 
 --- Given a STEAM_0 style Steam ID will return a 64bit Steam ID
--- @param id The STEAM_0 style id
+-- @param string id The STEAM_0 style id
 -- @return string 64bit Steam ID
 function game_library.steamIDTo64(id)
 	return util.SteamIDTo64(id)
@@ -102,9 +102,9 @@ if SERVER then
 
 	--- Applies explosion damage to all entities in the specified radius
 	-- @server
-	-- @param damageOrigin The center of the explosion
-	-- @param damageRadius The radius in which entities will be damaged (0 - 1500)
-	-- @param damage The amount of damage to be applied
+	-- @param vector damageOrigin The center of the explosion
+	-- @param number damageRadius The radius in which entities will be damaged (0 - 1500)
+	-- @param number damage The amount of damage to be applied
 	function game_library.blastDamage(damageOrigin, damageRadius, damage)
 		checkpermission(instance, nil, "blast.create")
 		util.BlastDamage(instance.entity, instance.player, vunwrap(damageOrigin), math.Clamp(damageRadius, 0, 1500), damage)
@@ -130,8 +130,8 @@ else
 
 	--- Check whether the skybox is visible from the point specified
 	-- @client
-	-- @param position The position to check the skybox visibility from
-	-- @return bool Whether the skybox is visible from the position
+	-- @param vector position The position to check the skybox visibility from
+	-- @return boolean Whether the skybox is visible from the position
 	function game_library.isSkyboxVisibleFromPoint(position)
 		return util.IsSkyboxVisibleFromPoint(vunwrap(position))
 	end

--- a/lua/starfall/libs_sh/holograms.lua
+++ b/lua/starfall/libs_sh/holograms.lua
@@ -475,7 +475,7 @@ end
 
 --- Animates a hologram
 -- @shared
--- @param any animation number or string name. Does nothing if nil
+-- @param number|string animation Animation number or string name. Does nothing if nil
 -- @param number? frame Optional int (Default 0) The starting frame number. Does nothing if nil
 -- @param number? rate Optional float (Default 1) Frame speed. Does nothing if nil
 function hologram_methods:setAnimation(animation, frame, rate)

--- a/lua/starfall/libs_sh/holograms.lua
+++ b/lua/starfall/libs_sh/holograms.lua
@@ -121,7 +121,7 @@ end
 
 --- Casts a hologram entity into the hologram type
 -- @shared
--- @return Hologram type
+-- @return hologram Hologram instance
 function ents_methods:toHologram()
 	local ent = getent(self)
 	if not ent.IsSFHologram then SF.Throw("The entity isn't a hologram", 2) end
@@ -130,11 +130,11 @@ end
 
 
 --- Creates a hologram.
--- @param pos The position to create the hologram
--- @param ang The angle to create the hologram
--- @param model The model to give the hologram
--- @param scale (Optional) The scale to give the hologram
--- @return The hologram object
+-- @param vector pos The position to create the hologram
+-- @param angle ang The angle to create the hologram
+-- @param string model The model to give the hologram
+-- @param vector? scale (Optional) The scale to give the hologram
+-- @return hologram The hologram object
 function holograms_library.create(pos, ang, model, scale)
 	checkpermission(instance, nil, "hologram.create")
 	checkluatype(model, TYPE_STRING)
@@ -198,14 +198,14 @@ function holograms_library.create(pos, ang, model, scale)
 end
 
 --- Checks if a user can spawn anymore holograms.
--- @return True if user can spawn holograms, False if not.
+-- @return boolean True if user can spawn holograms, False if not.
 function holograms_library.canSpawn()
 	if not SF.Permissions.hasAccess(instance,  nil, "hologram.create") then return false end
 	return plyCount:check(instance.player) > 0
 end
 
 --- Checks how many holograms can be spawned
--- @return number of holograms able to be spawned
+-- @return number Number of holograms able to be spawned
 function holograms_library.hologramsLeft()
 	if not SF.Permissions.hasAccess(instance,  nil, "hologram.create") then return 0 end
 	return plyCount:check(instance.player)
@@ -214,7 +214,7 @@ end
 if SERVER then
 	--- Sets the hologram linear velocity
 	-- @server
-	-- @param vel New velocity
+	-- @param vector vel New velocity
 	function hologram_methods:setVel(vel)
 		local vel = vunwrap(vel)
 
@@ -226,7 +226,7 @@ if SERVER then
 
 	--- Sets the hologram's angular velocity.
 	-- @server
-	-- @param angvel *Vector* angular velocity.
+	-- @param angle angvel *Vector* angular velocity.
 	function hologram_methods:setAngVel(angvel)
 
 		local holo = getholo(self)
@@ -235,12 +235,12 @@ if SERVER then
 		holo:SetLocalAngularVelocity(aunwrap(angvel))
 	end
 
-	
+
 
 else
 	--- Sets the hologram's position.
 	-- @shared
-	-- @param vec New position
+	-- @param vector vec New position
 	function hologram_methods:setPos(vec)
 		local holo = getholo(self)
 		local vec = vunwrap(vec)
@@ -252,7 +252,7 @@ else
 
 	--- Sets the hologram's angles.
 	-- @shared
-	-- @param ang New angles
+	-- @param angle ang New angles
 	function hologram_methods:setAngles(ang)
 		local holo = getholo(self)
 		local ang = aunwrap(ang)
@@ -264,7 +264,7 @@ else
 
 	--- Sets the texture filtering function when viewing a close texture
 	-- @client
-	-- @param val The filter function to use http://wiki.facepunch.com/gmod/Enums/TEXFILTER
+	-- @param number val The filter function to use http://wiki.facepunch.com/gmod/Enums/TEXFILTER
 	function hologram_methods:setFilterMag(val)
 		local holo = getholo(self)
 
@@ -280,7 +280,7 @@ else
 
 	--- Sets the texture filtering function when viewing a far texture
 	-- @client
-	-- @param val The filter function to use http://wiki.facepunch.com/gmod/Enums/TEXFILTER
+	-- @param number val The filter function to use http://wiki.facepunch.com/gmod/Enums/TEXFILTER
 	function hologram_methods:setFilterMin(val)
 		local holo = getholo(self)
 
@@ -296,7 +296,7 @@ else
 
 	--- Sets a hologram entity's rendermatrix
 	-- @client
-	-- @param mat Starfall matrix to use
+	-- @param vmatrix mat Starfall matrix to use
 	function hologram_methods:setRenderMatrix(mat)
 		local holo = getholo(self)
 
@@ -316,53 +316,53 @@ else
 			holo:DisableMatrix("RenderMultiply")
 		end
 	end
-	
+
 	--- Parents a hologram
-	-- @param ent Entity parent (nil to unparent)
-	-- @param attachment Optional attachment ID
+	-- @param entity? ent Entity parent (nil to unparent)
+	-- @param number? attachment Optional attachment ID
 	function hologram_methods:setParent(ent, attachment)
-		
+
 		local holo = getholo(self)
-		
+
 		checkpermission(instance, holo, "hologram.setParent")
-		
+
 		if ent ~= nil then
 			local parent = getent(ent)
-			
+
 			if attachment == nil then attachment = -1 end
 			checkluatype(attachment, TYPE_NUMBER)
-			
+
 			if not parent.sf_children then
 				parent.sf_children = {}
 			end
-			
+
 			if holo.sf_parent then
 				holo.sf_parent.sf_children[holo] = nil
 			end
-			
+
 			parent.sf_children[holo] = attachment
 			holo.sf_parent = parent
-			
+
 			holo:SetParent(parent, attachment)
-			
+
 		else
-			
+
 			if holo.sf_parent then
 				holo.sf_parent.sf_children[holo] = nil
 			end
-			
+
 			holo.sf_parent = nil
 			holo:SetParent()
-			
+
 		end
-		
+
 	end
-	
+
 	--- Manually draws a hologram, requires a 3d render context
 	-- @client
 	function hologram_methods:draw()
 		if not instance.data.render.isRendering then SF.Throw("Not in rendering hook.", 2) end
-		
+
 		local holo = getholo(self)
 		holo:SetupBones()
 		holo:DrawModel()
@@ -371,11 +371,11 @@ end
 
 --- Updates a clip plane
 -- @shared
--- @param index Whatever number you want the clip to be
--- @param enabled Whether the clip is enabled
--- @param origin The center of the clip plane in world coordinates, or local to entity if it is specified
--- @param normal The the direction of the clip plane in world coordinates, or local to entity if it is specified
--- @param entity (Optional) The entity to make coordinates local to, otherwise the world is used
+-- @param number index Whatever number you want the clip to be
+-- @param boolean enabled Whether the clip is enabled
+-- @param vector origin The center of the clip plane in world coordinates, or local to entity if it is specified
+-- @param vector normal The the direction of the clip plane in world coordinates, or local to entity if it is specified
+-- @param entity? entity (Optional) The entity to make coordinates local to, otherwise the world is used
 function hologram_methods:setClip(index, enabled, origin, normal, entity)
 	local holo = getholo(self)
 
@@ -408,7 +408,7 @@ end
 
 --- Sets the hologram scale. Basically the same as setRenderMatrix() with a scaled matrix
 -- @shared
--- @param scale Vector new scale
+-- @param vector scale Vector new scale
 function hologram_methods:setScale(scale)
 	local holo = getholo(self)
 	local scale = vunwrap(scale)
@@ -420,13 +420,13 @@ end
 
 --- Sets the hologram size in game units
 -- @shared
--- @param size Vector new size in game units
+-- @param vector size Vector new size in game units
 function hologram_methods:setSize(size)
 	local holo = getholo(self)
 	local size = vunwrap(size)
-	
+
 	checkpermission(instance, holo, "hologram.setRenderProperty")
-	
+
 	local bounds = holo:OBBMaxs() - holo:OBBMins()
 	local scale = Vector(size[1] / bounds[1], size[2] / bounds[2], size[3] / bounds[3])
 	holo:SetScale(scale)
@@ -434,14 +434,14 @@ end
 
 --- Gets the hologram scale.
 -- @shared
--- @return Vector scale
+-- @return vector Vector scale
 function hologram_methods:getScale()
 	return vwrap(getholo(self):GetScale())
 end
 
 --- Suppress Engine Lighting of a hologram. Disabled by default.
 -- @shared
--- @param suppress Boolean to represent if shading should be set or not.
+-- @param boolean suppress Boolean to represent if shading should be set or not.
 function hologram_methods:suppressEngineLighting(suppress)
 	local holo = getholo(self)
 
@@ -454,13 +454,13 @@ end
 
 --- Suppress Engine Lighting of a hologram. Disabled by default.
 -- @shared
--- @param suppress Boolean to represent if shading should be set or not.
+-- @return boolean Whether engine lighting is suppressed
 function hologram_methods:getSuppressEngineLighting()
 	return getholo(self):GetSuppressEngineLighting()
 end
 
 --- Sets the model of a hologram
--- @param model string model path
+-- @param string model string model path
 function hologram_methods:setModel(model)
 	local holo = getholo(self)
 	checkluatype(model, TYPE_STRING)
@@ -475,9 +475,9 @@ end
 
 --- Animates a hologram
 -- @shared
--- @param animation number or string name. Does nothing if nil
--- @param frame Optional int (Default 0) The starting frame number. Does nothing if nil
--- @param rate Optional float (Default 1) Frame speed. Does nothing if nil
+-- @param any animation number or string name. Does nothing if nil
+-- @param number? frame Optional int (Default 0) The starting frame number. Does nothing if nil
+-- @param number? rate Optional float (Default 1) Frame speed. Does nothing if nil
 function hologram_methods:setAnimation(animation, frame, rate)
 	local holo = getholo(self)
 	checkpermission(instance, holo, "hologram.setRenderProperty")
@@ -504,25 +504,25 @@ end
 
 --- Applies engine effects to the hologram
 -- @shared
--- @param effect The effects to add. EF table values
+-- @param number effect The effects to add. See EF Enums
 function hologram_methods:addEffects(effect)
 	checkluatype(effect, TYPE_NUMBER)
-	
+
 	local holo = getholo(self)
 	checkpermission(instance, holo, "entities.setRenderProperty")
-	
+
 	holo:AddEffects(effect)
 end
 
 --- Removes engine effects from the hologram
 -- @shared
--- @param effect The effects to remove. EF table values
+-- @param number effect The effects to remove. See EF Enums
 function hologram_methods:removeEffects(effect)
 	checkluatype(effect, TYPE_NUMBER)
-	
+
 	local holo = getholo(self)
 	checkpermission(instance, holo, "entities.setRenderProperty")
-	
+
 	holo:RemoveEffects(effect)
 end
 

--- a/lua/starfall/libs_sh/holograms.lua
+++ b/lua/starfall/libs_sh/holograms.lua
@@ -121,7 +121,7 @@ end
 
 --- Casts a hologram entity into the hologram type
 -- @shared
--- @return hologram Hologram instance
+-- @return Hologram Hologram instance
 function ents_methods:toHologram()
 	local ent = getent(self)
 	if not ent.IsSFHologram then SF.Throw("The entity isn't a hologram", 2) end
@@ -130,11 +130,11 @@ end
 
 
 --- Creates a hologram.
--- @param vector pos The position to create the hologram
--- @param angle ang The angle to create the hologram
+-- @param Vector pos The position to create the hologram
+-- @param Angle ang The angle to create the hologram
 -- @param string model The model to give the hologram
--- @param vector? scale (Optional) The scale to give the hologram
--- @return hologram The hologram object
+-- @param Vector? scale (Optional) The scale to give the hologram
+-- @return Hologram The hologram object
 function holograms_library.create(pos, ang, model, scale)
 	checkpermission(instance, nil, "hologram.create")
 	checkluatype(model, TYPE_STRING)
@@ -214,7 +214,7 @@ end
 if SERVER then
 	--- Sets the hologram linear velocity
 	-- @server
-	-- @param vector vel New velocity
+	-- @param Vector vel New velocity
 	function hologram_methods:setVel(vel)
 		local vel = vunwrap(vel)
 
@@ -226,7 +226,7 @@ if SERVER then
 
 	--- Sets the hologram's angular velocity.
 	-- @server
-	-- @param angle angvel *Vector* angular velocity.
+	-- @param Angle angvel *Vector* angular velocity.
 	function hologram_methods:setAngVel(angvel)
 
 		local holo = getholo(self)
@@ -240,7 +240,7 @@ if SERVER then
 else
 	--- Sets the hologram's position.
 	-- @shared
-	-- @param vector vec New position
+	-- @param Vector vec New position
 	function hologram_methods:setPos(vec)
 		local holo = getholo(self)
 		local vec = vunwrap(vec)
@@ -252,7 +252,7 @@ else
 
 	--- Sets the hologram's angles.
 	-- @shared
-	-- @param angle ang New angles
+	-- @param Angle ang New angles
 	function hologram_methods:setAngles(ang)
 		local holo = getholo(self)
 		local ang = aunwrap(ang)
@@ -296,7 +296,7 @@ else
 
 	--- Sets a hologram entity's rendermatrix
 	-- @client
-	-- @param vmatrix mat Starfall matrix to use
+	-- @param VMatrix mat Starfall matrix to use
 	function hologram_methods:setRenderMatrix(mat)
 		local holo = getholo(self)
 
@@ -318,7 +318,7 @@ else
 	end
 
 	--- Parents a hologram
-	-- @param entity? ent Entity parent (nil to unparent)
+	-- @param Entity? ent Entity parent (nil to unparent)
 	-- @param number? attachment Optional attachment ID
 	function hologram_methods:setParent(ent, attachment)
 
@@ -373,9 +373,9 @@ end
 -- @shared
 -- @param number index Whatever number you want the clip to be
 -- @param boolean enabled Whether the clip is enabled
--- @param vector origin The center of the clip plane in world coordinates, or local to entity if it is specified
--- @param vector normal The the direction of the clip plane in world coordinates, or local to entity if it is specified
--- @param entity? entity (Optional) The entity to make coordinates local to, otherwise the world is used
+-- @param Vector origin The center of the clip plane in world coordinates, or local to entity if it is specified
+-- @param Vector normal The the direction of the clip plane in world coordinates, or local to entity if it is specified
+-- @param Entity? entity (Optional) The entity to make coordinates local to, otherwise the world is used
 function hologram_methods:setClip(index, enabled, origin, normal, entity)
 	local holo = getholo(self)
 
@@ -408,7 +408,7 @@ end
 
 --- Sets the hologram scale. Basically the same as setRenderMatrix() with a scaled matrix
 -- @shared
--- @param vector scale Vector new scale
+-- @param Vector scale Vector new scale
 function hologram_methods:setScale(scale)
 	local holo = getholo(self)
 	local scale = vunwrap(scale)
@@ -420,7 +420,7 @@ end
 
 --- Sets the hologram size in game units
 -- @shared
--- @param vector size Vector new size in game units
+-- @param Vector size Vector new size in game units
 function hologram_methods:setSize(size)
 	local holo = getholo(self)
 	local size = vunwrap(size)
@@ -434,7 +434,7 @@ end
 
 --- Gets the hologram scale.
 -- @shared
--- @return vector Vector scale
+-- @return Vector Vector scale
 function hologram_methods:getScale()
 	return vwrap(getholo(self):GetScale())
 end

--- a/lua/starfall/libs_sh/holograms.lua
+++ b/lua/starfall/libs_sh/holograms.lua
@@ -475,7 +475,7 @@ end
 
 --- Animates a hologram
 -- @shared
--- @param number|string animation Animation number or string name. Does nothing if nil
+-- @param number|string animation Animation number or string name.
 -- @param number? frame Optional int (Default 0) The starting frame number. Does nothing if nil
 -- @param number? rate Optional float (Default 1) Frame speed. Does nothing if nil
 function hologram_methods:setAnimation(animation, frame, rate)

--- a/lua/starfall/libs_sh/hook.lua
+++ b/lua/starfall/libs_sh/hook.lua
@@ -159,8 +159,8 @@ end
 -- @name remote
 -- @class hook
 -- @shared
--- @param entity sender The entity that caused the hook to run
--- @param player owner The owner of the sender
+-- @param Entity sender The entity that caused the hook to run
+-- @param Player owner The owner of the sender
 -- @param ... payload The payload that was supplied when calling the hook
 
 local hookrun = hook_library.run
@@ -168,7 +168,7 @@ local hookrun = hook_library.run
 --- Run a hook remotely.
 -- This will call the hook "remote" on either a specified entity or all instances on the server/client
 -- @shared
--- @param entity? recipient Starfall entity to call the hook on. Nil to run on every starfall entity
+-- @param Entity? recipient Starfall entity to call the hook on. Nil to run on every starfall entity
 -- @param ... payload Payload. These parameters will be used to call the hook functions
 -- @return table A list of the resultset of each called hook
 function hook_library.runRemote(recipient, ...)
@@ -227,93 +227,93 @@ end
 -- @name GravGunOnPickedUp
 -- @class hook
 -- @server
--- @param player ply Player picking up an object
--- @param entity ent Entity being picked up
+-- @param Player ply Player picking up an object
+-- @param Entity ent Entity being picked up
 
 --- Called when an entity is being dropped by a gravity gun
 -- @name GravGunOnDropped
 -- @class hook
 -- @server
--- @param player ply Player dropping the object
--- @param entity ent Entity being dropped
+-- @param Player ply Player dropping the object
+-- @param Entity ent Entity being dropped
 
 --- Called when an entity is being picked up by +use
 -- @name OnPlayerPhysicsPickup
 -- @class hook
 -- @server
--- @param player ply Player picking up an object
--- @param entity ent Entity being picked up
+-- @param Player ply Player picking up an object
+-- @param Entity ent Entity being picked up
 
 --- Called when an entity is being dropped or thrown by +use
 -- @name OnPlayerPhysicsDrop
 -- @class hook
 -- @server
--- @param player ply Player dropping the object
--- @param entity ent Entity being dropped
+-- @param Player ply Player dropping the object
+-- @param Entity ent Entity being dropped
 -- @param boolean thrown Whether the entity was thrown or dropped
 
 --- Called when an entity is being frozen
 -- @name OnPhysgunFreeze
 -- @class hook
 -- @server
--- @param entity physgun Entity of the physgun
+-- @param Entity physgun Entity of the physgun
 -- @param physobj physobj PhysObj of the entity
--- @param entity ent Entity being frozen
--- @param player ply Player freezing the entity
+-- @param Entity ent Entity being frozen
+-- @param Player ply Player freezing the entity
 
 --- Called when a player reloads his physgun
 -- @name OnPhysgunReload
 -- @class hook
 -- @server
--- @param entity physgun Entity of the physgun
--- @param player ply Player reloading the physgun
+-- @param Entity physgun Entity of the physgun
+-- @param Player ply Player reloading the physgun
 
 --- Called when a player dies
 -- @name PlayerDeath
 -- @class hook
 -- @server
--- @param player ply Player who died
--- @param entity inflictor Entity used to kill the player
--- @param entity attacker Entity that killed the player
+-- @param Player ply Player who died
+-- @param Entity inflictor Entity used to kill the player
+-- @param Entity attacker Entity that killed the player
 
 --- Called when a player disconnects
 -- @name PlayerDisconnected
 -- @class hook
 -- @server
--- @param player ply Player that disconnected
+-- @param Player ply Player that disconnected
 
 --- Called when a player spawns for the first time
 -- @name PlayerInitialSpawn
 -- @class hook
 -- @server
--- @param player ply Player who spawned
+-- @param Player ply Player who spawned
 
 --- Called when a player spawns
 -- @name PlayerSpawn
 -- @class hook
 -- @server
--- @param player ply Player who spawned
+-- @param Player ply Player who spawned
 
 --- Called when a players enters a vehicle
 -- @name PlayerEnteredVehicle
 -- @class hook
 -- @server
--- @param player ply Player who entered a vehicle
--- @param vehicle vehicle Vehicle that was entered
+-- @param Player ply Player who entered a vehicle
+-- @param Vehicle vehicle Vehicle that was entered
 -- @param number num Role. The seat number
 
 --- Called when a players leaves a vehicle
 -- @name PlayerLeaveVehicle
 -- @class hook
 -- @server
--- @param player ply Player who left a vehicle
--- @param vehicle vehicle Vehicle that was left
+-- @param Player ply Player who left a vehicle
+-- @param Vehicle vehicle Vehicle that was left
 
 --- Called when a player sends a chat message
 -- @name PlayerSay
 -- @class hook
 -- @server
--- @param player ply Player that sent the message
+-- @param Player ply Player that sent the message
 -- @param string text Content of the message
 -- @param boolean teamChat True if team chat
 -- @return string? New text. "" to stop from displaying. Nil to keep original.
@@ -322,36 +322,36 @@ end
 -- @name PlayerSpray
 -- @class hook
 -- @server
--- @param player ply Player that sprayed
+-- @param Player ply Player that sprayed
 
 --- Called when a player holds their use key and looks at an entity.
 -- Will continuously run.
 -- @name PlayerUse
 -- @server
 -- @class hook
--- @param player ply Player using the entity
--- @param entity ent Entity being used
+-- @param Player ply Player using the entity
+-- @param Entity ent Entity being used
 
 --- Called when a players turns their flashlight on or off
 -- @name PlayerSwitchFlashlight
 -- @class hook
 -- @server
--- @param player ply Player switching flashlight
+-- @param Player ply Player switching flashlight
 -- @param boolean state New flashlight state. True if on.
 
 --- Called when a wants to pick up a weapon
 -- @name PlayerCanPickupWeapon
 -- @class hook
 -- @server
--- @param player ply Player
--- @param weapon wep Weapon
+-- @param Player ply Player
+-- @param Weapon wep Weapon
 
 --- Called when a player gets hurt
 -- @name PlayerHurt
 -- @class hook
 -- @shared
--- @param player ply Player being hurt
--- @param entity attacker Entity causing damage to the player
+-- @param Player ply Player being hurt
+-- @param Entity attacker Entity causing damage to the player
 -- @param number newHealth New health of the player
 -- @param number damageTaken Amount of damage the player has taken
 
@@ -359,63 +359,63 @@ end
 -- @name PlayerNoClip
 -- @class hook
 -- @shared
--- @param player ply Player toggling noclip
+-- @param Player ply Player toggling noclip
 -- @param boolean newState New noclip state. True if on.
 
 --- Called when a player presses a key
 -- @name KeyPress
 -- @class hook
 -- @shared
--- @param player ply Player pressing the key
+-- @param Player ply Player pressing the key
 -- @param number key The key being pressed
 
 --- Called when a player releases a key
 -- @name KeyRelease
 -- @class hook
 -- @shared
--- @param player ply Player releasing the key
+-- @param Player ply Player releasing the key
 -- @param number key The key being released
 
 --- Called when a player punts with the gravity gun
 -- @name GravGunPunt
 -- @class hook
 -- @shared
--- @param player ply Player punting the gravgun
--- @param entity ent Entity being punted
+-- @param Player ply Player punting the gravgun
+-- @param Entity ent Entity being punted
 
 --- Called when an entity gets picked up by a physgun
 -- @name PhysgunPickup
 -- @class hook
 -- @shared
--- @param player ply Player picking up the entity
--- @param entity ent Entity being picked up
+-- @param Player ply Player picking up the entity
+-- @param Entity ent Entity being picked up
 
 --- Called when an entity being held by a physgun gets dropped
 -- @name PhysgunDrop
 -- @class hook
 -- @shared
--- @param player ply Player dropping the entity
--- @param entity ent Entity being dropped
+-- @param Player ply Player dropping the entity
+-- @param Entity ent Entity being dropped
 
 --- Called when a player switches their weapon
 -- @name PlayerSwitchWeapon
 -- @class hook
 -- @shared
--- @param player ply Player changing weapon
--- @param weapon oldwep Old weapon
--- @param weapon newweapon New weapon
+-- @param Player ply Player changing weapon
+-- @param Weapon oldwep Old weapon
+-- @param Weapon newweapon New weapon
 
 --- Called when an entity gets created
 -- @name OnEntityCreated
 -- @class hook
 -- @shared
--- @param entity ent New entity
+-- @param Entity ent New entity
 
 --- Called when a clientside entity gets created or re-created via lag/PVS
 -- @name NetworkEntityCreated
 -- @class hook
 -- @client
--- @param entity ent New entity
+-- @param Entity ent New entity
 
 --- Called when a clientside entity transmit state is changed. Usually when changing PVS
 -- If you want clientside render changes to persist on an entity you have to re-apply them
@@ -423,54 +423,54 @@ end
 -- @name NotifyShouldTransmit
 -- @class hook
 -- @client
--- @param entity ent The entity
+-- @param Entity ent The entity
 -- @param boolean shouldtransmit Whether it is now transmitting or not
 
 --- Called when an entity is removed
 -- @name EntityRemoved
 -- @class hook
 -- @shared
--- @param entity ent Entity being removed
+-- @param Entity ent Entity being removed
 
 --- Called when an entity is broken
 -- @name PropBreak
 -- @class hook
 -- @shared
--- @param player ply Player who broke it
--- @param entity ent Entity broken
+-- @param Player ply Player who broke it
+-- @param Entity ent Entity broken
 
 --- Called every time a bullet is fired from an entity
 -- @name EntityFireBullets
 -- @class hook
 -- @shared
--- @param entity ent The entity that fired the bullet
+-- @param Entity ent The entity that fired the bullet
 -- @param table data The bullet data. See http://wiki.facepunch.com/gmod/Structures/Bullet
 
 --- Called when an entity is damaged
 -- @name EntityTakeDamage
 -- @class hook
 -- @server
--- @param entity target Entity that is hurt
--- @param entity attacker Entity that attacked
--- @param entity inflictor Entity that inflicted the damage
+-- @param Entity target Entity that is hurt
+-- @param Entity attacker Entity that attacked
+-- @param Entity inflictor Entity that inflicted the damage
 -- @param number amount How much damage
 -- @param number type Type of the damage
--- @param vector position Position of the damage
--- @param vector force Force of the damage
+-- @param Vector position Position of the damage
+-- @param Vector force Force of the damage
 
 --- Called when a player stops driving an entity
 -- @name EndEntityDriving
 -- @class hook
 -- @shared
--- @param entity ent Entity that had been driven
--- @param player ply Player that drove the entity
+-- @param Entity ent Entity that had been driven
+-- @param Player ply Player that drove the entity
 
 --- Called when a player starts driving an entity
 -- @name StartEntityDriving
 -- @class hook
 -- @shared
--- @param entity ent Entity being driven
--- @param player ply Player that is driving the entity
+-- @param Entity ent Entity being driven
+-- @param Player ply Player that is driving the entity
 
 --- Think hook. Called each frame on the client and each game tick on the server.
 -- @name think
@@ -497,7 +497,7 @@ end
 -- @name ClientInitialized
 -- @class hook
 -- @server
--- @param player ply The player that initialized
+-- @param Player ply The player that initialized
 
 --- Called when the local player opens their chat window.
 -- @name StartChat
@@ -513,7 +513,7 @@ end
 -- @name PlayerChat
 -- @class hook
 -- @client
--- @param player ply Player that said the message
+-- @param Player ply Player that said the message
 -- @param string text The message
 -- @param boolean team Whether the message was team only
 -- @param boolean isdead Whether the message was send from a dead player
@@ -522,18 +522,18 @@ end
 -- @name StarfallError
 -- @class hook
 -- @shared
--- @param entity ent Starfall chip that errored
--- @param player ply Owner of the chip on server or player that script errored for on client
+-- @param Entity ent Starfall chip that errored
+-- @param Player ply Owner of the chip on server or player that script errored for on client
 -- @param string err Error message
 
 --- Called when a component is linked to the starfall
 -- @name ComponentLinked
 -- @class hook
 -- @shared
--- @param entity ent The component entity
+-- @param Entity ent The component entity
 
 --- Called when a component is unlinked to the starfall
 -- @name ComponentUnlinked
 -- @class hook
 -- @shared
--- @param entity ent The component entity
+-- @param Entity ent The component entity

--- a/lua/starfall/libs_sh/hook.lua
+++ b/lua/starfall/libs_sh/hook.lua
@@ -257,7 +257,7 @@ end
 -- @class hook
 -- @server
 -- @param Entity physgun Entity of the physgun
--- @param physobj physobj PhysObj of the entity
+-- @param PhysObj physobj PhysObj of the entity
 -- @param Entity ent Entity being frozen
 -- @param Player ply Player freezing the entity
 

--- a/lua/starfall/libs_sh/hook.lua
+++ b/lua/starfall/libs_sh/hook.lua
@@ -114,9 +114,9 @@ local ent_meta, ewrap, eunwrap = instance.Types.Entity, instance.Types.Entity.Wr
 local pwrap = instance.Types.Player.Wrap
 
 --- Sets a hook function
--- @param hookname Name of the event
--- @param name Unique identifier
--- @param func Function to run
+-- @param string hookname Name of the event
+-- @param string name Unique identifier
+-- @param function func Function to run
 function hook_library.add(hookname, name, func)
 	checkluatype (hookname, TYPE_STRING)
 	checkluatype (name, TYPE_STRING)
@@ -133,10 +133,11 @@ function hook_library.add(hookname, name, func)
 	SF.HookAddInstance(instance, hookname)
 end
 
---- Run a hook
+--- Run a hook and return the result
 -- @shared
--- @param hookname The hook name
--- @param ... arguments
+-- @param string hookname The hook name
+-- @param ... arguments Arguments to pass to the hook
+-- @return ... returns Return result(s) of the hook ran
 function hook_library.run(hookname, ...)
 	checkluatype (hookname, TYPE_STRING)
 
@@ -158,18 +159,18 @@ end
 -- @name remote
 -- @class hook
 -- @shared
--- @param sender The entity that caused the hook to run
--- @param owner The owner of the sender
--- @param ... The payload that was supplied when calling the hook
+-- @param entity sender The entity that caused the hook to run
+-- @param player owner The owner of the sender
+-- @param ... payload The payload that was supplied when calling the hook
 
 local hookrun = hook_library.run
 
 --- Run a hook remotely.
 -- This will call the hook "remote" on either a specified entity or all instances on the server/client
 -- @shared
--- @param recipient Starfall entity to call the hook on. Nil to run on every starfall entity
--- @param ... Payload. These parameters will be used to call the hook functions
--- @return tbl A list of the resultset of each called hook
+-- @param entity? recipient Starfall entity to call the hook on. Nil to run on every starfall entity
+-- @param ... payload Payload. These parameters will be used to call the hook functions
+-- @return table A list of the resultset of each called hook
 function hook_library.runRemote(recipient, ...)
 	local recipients
 	if recipient then
@@ -203,8 +204,8 @@ end
 
 --- Remove a hook
 -- @shared
--- @param hookname The hook name
--- @param name The unique name for this hook
+-- @param string hookname The hook name
+-- @param string name The unique name for this hook
 function hook_library.remove(hookname, name)
 	checkluatype (hookname, TYPE_STRING)
 	checkluatype (name, TYPE_STRING)
@@ -226,195 +227,195 @@ end
 -- @name GravGunOnPickedUp
 -- @class hook
 -- @server
--- @param ply Player picking up an object
--- @param ent Entity being picked up
+-- @param player ply Player picking up an object
+-- @param entity ent Entity being picked up
 
 --- Called when an entity is being dropped by a gravity gun
 -- @name GravGunOnDropped
 -- @class hook
 -- @server
--- @param ply Player dropping the object
--- @param ent Entity being dropped
+-- @param player ply Player dropping the object
+-- @param entity ent Entity being dropped
 
 --- Called when an entity is being picked up by +use
 -- @name OnPlayerPhysicsPickup
 -- @class hook
 -- @server
--- @param ply Player picking up an object
--- @param ent Entity being picked up
+-- @param player ply Player picking up an object
+-- @param entity ent Entity being picked up
 
 --- Called when an entity is being dropped or thrown by +use
 -- @name OnPlayerPhysicsDrop
 -- @class hook
 -- @server
--- @param ply Player dropping the object
--- @param ent Entity being dropped
--- @param thrown Whether the entity was thrown or dropped
+-- @param player ply Player dropping the object
+-- @param entity ent Entity being dropped
+-- @param boolean thrown Whether the entity was thrown or dropped
 
 --- Called when an entity is being frozen
 -- @name OnPhysgunFreeze
 -- @class hook
 -- @server
--- @param physgun Entity of the physgun
--- @param physobj PhysObj of the entity
--- @param ent Entity being frozen
--- @param ply Player freezing the entity
+-- @param entity physgun Entity of the physgun
+-- @param physobj physobj PhysObj of the entity
+-- @param entity ent Entity being frozen
+-- @param player ply Player freezing the entity
 
 --- Called when a player reloads his physgun
 -- @name OnPhysgunReload
 -- @class hook
 -- @server
--- @param physgun Entity of the physgun
--- @param ply Player reloading the physgun
+-- @param entity physgun Entity of the physgun
+-- @param player ply Player reloading the physgun
 
 --- Called when a player dies
 -- @name PlayerDeath
 -- @class hook
 -- @server
--- @param ply Player who died
--- @param inflictor Entity used to kill the player
--- @param attacker Entity that killed the player
+-- @param player ply Player who died
+-- @param entity inflictor Entity used to kill the player
+-- @param entity attacker Entity that killed the player
 
 --- Called when a player disconnects
 -- @name PlayerDisconnected
 -- @class hook
 -- @server
--- @param ply Player that disconnected
+-- @param player ply Player that disconnected
 
 --- Called when a player spawns for the first time
 -- @name PlayerInitialSpawn
 -- @class hook
 -- @server
--- @param ply Player who spawned
+-- @param player ply Player who spawned
 
 --- Called when a player spawns
 -- @name PlayerSpawn
 -- @class hook
 -- @server
--- @param ply Player who spawned
+-- @param player ply Player who spawned
 
 --- Called when a players enters a vehicle
 -- @name PlayerEnteredVehicle
 -- @class hook
 -- @server
--- @param ply Player who entered a vehicle
--- @param vehicle Vehicle that was entered
--- @param num Role
+-- @param player ply Player who entered a vehicle
+-- @param vehicle vehicle Vehicle that was entered
+-- @param number num Role. The seat number
 
 --- Called when a players leaves a vehicle
 -- @name PlayerLeaveVehicle
 -- @class hook
 -- @server
--- @param ply Player who left a vehicle
--- @param vehicle Vehicle that was left
+-- @param player ply Player who left a vehicle
+-- @param vehicle vehicle Vehicle that was left
 
 --- Called when a player sends a chat message
 -- @name PlayerSay
 -- @class hook
 -- @server
--- @param ply Player that sent the message
--- @param text Content of the message
--- @param teamChat True if team chat
--- @return New text. "" to stop from displaying. Nil to keep original.
+-- @param player ply Player that sent the message
+-- @param string text Content of the message
+-- @param boolean teamChat True if team chat
+-- @return string? New text. "" to stop from displaying. Nil to keep original.
 
 --- Called when a players sprays his logo
 -- @name PlayerSpray
 -- @class hook
 -- @server
--- @param ply Player that sprayed
+-- @param player ply Player that sprayed
 
 --- Called when a player holds their use key and looks at an entity.
 -- Will continuously run.
 -- @name PlayerUse
 -- @server
 -- @class hook
--- @param ply Player using the entity
--- @param ent Entity being used
+-- @param player ply Player using the entity
+-- @param entity ent Entity being used
 
 --- Called when a players turns their flashlight on or off
 -- @name PlayerSwitchFlashlight
 -- @class hook
 -- @server
--- @param ply Player switching flashlight
--- @param state New flashlight state. True if on.
+-- @param player ply Player switching flashlight
+-- @param boolean state New flashlight state. True if on.
 
 --- Called when a wants to pick up a weapon
 -- @name PlayerCanPickupWeapon
 -- @class hook
 -- @server
--- @param ply Player
--- @param wep Weapon
+-- @param player ply Player
+-- @param weapon wep Weapon
 
 --- Called when a player gets hurt
 -- @name PlayerHurt
 -- @class hook
 -- @shared
--- @param ply Player being hurt
--- @param attacker Entity causing damage to the player
--- @param newHealth New health of the player
--- @param damageTaken Amount of damage the player has taken
+-- @param player ply Player being hurt
+-- @param entity attacker Entity causing damage to the player
+-- @param number newHealth New health of the player
+-- @param number damageTaken Amount of damage the player has taken
 
 --- Called when a player toggles noclip
 -- @name PlayerNoClip
 -- @class hook
 -- @shared
--- @param ply Player toggling noclip
--- @param newState New noclip state. True if on.
+-- @param player ply Player toggling noclip
+-- @param boolean newState New noclip state. True if on.
 
 --- Called when a player presses a key
 -- @name KeyPress
 -- @class hook
 -- @shared
--- @param ply Player pressing the key
--- @param key The key being pressed
+-- @param player ply Player pressing the key
+-- @param number key The key being pressed
 
 --- Called when a player releases a key
 -- @name KeyRelease
 -- @class hook
 -- @shared
--- @param ply Player releasing the key
--- @param key The key being released
+-- @param player ply Player releasing the key
+-- @param number key The key being released
 
 --- Called when a player punts with the gravity gun
 -- @name GravGunPunt
 -- @class hook
 -- @shared
--- @param ply Player punting the gravgun
--- @param ent Entity being punted
+-- @param player ply Player punting the gravgun
+-- @param entity ent Entity being punted
 
 --- Called when an entity gets picked up by a physgun
 -- @name PhysgunPickup
 -- @class hook
 -- @shared
--- @param ply Player picking up the entity
--- @param ent Entity being picked up
+-- @param player ply Player picking up the entity
+-- @param entity ent Entity being picked up
 
 --- Called when an entity being held by a physgun gets dropped
 -- @name PhysgunDrop
 -- @class hook
 -- @shared
--- @param ply Player dropping the entity
--- @param ent Entity being dropped
+-- @param player ply Player dropping the entity
+-- @param entity ent Entity being dropped
 
 --- Called when a player switches their weapon
 -- @name PlayerSwitchWeapon
 -- @class hook
 -- @shared
--- @param ply Player changing weapon
--- @param oldwep Old weapon
--- @param newweapon New weapon
+-- @param player ply Player changing weapon
+-- @param weapon oldwep Old weapon
+-- @param weapon newweapon New weapon
 
 --- Called when an entity gets created
 -- @name OnEntityCreated
 -- @class hook
 -- @shared
--- @param ent New entity
+-- @param entity ent New entity
 
 --- Called when a clientside entity gets created or re-created via lag/PVS
 -- @name NetworkEntityCreated
 -- @class hook
 -- @client
--- @param ent New entity
+-- @param entity ent New entity
 
 --- Called when a clientside entity transmit state is changed. Usually when changing PVS
 -- If you want clientside render changes to persist on an entity you have to re-apply them
@@ -422,54 +423,54 @@ end
 -- @name NotifyShouldTransmit
 -- @class hook
 -- @client
--- @param ent The entity
--- @param shouldtransmit Whether it is now transmitting or not
+-- @param entity ent The entity
+-- @param boolean shouldtransmit Whether it is now transmitting or not
 
 --- Called when an entity is removed
 -- @name EntityRemoved
 -- @class hook
 -- @shared
--- @param ent Entity being removed
+-- @param entity ent Entity being removed
 
 --- Called when an entity is broken
 -- @name PropBreak
 -- @class hook
 -- @shared
--- @param ply Player who broke it
--- @param ent Entity broken
+-- @param player ply Player who broke it
+-- @param entity ent Entity broken
 
 --- Called every time a bullet is fired from an entity
 -- @name EntityFireBullets
 -- @class hook
 -- @shared
--- @param ent The entity that fired the bullet
--- @param data The bullet data. See http://wiki.facepunch.com/gmod/Structures/Bullet
+-- @param entity ent The entity that fired the bullet
+-- @param table data The bullet data. See http://wiki.facepunch.com/gmod/Structures/Bullet
 
 --- Called when an entity is damaged
 -- @name EntityTakeDamage
 -- @class hook
 -- @server
--- @param target Entity that is hurt
--- @param attacker Entity that attacked
--- @param inflictor Entity that inflicted the damage
--- @param amount How much damage
--- @param type Type of the damage
--- @param position Position of the damage
--- @param force Force of the damage
+-- @param entity target Entity that is hurt
+-- @param entity attacker Entity that attacked
+-- @param entity inflictor Entity that inflicted the damage
+-- @param number amount How much damage
+-- @param number type Type of the damage
+-- @param vector position Position of the damage
+-- @param vector force Force of the damage
 
 --- Called when a player stops driving an entity
 -- @name EndEntityDriving
 -- @class hook
 -- @shared
--- @param ent Entity that had been driven
--- @param ply Player that drove the entity
+-- @param entity ent Entity that had been driven
+-- @param player ply Player that drove the entity
 
 --- Called when a player starts driving an entity
 -- @name StartEntityDriving
 -- @class hook
 -- @shared
--- @param ent Entity being driven
--- @param ply Player that is driving the entity
+-- @param entity ent Entity being driven
+-- @param player ply Player that is driving the entity
 
 --- Think hook. Called each frame on the client and each game tick on the server.
 -- @name think
@@ -490,13 +491,13 @@ end
 -- @name DupeFinished
 -- @class hook
 -- @server
--- @param entTbl A table of entities duped with the chip mapped to their previous indices.
+-- @param table entTbl A table of entities duped with the chip mapped to their previous indices.
 
 --- Called after a client's starfall has initialized. Use this to know when it's safe to send net messages to the client.
 -- @name ClientInitialized
 -- @class hook
 -- @server
--- @param ply The player that initialized
+-- @param player ply The player that initialized
 
 --- Called when the local player opens their chat window.
 -- @name StartChat
@@ -512,27 +513,27 @@ end
 -- @name PlayerChat
 -- @class hook
 -- @client
--- @param ply Player that said the message
--- @param text The message
--- @param team Whether the message was team only
--- @param isdead Whether the message was send from a dead player
+-- @param player ply Player that said the message
+-- @param string text The message
+-- @param boolean team Whether the message was team only
+-- @param boolean isdead Whether the message was send from a dead player
 
 --- Called when starfall chip errors
 -- @name StarfallError
 -- @class hook
 -- @shared
--- @param ent Starfall chip that errored
--- @param ply Owner of the chip on server or player that script errored for on client
--- @param err Error message
+-- @param entity ent Starfall chip that errored
+-- @param player ply Owner of the chip on server or player that script errored for on client
+-- @param string err Error message
 
 --- Called when a component is linked to the starfall
 -- @name ComponentLinked
 -- @class hook
 -- @shared
--- @param ent The component entity
+-- @param entity ent The component entity
 
 --- Called when a component is unlinked to the starfall
 -- @name ComponentUnlinked
 -- @class hook
 -- @shared
--- @param ent The component entity
+-- @param entity ent The component entity

--- a/lua/starfall/libs_sh/http.lua
+++ b/lua/starfall/libs_sh/http.lua
@@ -38,10 +38,10 @@ function http_library.canRequest()
 end
 
 --- Runs a new http GET request
--- @param url http target url
--- @param callbackSuccess the function to be called on request success, taking the arguments body (string), length (number), headers (table) and code (number)
--- @param callbackFail the function to be called on request fail, taking the failing reason as an argument
--- @param headers GET headers to be sent
+-- @param string url Http target url
+-- @param function callbackSuccess The function to be called on request success, taking the arguments body (string), length (number), headers (table) and code (number)
+-- @param function? callbackFail The function to be called on request fail, taking the failing reason as an argument
+-- @param table? headers GET headers to be sent
 function http_library.get(url, callbackSuccess, callbackFail, headers)
 	checkpermission(instance, url, "http.get")
 
@@ -66,11 +66,11 @@ function http_library.get(url, callbackSuccess, callbackFail, headers)
 end
 
 --- Runs a new http POST request
--- @param url http target url
--- @param payload optional POST payload to be sent, can be both table and string. When table is used, the request body is encoded as application/x-www-form-urlencoded
--- @param callbackSuccess optional function to be called on request success, taking the arguments body (string), length (number), headers (table) and code (number)
--- @param callbackFail optional function to be called on request fail, taking the failing reason as an argument
--- @param headers optional POST headers to be sent
+-- @param string url Http target url
+-- @param table? payload Optional POST payload to be sent, can be both table and string. When table is used, the request body is encoded as application/x-www-form-urlencoded
+-- @param function? callbackSuccess Optional function to be called on request success, taking the arguments body (string), length (number), headers (table) and code (number)
+-- @param function? callbackFail Optional function to be called on request fail, taking the failing reason as an argument
+-- @param table? headers Optional POST headers to be sent
 function http_library.post(url, payload, callbackSuccess, callbackFail, headers)
 	checkluatype(url, TYPE_STRING)
 	checkpermission(instance, url, "http.post")
@@ -131,25 +131,25 @@ function http_library.post(url, payload, callbackSuccess, callbackFail, headers)
 end
 
 --- Converts data into base64 format or nil if the string is 0 length
---@name http_library.base64Encode
---@class function
---@param data The data to convert
---@return The converted data
+-- @name http_library.base64Encode
+-- @class function
+-- @param string data The data to convert
+-- @return string The converted data
 function http_library.base64Encode(data)
 	checkluatype(data, TYPE_STRING)
 	return string.gsub(util.Base64Encode(data),"\n","")
 end
 
 --- Converts data from base64 format
---@name http_library.base64Decode
---@class function
---@param data The data to convert
---@return The converted data
+-- @name http_library.base64Decode
+-- @class function
+-- @param string data The data to convert
+-- @return string The converted data
 http_library.base64Decode = util.Base64Decode
 
 --- Encodes illegal url characters to be legal
---@param data The data to convert
---@return The converted data
+-- @param string data The data to convert
+-- @return string The converted data
 function http_library.urlEncode(data)
 	checkluatype(data, TYPE_STRING)
 	data = string.gsub(data, "[^%w_~%.%-%(%)!%*]", function(char)

--- a/lua/starfall/libs_sh/input.lua
+++ b/lua/starfall/libs_sh/input.lua
@@ -234,7 +234,7 @@ end
 
 --- Gets whether the cursor is visible on the screen
 -- @client
--- @return The cursor's visibility
+-- @return boolean The cursor's visibility
 function input_library.getCursorVisible()
 	checkpermission(instance, nil, "input")
 

--- a/lua/starfall/libs_sh/input.lua
+++ b/lua/starfall/libs_sh/input.lua
@@ -245,7 +245,7 @@ end
 -- @client
 -- @param number x X coordinate on the screen
 -- @param number y Y coordinate on the screen
--- @return vector Aim vector
+-- @return Vector Aim vector
 function input_library.screenToVector(x, y)
 	checkpermission(instance, nil, "input")
 	checkluatype(x, TYPE_NUMBER)
@@ -270,7 +270,7 @@ end
 
 --- Makes the local player select a weapon
 -- @client
--- @param weapon weapon The weapon entity to select
+-- @param Weapon weapon The weapon entity to select
 function input_library.selectWeapon(weapon)
 	local ent = getent(weapon)
 	if not (ent:IsWeapon() and ent:IsCarriedByLocalPlayer()) then SF.Throw("This weapon is not your own!", 2) end

--- a/lua/starfall/libs_sh/input.lua
+++ b/lua/starfall/libs_sh/input.lua
@@ -151,9 +151,9 @@ local vwrap = instance.Types.Vector.Wrap
 
 --- Gets the first key that is bound to the command passed
 -- @client
--- @param binding The name of the bind
--- @return The id of the first key bound
--- @return The name of the first key bound
+-- @param string binding The name of the bind
+-- @return number The id of the first key bound
+-- @return string The name of the first key bound
 
 function input_library.lookupBinding(binding)
 	checkluatype(binding, TYPE_STRING)
@@ -170,8 +170,8 @@ end
 
 --- Gets whether a key is down
 -- @client
--- @param key The key id, see input
--- @return True if the key is down
+-- @param number key The key id, see input
+-- @return boolean True if the key is down
 function input_library.isKeyDown(key)
 	checkluatype(key, TYPE_NUMBER)
 
@@ -182,8 +182,8 @@ end
 
 --- Gets whether a mouse button is down
 -- @client
--- @param key The mouse button id, see input
--- @return True if the key is down
+-- @param number key The mouse button id, see input
+-- @return boolean True if the key is down
 function input_library.isMouseDown(key)
 	checkluatype(key, TYPE_NUMBER)
 
@@ -194,8 +194,8 @@ end
 
 --- Gets the name of a key from the id
 -- @client
--- @param key The key id, see input
--- @return The name of the key
+-- @param number key The key id, see input
+-- @return string The name of the key
 function input_library.getKeyName(key)
 	checkluatype(key, TYPE_NUMBER)
 
@@ -206,7 +206,7 @@ end
 
 --- Gets whether the shift key is down
 -- @client
--- @return True if the shift key is down
+-- @return boolean True if the shift key is down
 function input_library.isShiftDown()
 	checkpermission(instance, nil, "input")
 
@@ -215,7 +215,7 @@ end
 
 --- Gets whether the control key is down
 -- @client
--- @return True if the control key is down
+-- @return boolean True if the control key is down
 function input_library.isControlDown()
 	checkpermission(instance, nil, "input")
 
@@ -224,8 +224,8 @@ end
 
 --- Gets the position of the mouse
 -- @client
--- @return The x position of the mouse
--- @return The y position of the mouse
+-- @return number The x position of the mouse
+-- @return number The y position of the mouse
 function input_library.getCursorPos()
 	checkpermission(instance, nil, "input")
 
@@ -243,9 +243,9 @@ end
 
 ---Translates position on player's screen to aim vector
 -- @client
--- @param x X coordinate on the screen
--- @param y Y coordinate on the screen
--- @return Aim vector
+-- @param number x X coordinate on the screen
+-- @param number y Y coordinate on the screen
+-- @return vector Aim vector
 function input_library.screenToVector(x, y)
 	checkpermission(instance, nil, "input")
 	checkluatype(x, TYPE_NUMBER)
@@ -255,7 +255,7 @@ end
 
 --- Sets the state of the mouse cursor
 -- @client
--- @param enabled Whether or not the cursor should be enabled
+-- @param boolean enabled Whether or not the cursor should be enabled
 function input_library.enableCursor(enabled)
 	checkluatype(enabled, TYPE_BOOL)
 	checkpermission(instance, nil, "input")
@@ -270,17 +270,17 @@ end
 
 --- Makes the local player select a weapon
 -- @client
--- @param weapon The weapon entity to select
+-- @param weapon weapon The weapon entity to select
 function input_library.selectWeapon(weapon)
 	local ent = getent(weapon)
 	if not (ent:IsWeapon() and ent:IsCarriedByLocalPlayer()) then SF.Throw("This weapon is not your own!", 2) end
 	checkpermission(instance, nil, "input.emulate")
-	input.SelectWeapon( ent ) 
+	input.SelectWeapon( ent )
 end
 
 --- Locks game controls for typing purposes. Alt will unlock the controls. Has a 10 second cooldown.
 -- @client
--- @param enabled Whether to lock or unlock the controls
+-- @param boolean enabled Whether to lock or unlock the controls
 function input_library.lockControls(enabled)
 	checkluatype(enabled, TYPE_BOOL)
 	checkpermission(instance, nil, "input")
@@ -302,14 +302,14 @@ end
 
 --- Gets whether the player's control is currenty locked
 -- @client
--- @return Whether the player's control is locked
+-- @return boolean Whether the player's control is locked
 function input_library.isControlLocked()
 	return controlsLocked
 end
 
 --- Gets whether the player's control can be locked
 -- @client
--- @return Whether the player's control can be locked
+-- @return boolean Whether the player's control can be locked
 function input_library.canLockControls()
 	return SF.IsHUDActive(instance.entity) and lockedControlCooldown <= CurTime()
 end
@@ -322,24 +322,24 @@ end
 -- @client
 -- @name inputPressed
 -- @class hook
--- @param button Number of the button
+-- @param number button Number of the button
 
 --- Called when a button is released
 -- @client
 -- @name inputReleased
 -- @class hook
--- @param button Number of the button
+-- @param number button Number of the button
 
 --- Called when the mouse is moved
 -- @client
 -- @name mousemoved
 -- @class hook
--- @param x X coordinate moved
--- @param y Y coordinate moved
+-- @param number x X coordinate moved
+-- @param number y Y coordinate moved
 
 --- Called when the mouse wheel is rotated
 -- @client
 -- @name mouseWheeled
 -- @class hook
--- @param delta Rotate delta
+-- @param number delta Rotate delta
 

--- a/lua/starfall/libs_sh/json.lua
+++ b/lua/starfall/libs_sh/json.lua
@@ -14,17 +14,17 @@ return function(instance)
 local json_library = instance.Libraries.json
 
 --- Convert table to JSON string
---@param tbl Table to encode
---@param prettyPrint Optional. If true, formats and indents the resulting JSON
---@return JSON encoded string representation of the table
+-- @param table tbl Table to encode
+-- @param boolean? prettyPrint Optional. If true, formats and indents the resulting JSON
+-- @return string JSON encoded string representation of the table
 function json_library.encode(tbl, prettyPrint)
 	SF.CheckLuaType(tbl, TYPE_TABLE)
 	return util.TableToJSON(instance.Unsanitize(tbl), prettyPrint)
 end
 
 --- Convert JSON string to table
--- @param s String to decode
--- @return Table representing the JSON object
+-- @param string s String to decode
+-- @return table Table representing the JSON object
 function json_library.decode(s)
 	SF.CheckLuaType(s, TYPE_STRING)
 	return instance.Sanitize(util.JSONToTable(s))

--- a/lua/starfall/libs_sh/math.lua
+++ b/lua/starfall/libs_sh/math.lua
@@ -18,137 +18,137 @@ local math_library = instance.Libraries.math
 
 --- Calculates the absolute value of a number (effectively removes any negative sign).
 -- @class function
--- @param x The number to get the absolute value of
--- @return Absolute value
+-- @param number x The number to get the absolute value of
+-- @return number Absolute value
 math_library.abs = math.abs
 
 --- Calculates the sign of a number
 -- @class function
--- @param x The number to get the sign of
--- @return -1 if negative, 1 if positive, 0 if 0
+-- @param number x The number to get the sign of
+-- @return number -1 if negative, 1 if positive, 0 if 0
 function math_library.sign(x)
 	return (x<0 and -1) or (x>0 and 1) or 0
 end
 
 --- Calculates an angle in radians, between 0 and pi, which has the given cos value.
 -- @class function
--- @param cos Cosine value in range of -1 to 1
--- @return Angle in radians or nothing if the argument is out of range
+-- @param number cos Cosine value in range of -1 to 1
+-- @return number Angle in radians or nothing if the argument is out of range
 math_library.acos = math.acos
 
 --- Calculates the difference between two angles.
 -- @class function
--- @param a The first angle
--- @param b The second angle
--- @return The difference between the angles between -180 and 180
+-- @param number a The first angle
+-- @param number b The second angle
+-- @return number The difference between the angles between -180 and 180
 math_library.angleDifference = math.AngleDifference
 
 --- Gradually approaches the target value by the specified amount.
 -- @class function
--- @param current The value we're currently at
--- @param target The target value. This function will never overshoot this value
--- @param change The amount that the current value is allowed to change by to approach the target (positive or negative)
--- @return New current value, closer to the target than it was previously
+-- @param number current The value we're currently at
+-- @param number target The target value. This function will never overshoot this value
+-- @param number change The amount that the current value is allowed to change by to approach the target (positive or negative)
+-- @return number New current value, closer to the target than it was previously
 math_library.approach = math.Approach
 
 --- Increments an angle towards another by specified rate.
 -- @class function
--- @param currentAngle The current angle to increase
--- @param targetAngle The angle to increase towards
--- @param rate The amount to approach the target angle by
--- @return Modified angle
+-- @param number currentAngle The current angle to increase
+-- @param number targetAngle The angle to increase towards
+-- @param number rate The amount to approach the target angle by
+-- @return number Modified angle
 math_library.approachAngle = math.ApproachAngle
 
 --- Calculates an angle in radians, in the range -pi/2 to pi/2, which has the given sine value.
 -- @class function
--- @param sin Sine value in the range of -1 to 1
--- @return Angle in radians or nothing if the argument is out of range
+-- @param number sin Sine value in the range of -1 to 1
+-- @return number Angle in radians or nothing if the argument is out of range
 math_library.asin = math.asin
 
 --- Calculates an angle in radians, in the range -pi/2 to pi/2, which has the given tangent.
 -- @class function
--- @param tan Tangent value
--- @return Angle in radians
+-- @param number tan Tangent value
+-- @return number Angle in radians
 math_library.atan = math.atan
 
 --- Functions like math.atan(y / x), except it also takes into account the quadrant of the angle and so doesn't have a limited range of output.
 -- @class function
--- @param y The Y coordinate
--- @param x The X coordinate
--- @return Angle of the line from (0, 0) to (x, y) in radians, in the range -pi to pi
+-- @param number y The Y coordinate
+-- @param number x The X coordinate
+-- @return number Angle of the line from (0, 0) to (x, y) in radians, in the range -pi to pi
 math_library.atan2 = math.atan2
 
 --- Converts a binary string into a number.
 -- @class function
--- @param sting Binary string to convert
--- @return Base 10 number
+-- @param string str Binary string to convert
+-- @return number Base 10 number
 math_library.binToInt = math.BinToInt
 
 --- Basic code for Bezier-Spline algorithm.
 -- @class function
--- @param i Number
--- @param k Number
--- @param t Number
--- @param tinc Number
--- @return Number value
+-- @param number i
+-- @param number k
+-- @param number t
+-- @param number tinc
+-- @return number Number value
 math_library.calcBSplineN = math.calcBSplineN
 
 --- Rounds a number up.
 -- @class function
--- @param n Number to be rounded
--- @return Rounded number
+-- @param number n Number to be rounded
+-- @return number Rounded number
 math_library.ceil = math.ceil
 
 --- Clamps a number between a minimum and maximum value.
 -- @class function
--- @param current Input number
--- @param min Minimum value
--- @param max Maximum value
--- @return Clamped number
+-- @param number current Input number
+-- @param number min Minimum value
+-- @param number max Maximum value
+-- @return number Clamped number
 math_library.clamp = math.Clamp
 
 --- Calculates cosine of the given angle.
 -- @class function
--- @param angle Angle in radians
--- @return Cosine of the angle
+-- @param number angle Angle in radians
+-- @return number Cosine of the angle
 math_library.cos = math.cos
 
 --- Calculates hyperbolic cosine of the given angle.
 -- @class function
--- @param angle Angle in radians
--- @return The hyperbolic cosine of the angle
+-- @param number angle Angle in radians
+-- @return number The hyperbolic cosine of the angle
 math_library.cosh = math.cosh
 
 --- Converts radians to degrees
 -- @class function
--- @param rad Angle in radians to be converted
--- @return Angle in degrees
+-- @param number rad Angle in radians to be converted
+-- @return number Angle in degrees
 math_library.deg = math.deg
 
 --- Calculates the difference between two points in 2D space (DEPRECATED! You should use math.distance instead)
 -- @class function
--- @param x1 X position of first point
--- @param y1 Y position of first point
--- @param x2 X position of second point
--- @param y2 Y position of second point
--- @return Distance between the two points
+-- @param number x1 X position of first point
+-- @param number y1 Y position of first point
+-- @param number x2 X position of second point
+-- @param number y2 Y position of second point
+-- @return number Distance between the two points
 math_library.dist = math.Dist
 
 --- Calculates the difference between two points in 2D space
 -- @class function
--- @param x1 X position of first point
--- @param y1 Y position of first point
--- @param x2 X position of second point
--- @param y2 Y position of second point
--- @return Distance between the two points
+-- @param number x1 X position of first point
+-- @param number y1 Y position of first point
+-- @param number x2 X position of second point
+-- @param number y2 Y position of second point
+-- @return number Distance between the two points
 math_library.distance = math.Distance
 
 --- Calculates the progress of a value fraction, taking in to account given easing fractions.
 -- @class function
--- @param progress Fraction of the progress to ease
--- @param easeIn Fraction of how much easing to begin with
--- @param easeOut Fraction of how much easing to end with
--- @return Eased value
+-- @param number progress Fraction of the progress to ease
+-- @param number easeIn Fraction of how much easing to begin with
+-- @param number easeOut Fraction of how much easing to end with
+-- @return number Eased value
 math_library.easeInOut = math.EaseInOut
 
 --- Returns the x power of the Euler constant.
@@ -159,193 +159,193 @@ math_library.exp = math.exp
 
 --- Rounds a number down.
 -- @class function
--- @param n Number to be rounded
--- @return Rounded number
+-- @param number n Number to be rounded
+-- @return number Rounded number
 math_library.floor = math.floor
 
 --- Calculates the modulus of the specified values.
 -- @class function
--- @param base The base value
--- @param mod The modulator
--- @return The calculated modulus
+-- @param number base The base value
+-- @param number mod The modulator
+-- @return number The calculated modulus
 math_library.fmod = math.fmod
 
 --- Used to split the number value into a normalized fraction and an exponent
 -- @class function
--- @param x The value to get the normalized fraction and the exponent from
--- @return Multiplier between 0.5 and 1
--- @return Exponent integer
+-- @param number x The value to get the normalized fraction and the exponent from
+-- @return number Multiplier between 0.5 and 1
+-- @return number Exponent integer
 math_library.frexp = math.frexp
 
 math_library.huge = math.huge
 
 --- Converts an integer to a binary (base-2) string.
 -- @class function
--- @param int Number to be converted
--- @return Binary number string. The length of this will always be a multiple of 3
+-- @param number int Number to be converted
+-- @return string Binary number string. The length of this will always be a multiple of 3
 math_library.intToBin = math.IntToBin
 
 --- Takes a normalised number and returns the floating point representation.
 -- @class function
--- @param normalizedFraction The value to get the normalized fraction and the exponent from
--- @param exponent The value to get the normalized fraction and the exponent from
--- @return Floating point reperesentation
+-- @param number normalizedFraction The value to get the normalized fraction and the exponent from
+-- @param number exponent The value to get the normalized fraction and the exponent from
+-- @return number Floating point reperesentation
 math_library.ldexp = math.ldexp
 
 --- With one argument, returns the natural logarithm of x (to base e).
 -- With two arguments, return the logarithm of x to the given base, calculated as log(x) / log(base).
 -- @class function
--- @param x The value to get the base from exponent from
--- @param base Optional logarithmic base
--- @return Logarithm of x to the given base
+-- @param number x The value to get the base from exponent from
+-- @param number? base Optional logarithmic base. Default 'e'
+-- @return number Logarithm of x to the given base
 math_library.log = math.log
 
 --- Returns the base-10 logarithm of x. This is usually more accurate than math.log(x, 10).
 -- @class function
--- @param x The value to get the base from exponent from
--- @return Logarithm of x to the base 10
+-- @param number x The value to get the base from exponent from
+-- @return number Logarithm of x to the base 10
 math_library.log10 = math.log10
 
 --- Picks the largest value of all provided arguments.
 -- @class function
--- @param ... Any amount of number values
--- @return The largest number
+-- @param ...number numbers Any amount of number values
+-- @return number The largest number
 math_library.max = math.max
 
 --- Picks the smallest value of all provided arguments.
 -- @class function
--- @param ... Any amount of number values
--- @return The smallest number
+-- @param ...number numbers Any amount of number values
+-- @return number The smallest number
 math_library.min = math.Min
 
 --- Returns the modulus of the specified values. (DEPRECATED! You should use the % operator instead)
 -- @class function
--- @param base The base value
--- @param mod The modulator
--- @return The calculated modulus
+-- @param number base The base value
+-- @param number mod The modulator
+-- @return number The calculated modulus
 math_library.mod = math.mod
 
 --- Returns the integral and fractional component of the modulo operation.
 -- @class function
--- @param base The base value
--- @return The integral component
--- @return The fractional component
+-- @param number base The base value
+-- @return number The integral component
+-- @return number The fractional component
 math_library.modf = math.modf
 
 --- Normalizes angle, so it returns value between -180 and 180.
 -- @class function
--- @param ang The angle in degrees
--- @return The normalized angle
+-- @param number ang The angle in degrees
+-- @return number The normalized angle
 math_library.normalizeAngle = math.NormalizeAngle
 
 math_library.pi = math.pi
 
 ---Returns x raised to the power y
 -- @class function
--- @param base The Base number
--- @param exp The Exponent
--- @return Exponent power of base
+-- @param number base The Base number
+-- @param number exp The Exponent
+-- @return number Exponent power of base
 math_library.pow = math.pow
 
 --- Converts an angle from degrees to radians.
 -- @class function
--- @param deg Angle in degrees
--- @return Angle in radians
+-- @param number deg Angle in degrees
+-- @return number Angle in radians
 math_library.rad = math.rad
 
 --- Returns a random float between min and max.
 -- @class function
--- @param min The minimum value
--- @param max The maximum value
--- @return Random float between min and max
+-- @param number min The minimum value
+-- @param number max The maximum value
+-- @return number Random float between min and max
 math_library.rand = math.Rand
 
 --- When called without arguments, returns a uniform pseudo-random real number in the range 0 to 1 which includes 0 but excludes 1.
 -- When called with an integer number m, returns a uniform pseudo-random integer in the range 1 to m inclusive.
 -- When called with two integer numbers m and n, returns a uniform pseudo-random integer in the range m to n inclusive.
 -- @class function
--- @param m Optional integer value. If n is not provided - upper limit; if n is provided - lower limit
--- @param n Optional integer value. Upper value
--- @return Random value
+-- @param number? m Optional integer value. If n is not provided - upper limit; if n is provided - lower limit
+-- @param number? n Optional integer value. Upper value
+-- @return number Random value
 math_library.random = math.random
 
 --- Remaps the value from one range to another.
 -- @class function
--- @param value The number value
--- @param inMin The minimum of the initial range
--- @param inMax The maximum of the initial range
--- @param outMin The minimum of new range
--- @param outMax The maximum of new range
--- @return The number in the new range
+-- @param number value The number value
+-- @param number inMin The minimum of the initial range
+-- @param number inMax The maximum of the initial range
+-- @param number outMin The minimum of new range
+-- @param number outMax The maximum of new range
+-- @return number The number in the new range
 math_library.remap = math.Remap
 
 --- Rounds the given value to the nearest whole number or to the given decimal places.
 -- @class function
--- @param value The number to be rounded
--- @param decimals Optional decimal places to round to. Defaults to 0
+-- @param number value The number to be rounded
+-- @param number? decimals Optional decimal places to round to. Defaults to 0
 math_library.round = math.Round
 
 --- Calculates the sine of given angle.
 -- @class function
--- @param ang Angle in radians
--- @return Sine for given angle
+-- @param number ang Angle in radians
+-- @return number Sine for given angle
 math_library.sin = math.sin
 
 --- Calculates the hyperbolic sine of the given angle.
 -- @class function
--- @param ang Angle in radians
--- @return The hyperbolic sine of the given angle
+-- @param number ang Angle in radians
+-- @return number The hyperbolic sine of the given angle
 math_library.sinh = math.sinh
 
 --- Calculates square root of the number.
 -- @class function
--- @param value The value to get the square root of
--- @return Square root of the provided value
+-- @param number value The value to get the square root of
+-- @return number Square root of the provided value
 math_library.sqrt = math.sqrt
 
 --- Calculates the tangent of the given angle.
 -- @class function
--- @param ang Angle in radians
--- @return The tangent of the given angle
+-- @param number ang Angle in radians
+-- @return number The tangent of the given angle
 math_library.tan = math.tan
 
 --- Calculates hyperbolic tangent of the given angle.
 -- @class function
--- @param ang Angle in radians
--- @return The hyperbolic tangent of the given angle
+-- @param number ang Angle in radians
+-- @return number The hyperbolic tangent of the given angle
 math_library.tanh = math.tanh
 
 --- Calculates the fraction of where the current time is relative to the start and end times.
 -- @class function
--- @param start Start time in seconds
--- @param end End time in seconds
--- @param current Current time in seconds
--- @return The time fraction
+-- @param number start Start time in seconds
+-- @param number end End time in seconds
+-- @param number current Current time in seconds
+-- @return number The time fraction
 math_library.timeFraction = math.TimeFraction
 
 --- Rounds towards zero
 -- @class function
--- @param val The number to truncate
--- @param digits The amount of digits to keep after the point
--- @return Rounded number
+-- @param number val The number to truncate
+-- @param number? digits The amount of digits to keep after the point. Default 0
+-- @return number Rounded number
 math_library.truncate = math.Truncate
 
 --- Calculates B-Spline point.
 -- @class function
--- @param tDiff From 0 to tMax, where alongside the spline the point will be
--- @param tPoints A table of Vectors. The amount cannot be less than 4
--- @param tMax Dictates maximum value for tDiff
--- @return Point on Bezier curve, related to tDiff
+-- @param number tDiff From 0 to tMax, where alongside the spline the point will be
+-- @param number tPoints A table of Vectors. The amount cannot be less than 4
+-- @param number tMax Dictates maximum value for tDiff
+-- @return number Point on Bezier curve, related to tDiff
 function math_library.bSplinePoint(tDiff, tPoints, tMax)
 	return vwrap(math.BSplinePoint(tDiff, instance.Unsanitize(tPoints), tMax))
 end
 
 --- Performs a linear interpolation from the start number to the end number.
 -- @class function
--- @param t The fraction for finding the result. This number is clamped between 0 and 1
--- @param from The starting number. The result will be equal to this if value t is 0
--- @param to The ending number. The result will be equal to this if value t is 1
--- @return The result of the linear interpolation, (1 - t) * from + t * to
+-- @param number t The fraction for finding the result. This number is clamped between 0 and 1
+-- @param number from The starting number. The result will be equal to this if value t is 0
+-- @param number to The ending number. The result will be equal to this if value t is 1
+-- @return number The result of the linear interpolation, (1 - t) * from + t * to
 function math_library.lerp(t, from, to)
 	checkluatype(t, TYPE_NUMBER)
 	checkluatype(from, TYPE_NUMBER)
@@ -355,10 +355,10 @@ end
 
 --- Calculates point between first and second angle using given fraction and linear interpolation.
 -- @class function
--- @param ratio Ratio of progress through values
--- @param from Angle to begin from
--- @param to Angle to end at
--- @return The interpolated angle
+-- @param number ratio Ratio of progress through values
+-- @param number from Angle to begin from
+-- @param number to Angle to end at
+-- @return number The interpolated angle
 function math_library.lerpAngle(ratio, from, to)
 	checkluatype(ratio, TYPE_NUMBER)
 	return awrap(LerpAngle(ratio, aunwrap(from), aunwrap(to)))
@@ -366,19 +366,19 @@ end
 
 --- Calculates point between first and second vector using given fraction and linear interpolation.
 -- @class function
--- @param ratio Ratio of progress through values
--- @param from Vector to begin from
--- @param to Vector to end at
--- @return The interpolated vector
+-- @param number ratio Ratio of progress through values
+-- @param vector from Vector to begin from
+-- @param vector Vector to end at
+-- @return vector The interpolated vector
 function math_library.lerpVector(ratio, from, to)
 	checkluatype(ratio, TYPE_NUMBER)
 	return vwrap(LerpVector(ratio, vunwrap(from), vunwrap(to)))
 end
 
 --- Gets the distance between a line and a point in 3d space
--- @param lineStart Start of the line
--- @param lineEnd End of the line
--- @param pointPos Position of the point
+-- @param vector lineStart Start of the line
+-- @param vector lineEnd End of the line
+-- @param vector pointPos Position of the point
 -- @return number Distance from line
 -- @return vector Nearest point on line
 -- @return number Distance along line from start
@@ -388,10 +388,10 @@ function math_library.distanceToLine(lineStart, lineEnd, pointPos)
 end
 
 --- Generates a random float value that should be the same on client and server
--- @param uniqueName The seed for the random value
--- @param Min The minimum value of the random range
--- @param Max The maximum value of the random range
--- @param additionalSeed The additional seed
+-- @param string uniqueName The seed for the random value
+-- @param number Min The minimum value of the random range
+-- @param number Max The maximum value of the random range
+-- @param number? additionalSeed The additional seed. Default 0
 -- @return number The random float value
 function math_library.sharedRandom(uniqueName, Min, Max, additionalSeed)
 	checkluatype(uniqueName, TYPE_STRING)

--- a/lua/starfall/libs_sh/math.lua
+++ b/lua/starfall/libs_sh/math.lua
@@ -153,8 +153,8 @@ math_library.easeInOut = math.EaseInOut
 
 --- Returns the x power of the Euler constant.
 -- @class function
--- @param x The exponent of the function
--- @return e to the specific power
+-- @param number x The exponent of the function
+-- @return number e to the specific power
 math_library.exp = math.exp
 
 --- Rounds a number down.

--- a/lua/starfall/libs_sh/math.lua
+++ b/lua/starfall/libs_sh/math.lua
@@ -367,20 +367,20 @@ end
 --- Calculates point between first and second vector using given fraction and linear interpolation.
 -- @class function
 -- @param number ratio Ratio of progress through values
--- @param vector from Vector to begin from
--- @param vector Vector to end at
--- @return vector The interpolated vector
+-- @param Vector from Vector to begin from
+-- @param Vector Vector to end at
+-- @return Vector The interpolated vector
 function math_library.lerpVector(ratio, from, to)
 	checkluatype(ratio, TYPE_NUMBER)
 	return vwrap(LerpVector(ratio, vunwrap(from), vunwrap(to)))
 end
 
 --- Gets the distance between a line and a point in 3d space
--- @param vector lineStart Start of the line
--- @param vector lineEnd End of the line
--- @param vector pointPos Position of the point
+-- @param Vector lineStart Start of the line
+-- @param Vector lineEnd End of the line
+-- @param Vector pointPos Position of the point
 -- @return number Distance from line
--- @return vector Nearest point on line
+-- @return Vector Nearest point on line
 -- @return number Distance along line from start
 function math_library.distanceToLine(lineStart, lineEnd, pointPos)
 	local nearDist, nearPoint, startDist = util.DistanceToLine(vunwrap(lineStart), vunwrap(lineEnd), vunwrap(pointPos))

--- a/lua/starfall/libs_sh/mesh.lua
+++ b/lua/starfall/libs_sh/mesh.lua
@@ -965,14 +965,14 @@ if CLIENT then
 	end
 	
 	--- Sets the vertex normal
-	-- @param vector normal Normal
+	-- @param Vector normal Normal
 	-- @client
 	function mesh_library.writeNormal(normal)
 		mesh.Normal(vunwrap(normal))
 	end
 	
 	--- Sets the vertex position
-	-- @param vector position Position
+	-- @param Vector position Position
 	-- @client
 	function mesh_library.writePosition(pos)
 		mesh.Position(vunwrap(pos))
@@ -998,18 +998,18 @@ if CLIENT then
 	end
 	
 	--- Draws a quad using 4 vertices
-	-- @param vector v1 Vertex1 position
-	-- @param vector v2 Vertex2 position
-	-- @param vector v3 Vertex3 position
-	-- @param vector v4 Vertex4 position
+	-- @param Vector v1 Vertex1 position
+	-- @param Vector v2 Vertex2 position
+	-- @param Vector v3 Vertex3 position
+	-- @param Vector v4 Vertex4 position
 	-- @client
 	function mesh_library.writeQuad(v1, v2, v3, v4)
 		mesh.Quad(vunwrap(v1), vunwrap(v2), vunwrap(v3), vunwrap(v4))
 	end
 	
 	--- Draws a quad using a position, normal and size
-	-- @param vector position
-	-- @param vector normal
+	-- @param Vector position
+	-- @param Vector normal
 	-- @param number w
 	-- @param number h
 	-- @client

--- a/lua/starfall/libs_sh/mesh.lua
+++ b/lua/starfall/libs_sh/mesh.lua
@@ -761,7 +761,7 @@ if CLIENT then
 	--- Creates a mesh from vertex data.
 	-- @param table verteces Table containing vertex data. http://wiki.facepunch.com/gmod/Structures/MeshVertex
 	-- @param boolean? threaded Optional bool, use threading object that can be used to load the mesh over time to prevent hitting quota limit. The thread will yield with number of vertices remaining to be processed. After 0 is yielded, the final expensive phase starts.
-	-- @return mesh Mesh object
+	-- @return Mesh Mesh object
 	-- @client
 	function mesh_library.createFromTable(verteces, threaded)
 		checkpermission (instance, nil, "mesh")
@@ -829,13 +829,13 @@ if CLIENT then
 	end
 
 	--- Creates a mesh without any vertex data.
-	-- @return mesh Mesh object
+	-- @return Mesh Mesh object
 	-- @client
 	function mesh_library.createEmpty()
 		checkpermission(instance, nil, "mesh")
-		
+
 		plyMeshCount:use(instance.player, 1)
-		
+
 		local mesh = Mesh()
 		meshData[mesh] = { ntriangles = 0 }
 		return wrap(mesh)
@@ -909,27 +909,27 @@ if CLIENT then
 		[MATERIAL_TRIANGLE_STRIP] = function(count) return count end
 	}
 	--- Generates mesh data. If an Mesh object is passed, it will populate that mesh with the data. Otherwise, it will render directly to renderer.
-	-- @param mesh? mesh_obj Optional Mesh object, mesh to build. (default: nil)
+	-- @param Mesh? mesh_obj Optional Mesh object, mesh to build. (default: nil)
 	-- @param number prim_type Int, primitive type, see MATERIAL
 	-- @param number prim_count Int, the amount of primitives
 	-- @param function func The function provided that will generate the mesh vertices
 	-- @client
 	function mesh_library.generate(mesh_obj, prim_type, prim_count, func)
 		if meshgenerating then SF.Throw("Dynamic mesh was already started.", 2) end
-		
+
 		checkpermission(instance, nil, "mesh")
-		
+
 		checkluatype(prim_type, TYPE_NUMBER)
 		checkluatype(prim_count, TYPE_NUMBER)
 		checkluatype(func, TYPE_FUNCTION)
-		
+
 		local prim_trifunc = prim_triangles[prim_type]
 		if not prim_trifunc then SF.Throw("Invalid Primitive.", 2) end
-		
+
 		if prim_count<1 then SF.Throw("Can't generate with less than 1 primitive", 2) end
 		if prim_count>8192 then SF.Throw("Can't generate more than 8192 primitives", 2) end
 		prim_count = math.floor(prim_count)
-		
+
 		local tri_count = math.max(1, math.ceil(prim_trifunc(prim_count)))
 		if mesh_obj == nil then
 			if not instance.data.render.isRendering then SF.Throw("Not in rendering hook.", 2) end 
@@ -947,13 +947,13 @@ if CLIENT then
 			meshgenerating = mesh_obj
 			mesh.Begin(mesh_obj, prim_type, prim_count)
 		end
-		
+
 		local ok, err = pcall(func)
 		mesh.End()
 		meshgenerating = false
 		if not ok then SF.Throw(err, 2) end
 	end
-	
+
 	--- Sets the vertex color by RGBA values
 	-- @param number r Number, red value
 	-- @param number g Number, green value
@@ -963,21 +963,21 @@ if CLIENT then
 	function mesh_library.writeColor(r, g, b, a)
 		mesh.Color(r, g, b, a)
 	end
-	
+
 	--- Sets the vertex normal
 	-- @param Vector normal Normal
 	-- @client
 	function mesh_library.writeNormal(normal)
 		mesh.Normal(vunwrap(normal))
 	end
-	
+
 	--- Sets the vertex position
 	-- @param Vector position Position
 	-- @client
 	function mesh_library.writePosition(pos)
 		mesh.Position(vunwrap(pos))
 	end
-	
+
 	--- Sets the vertex texture coordinates
 	-- @param number stage Stage of the texture coordinate
 	-- @param number u U coordinate
@@ -986,7 +986,7 @@ if CLIENT then
 	function mesh_library.writeUV(stage, u, v)
 		mesh.TexCoord(stage, u, v)
 	end
-	
+
 	--- Sets the vertex tangent user data
 	-- @param number x x
 	-- @param number y y
@@ -996,7 +996,7 @@ if CLIENT then
 	function mesh_library.writeUserData(x, y, z, handedness)
 		mesh.UserData(x, y, z, handedness)
 	end
-	
+
 	--- Draws a quad using 4 vertices
 	-- @param Vector v1 Vertex1 position
 	-- @param Vector v2 Vertex2 position
@@ -1006,7 +1006,7 @@ if CLIENT then
 	function mesh_library.writeQuad(v1, v2, v3, v4)
 		mesh.Quad(vunwrap(v1), vunwrap(v2), vunwrap(v3), vunwrap(v4))
 	end
-	
+
 	--- Draws a quad using a position, normal and size
 	-- @param Vector position
 	-- @param Vector normal
@@ -1016,13 +1016,13 @@ if CLIENT then
 	function mesh_library.writeQuadEasy(position, normal, w, h)
 		mesh.QuadEasy(vunwrap(position), vunwrap(normal), w, h)
 	end
-	
+
 	--- Pushes the vertex data onto the render stack
 	-- @client
 	function mesh_library.advanceVertex()
 		mesh.AdvanceVertex()
 	end
-	
+
 	--- Draws the mesh. Must be in a 3D rendering context.
 	-- @client
 	function mesh_methods:draw()

--- a/lua/starfall/libs_sh/net.lua
+++ b/lua/starfall/libs_sh/net.lua
@@ -526,4 +526,4 @@ end
 -- @class hook
 -- @param string name Name of the arriving net message
 -- @param number len Length of the arriving net message in bits
--- @param Entity ply On server, the player that sent the message. Nil on client.
+-- @param Player? ply On server, the player that sent the message. Nil on client.

--- a/lua/starfall/libs_sh/net.lua
+++ b/lua/starfall/libs_sh/net.lua
@@ -70,7 +70,7 @@ end
 
 --- Starts the net message
 -- @shared
--- @param name The message name
+-- @param string name The message name
 function net_library.start(name)
 	checkluatype (name, TYPE_STRING)
 	if netStarted then SF.Throw("net message was already started", 2) end
@@ -83,9 +83,9 @@ function net_library.start(name)
 end
 
 --- Send a net message from client->server, or server->client.
---@shared
---@param target Optional target location to send the net message.
---@param unreliable Optional choose whether it's more important for the message to actually reach its destination (false) or reach it as fast as possible (true).
+-- @shared
+-- @param any? target Optional target location to send the net message. Entity or table of targets
+-- @param boolean? unreliable Optional choose whether it's more important for the message to actually reach its destination (false) or reach it as fast as possible (true).
 function net_library.send(target, unreliable)
 	if target~=nil then checkluatype(target, TYPE_TABLE) end
 	if unreliable~=nil then checkluatype(unreliable, TYPE_BOOL) end
@@ -138,7 +138,7 @@ end
 
 --- Writes an object to a net message automatically typing it
 -- @shared
--- @param v The object to write
+-- @param any v The object to write
 function net_library.writeType(v)
 	if not netStarted then SF.Throw("net message not started", 2) end
 
@@ -150,14 +150,14 @@ end
 --- Reads an object from a net message automatically typing it
 --- Will throw an error if invalid type is read. Make sure to pcall it
 -- @shared
--- @return The object
+-- @return any The object
 function net_library.readType()
 	return SF.StringToTable(util.Decompress(net.ReadData(net.ReadUInt(32))), instance)[1]
 end
 
 --- Writes a table to a net message automatically typing it.
 -- @shared
--- @param v The object to write
+-- @param table v The table to write
 function net_library.writeTable(t)
 	if not netStarted then SF.Throw("net message not started", 2) end
 	checkluatype(t, TYPE_TABLE)
@@ -167,18 +167,17 @@ function net_library.writeTable(t)
 	write(net.WriteData, #str*8, str, #str)
 end
 
---- Reads an object from a net message automatically typing it
+--- Reads an table from a net message automatically typing it
 --- Will throw an error if invalid type is read. Make sure to pcall it
 -- @shared
--- @return The object
+-- @return table The table
 function net_library.readTable()
 	return SF.StringToTable(util.Decompress(net.ReadData(net.ReadUInt(32))), instance)
 end
 
 --- Writes a string to the net message. Null characters will terminate the string.
 -- @shared
--- @param t The string to be written
-
+-- @param string t The string to be written
 function net_library.writeString(t)
 	if not netStarted then SF.Throw("net message not started", 2) end
 
@@ -190,17 +189,15 @@ end
 
 --- Reads a string from the net message
 -- @shared
--- @return The string that was read
-
+-- @return string The string that was read
 function net_library.readString()
 	return net.ReadString()
 end
 
 --- Writes string containing null characters to the net message
 -- @shared
--- @param t The string to be written
--- @param n How much of the string to write
-
+-- @param string t The string to be written
+-- @param number n How much of the string to write
 function net_library.writeData(t, n)
 	if not netStarted then SF.Throw("net message not started", 2) end
 
@@ -214,8 +211,8 @@ end
 
 --- Reads a string from the net message
 -- @shared
--- @param n How many characters are in the data
--- @return The string that was read
+-- @param number n How many characters are in the data
+-- @return string The string that was read
 
 function net_library.readData(n)
 	checkluatype (n, TYPE_NUMBER)
@@ -225,8 +222,8 @@ end
 
 --- Streams a large 20MB string.
 -- @shared
--- @param str The string to be written
--- @param compress Compress the data. True by default
+-- @param string str The string to be written
+-- @param boolean? compress Compress the data. True by default
 function net_library.writeStream(str, compress)
 	if not netStarted then SF.Throw("net message not started", 2) end
 
@@ -237,7 +234,7 @@ end
 
 --- Reads a large string stream from the net message.
 -- @shared
--- @param cb Callback to run when the stream is finished. The first parameter in the callback is the data. Will be nil if transfer fails or is cancelled
+-- @param function cb Callback to run when the stream is finished. The first parameter in the callback is the data. Will be nil if transfer fails or is cancelled
 function net_library.readStream(cb)
 	checkluatype (cb, TYPE_FUNCTION)
 	if streams[instance.player] then SF.Throw("The previous stream must finish before reading another.", 2) end
@@ -265,7 +262,7 @@ end
 
 --- Returns the progress of a running readStream
 -- @shared
--- @return The progress ratio 0-1
+-- @return number The progress ratio 0-1
 function net_library.getStreamProgress()
 	if not streams[instance.player] then SF.Throw("Not currently reading a stream.", 2) end
 	return streams[instance.player]:GetProgress()
@@ -273,8 +270,8 @@ end
 
 --- Writes an integer to the net message
 -- @shared
--- @param t The integer to be written
--- @param n The amount of bits the integer consists of
+-- @param number t The integer to be written
+-- @param number n The amount of bits the integer consists of
 function net_library.writeInt(t, n)
 	if not netStarted then SF.Throw("net message not started", 2) end
 
@@ -288,8 +285,8 @@ end
 
 --- Reads an integer from the net message
 -- @shared
--- @param n The amount of bits to read
--- @return The integer that was read
+-- @param number n The amount of bits to read
+-- @return number The integer that was read
 function net_library.readInt(n)
 	checkluatype (n, TYPE_NUMBER)
 	return net.ReadInt(n)
@@ -297,8 +294,8 @@ end
 
 --- Writes an unsigned integer to the net message
 -- @shared
--- @param t The integer to be written
--- @param n The amount of bits the integer consists of. Should not be greater than 32
+-- @param number t The integer to be written
+-- @param number n The amount of bits the integer consists of. Should not be greater than 32
 function net_library.writeUInt(t, n)
 	if not netStarted then SF.Throw("net message not started", 2) end
 
@@ -312,8 +309,8 @@ end
 
 --- Reads an unsigned integer from the net message
 -- @shared
--- @param n The amount of bits to read
--- @return The unsigned integer that was read
+-- @param number n The amount of bits to read
+-- @return number The unsigned integer that was read
 function net_library.readUInt(n)
 	checkluatype (n, TYPE_NUMBER)
 	return net.ReadUInt(n)
@@ -321,7 +318,7 @@ end
 
 --- Writes a bit to the net message
 -- @shared
--- @param t The bit to be written. (0 for false, 1 (or anything) for true)
+-- @param number t The bit to be written. (0 for false, 1 (or anything) for true)
 function net_library.writeBit(t)
 	if not netStarted then SF.Throw("net message not started", 2) end
 
@@ -333,14 +330,14 @@ end
 
 --- Reads a bit from the net message
 -- @shared
--- @return The bit that was read. (0 for false, 1 for true)
+-- @return number The bit that was read. (0 for false, 1 for true)
 function net_library.readBit()
 	return net.ReadBit()
 end
 
 --- Writes a bool to the net message
 -- @shared
--- @param t The bit to be written. (boolean)
+-- @param number t The bit to be written. (boolean)
 function net_library.writeBool(t)
 	if not netStarted then SF.Throw("net message not started", 2) end
 
@@ -352,14 +349,14 @@ end
 
 --- Reads a boolean from the net message
 -- @shared
--- @return The boolean that was read.
+-- @return number The boolean that was read.
 function net_library.readBool()
 	return net.ReadBool()
 end
 
 --- Writes a double to the net message
 -- @shared
--- @param t The double to be written
+-- @param number t The double to be written
 function net_library.writeDouble(t)
 	if not netStarted then SF.Throw("net message not started", 2) end
 
@@ -371,14 +368,14 @@ end
 
 --- Reads a double from the net message
 -- @shared
--- @return The double that was read
+-- @return number The double that was read
 function net_library.readDouble()
 	return net.ReadDouble()
 end
 
 --- Writes a float to the net message
 -- @shared
--- @param t The float to be written
+-- @param number t The float to be written
 function net_library.writeFloat(t)
 	if not netStarted then SF.Throw("net message not started", 2) end
 
@@ -390,14 +387,14 @@ end
 
 --- Reads a float from the net message
 -- @shared
--- @return The float that was read
+-- @return number The float that was read
 function net_library.readFloat()
 	return net.ReadFloat()
 end
 
 --- Writes an angle to the net message
 -- @shared
--- @param t The angle to be written
+-- @param angle t The angle to be written
 function net_library.writeAngle(t)
 	if not netStarted then SF.Throw("net message not started", 2) end
 	write(net.WriteFloat, 4*8, t[1])
@@ -408,14 +405,14 @@ end
 
 --- Reads an angle from the net message
 -- @shared
--- @return The angle that was read
+-- @return angle The angle that was read
 function net_library.readAngle()
 	return awrap(Angle(net.ReadFloat(), net.ReadFloat(), net.ReadFloat()))
 end
 
 --- Writes an vector to the net message. Has significantly lower precision than writeFloat
 -- @shared
--- @param t The vector to be written
+-- @param vector t The vector to be written
 function net_library.writeVector(t)
 	if not netStarted then SF.Throw("net message not started", 2) end
 	write(net.WriteFloat, 4*8, t[1])
@@ -426,14 +423,14 @@ end
 
 --- Reads a vector from the net message
 -- @shared
--- @return The vector that was read
+-- @return vector The vector that was read
 function net_library.readVector()
 	return vwrap(Vector(net.ReadFloat(), net.ReadFloat(), net.ReadFloat()))
 end
 
 --- Writes an matrix to the net message
 -- @shared
--- @param t The matrix to be written
+-- @param vmatrix t The matrix to be written
 function net_library.writeMatrix(t)
 	if not netStarted then SF.Throw("net message not started", 2) end
 	local vals = {munwrap(t):Unpack()}
@@ -445,7 +442,7 @@ end
 
 --- Reads a matrix from the net message
 -- @shared
--- @return The matrix that was read
+-- @return vmatrix The matrix that was read
 function net_library.readMatrix()
 	local m = Matrix()
 	m:SetUnpacked(net.ReadFloat(), net.ReadFloat(), net.ReadFloat(), net.ReadFloat(), net.ReadFloat(), net.ReadFloat(), net.ReadFloat(), net.ReadFloat(), net.ReadFloat(), net.ReadFloat(), net.ReadFloat(), net.ReadFloat(), net.ReadFloat(), net.ReadFloat(), net.ReadFloat(), net.ReadFloat())
@@ -454,7 +451,7 @@ end
 
 --- Writes an color to the net message
 -- @shared
--- @param t The color to be written
+-- @param color t The color to be written
 function net_library.writeColor(t)
 	if not netStarted then SF.Throw("net message not started", 2) end
 	write(net.WriteColor, 4*8, cunwrap(t))
@@ -463,14 +460,14 @@ end
 
 --- Reads a color from the net message
 -- @shared
--- @return The color that was read
+-- @return color The color that was read
 function net_library.readColor()
 	return cwrap(net.ReadColor())
 end
 
 --- Writes an entity to the net message
 -- @shared
--- @param t The entity to be written
+-- @param entity t The entity to be written
 function net_library.writeEntity(t)
 	if not netStarted then SF.Throw("net message not started", 2) end
 	write(net.WriteUInt, 16, getent(t):EntIndex(), 16)
@@ -479,8 +476,8 @@ end
 
 --- Reads a entity from the net message
 -- @shared
--- @param callback (Client only) optional callback to be ran whenever the entity becomes valid; returns nothing if this is used. The callback passes the entity if it succeeds or nil if it fails.
--- @return The entity that was read
+-- @param function? callback (Client only) optional callback to be ran whenever the entity becomes valid; returns nothing if this is used. The callback passes the entity if it succeeds or nil if it fails.
+-- @return entity The entity that was read
 function net_library.readEntity(callback)
 	local index = net.ReadUInt(16)
 	if callback ~= nil and CLIENT then
@@ -496,8 +493,8 @@ end
 
 --- Like glua net.Receive, adds a callback that is called when a net message with the matching name is received. If this happens, the net hook won't be called.
 -- @shared
--- @param name The name of the net message
--- @param func The callback or nil to remove callback. (len - length of the net message, ply - player that sent it or nil if clientside)
+-- @param string name The name of the net message
+-- @param function func The callback or nil to remove callback. (len - length of the net message, ply - player that sent it or nil if clientside)
 function net_library.receive(name, func)
 	checkluatype (name, TYPE_STRING)
 	if func~=nil then checkluatype (func, TYPE_FUNCTION) end
@@ -505,19 +502,19 @@ function net_library.receive(name, func)
 end
 
 --- Returns available bandwidth in bytes
--- @return number of bytes that can be sent
+-- @return number Number of bytes that can be sent
 function net_library.getBytesLeft()
 	return math.floor((netBurst:check(instance.player) - netSize)/8)
 end
 
 --- Returns available bandwidth in bits
--- @return number of bits that can be sent
+-- @return number Number of bits that can be sent
 function net_library.getBitsLeft()
 	return math.floor(netBurst:check(instance.player) - netSize) -- Flooring, because the value can be decimal
 end
 
 --- Returns whether or not the library is currently reading data from a stream
--- @return Boolean
+-- @return boolean Whether we're currently reading data from a stream
 function net_library.isStreaming()
 	return streams[instance.player] ~= nil
 end
@@ -527,6 +524,6 @@ end
 --- Called when a net message arrives
 -- @name net
 -- @class hook
--- @param name Name of the arriving net message
--- @param len Length of the arriving net message in bits
--- @param ply On server, the player that sent the message. Nil on client.
+-- @param string name Name of the arriving net message
+-- @param number len Length of the arriving net message in bits
+-- @param entity ply On server, the player that sent the message. Nil on client.

--- a/lua/starfall/libs_sh/net.lua
+++ b/lua/starfall/libs_sh/net.lua
@@ -84,7 +84,7 @@ end
 
 --- Send a net message from client->server, or server->client.
 -- @shared
--- @param any? target Optional target location to send the net message. Entity or table of targets
+-- @param entity?|table? target Optional target location to send the net message. Entity or table of targets. If nil, sends to server on client
 -- @param boolean? unreliable Optional choose whether it's more important for the message to actually reach its destination (false) or reach it as fast as possible (true).
 function net_library.send(target, unreliable)
 	if target~=nil then checkluatype(target, TYPE_TABLE) end

--- a/lua/starfall/libs_sh/net.lua
+++ b/lua/starfall/libs_sh/net.lua
@@ -161,7 +161,7 @@ end
 function net_library.writeTable(t)
 	if not netStarted then SF.Throw("net message not started", 2) end
 	checkluatype(t, TYPE_TABLE)
-	
+
 	local str = util.Compress(SF.TableToString(t, instance))
 	write(net.WriteUInt, 32, #str, 32)
 	write(net.WriteData, #str*8, str, #str)

--- a/lua/starfall/libs_sh/net.lua
+++ b/lua/starfall/libs_sh/net.lua
@@ -394,7 +394,7 @@ end
 
 --- Writes an angle to the net message
 -- @shared
--- @param angle t The angle to be written
+-- @param Angle t The angle to be written
 function net_library.writeAngle(t)
 	if not netStarted then SF.Throw("net message not started", 2) end
 	write(net.WriteFloat, 4*8, t[1])
@@ -405,14 +405,14 @@ end
 
 --- Reads an angle from the net message
 -- @shared
--- @return angle The angle that was read
+-- @return Angle The angle that was read
 function net_library.readAngle()
 	return awrap(Angle(net.ReadFloat(), net.ReadFloat(), net.ReadFloat()))
 end
 
 --- Writes an vector to the net message. Has significantly lower precision than writeFloat
 -- @shared
--- @param vector t The vector to be written
+-- @param Vector t The vector to be written
 function net_library.writeVector(t)
 	if not netStarted then SF.Throw("net message not started", 2) end
 	write(net.WriteFloat, 4*8, t[1])
@@ -423,14 +423,14 @@ end
 
 --- Reads a vector from the net message
 -- @shared
--- @return vector The vector that was read
+-- @return Vector The vector that was read
 function net_library.readVector()
 	return vwrap(Vector(net.ReadFloat(), net.ReadFloat(), net.ReadFloat()))
 end
 
 --- Writes an matrix to the net message
 -- @shared
--- @param vmatrix t The matrix to be written
+-- @param VMatrix t The matrix to be written
 function net_library.writeMatrix(t)
 	if not netStarted then SF.Throw("net message not started", 2) end
 	local vals = {munwrap(t):Unpack()}
@@ -442,7 +442,7 @@ end
 
 --- Reads a matrix from the net message
 -- @shared
--- @return vmatrix The matrix that was read
+-- @return VMatrix The matrix that was read
 function net_library.readMatrix()
 	local m = Matrix()
 	m:SetUnpacked(net.ReadFloat(), net.ReadFloat(), net.ReadFloat(), net.ReadFloat(), net.ReadFloat(), net.ReadFloat(), net.ReadFloat(), net.ReadFloat(), net.ReadFloat(), net.ReadFloat(), net.ReadFloat(), net.ReadFloat(), net.ReadFloat(), net.ReadFloat(), net.ReadFloat(), net.ReadFloat())
@@ -451,7 +451,7 @@ end
 
 --- Writes an color to the net message
 -- @shared
--- @param color t The color to be written
+-- @param Color t The color to be written
 function net_library.writeColor(t)
 	if not netStarted then SF.Throw("net message not started", 2) end
 	write(net.WriteColor, 4*8, cunwrap(t))
@@ -460,14 +460,14 @@ end
 
 --- Reads a color from the net message
 -- @shared
--- @return color The color that was read
+-- @return Color The color that was read
 function net_library.readColor()
 	return cwrap(net.ReadColor())
 end
 
 --- Writes an entity to the net message
 -- @shared
--- @param entity t The entity to be written
+-- @param Entity t The entity to be written
 function net_library.writeEntity(t)
 	if not netStarted then SF.Throw("net message not started", 2) end
 	write(net.WriteUInt, 16, getent(t):EntIndex(), 16)
@@ -477,7 +477,7 @@ end
 --- Reads a entity from the net message
 -- @shared
 -- @param function? callback (Client only) optional callback to be ran whenever the entity becomes valid; returns nothing if this is used. The callback passes the entity if it succeeds or nil if it fails.
--- @return entity The entity that was read
+-- @return Entity The entity that was read
 function net_library.readEntity(callback)
 	local index = net.ReadUInt(16)
 	if callback ~= nil and CLIENT then
@@ -526,4 +526,4 @@ end
 -- @class hook
 -- @param string name Name of the arriving net message
 -- @param number len Length of the arriving net message in bits
--- @param entity ply On server, the player that sent the message. Nil on client.
+-- @param Entity ply On server, the player that sent the message. Nil on client.

--- a/lua/starfall/libs_sh/net.lua
+++ b/lua/starfall/libs_sh/net.lua
@@ -84,7 +84,7 @@ end
 
 --- Send a net message from client->server, or server->client.
 -- @shared
--- @param entity?|table? target Optional target location to send the net message. Entity or table of targets. If nil, sends to server on client
+-- @param Entity|table|nil target Optional target location to send the net message. Entity or table of targets. If nil, sends to server on client
 -- @param boolean? unreliable Optional choose whether it's more important for the message to actually reach its destination (false) or reach it as fast as possible (true).
 function net_library.send(target, unreliable)
 	if target~=nil then checkluatype(target, TYPE_TABLE) end

--- a/lua/starfall/libs_sh/npc.lua
+++ b/lua/starfall/libs_sh/npc.lua
@@ -70,7 +70,7 @@ if SERVER then
 	}
 	--- Adds a relationship to the npc with an entity
 	-- @server
-	-- @param entity ent The target entity
+	-- @param Entity ent The target entity
 	-- @param string disp String of the relationship. ("hate", "fear", "like", "neutral")
 	-- @param number priority How strong the relationship is. Higher number is stronger
 	function npc_methods:addEntityRelationship(ent, disp, priority)
@@ -84,7 +84,7 @@ if SERVER then
 
 	--- Gets the npc's relationship to the target
 	-- @server
-	-- @param entity ent Target entity
+	-- @param Entity ent Target entity
 	-- @return string Relationship of the npc with the target
 	function npc_methods:getRelationship(ent)
 		return dispositions[getnpc(self):Disposition(getent(ent))]
@@ -92,7 +92,7 @@ if SERVER then
 
 	--- Gives the npc a weapon
 	-- @server
-	-- @param weapon wep The classname of the weapon
+	-- @param Weapon wep The classname of the weapon
 	function npc_methods:giveWeapon(wep)
 		checkluatype(wep, TYPE_STRING)
 
@@ -110,7 +110,7 @@ if SERVER then
 
 	--- Tell the npc to fight this
 	-- @server
-	-- @param entity ent Target entity
+	-- @param Entity ent Target entity
 	function npc_methods:setEnemy(ent)
 		local npc = getnpc(self)
 		checkpermission(instance, npc, "npcs.modify")
@@ -119,7 +119,7 @@ if SERVER then
 
 	--- Gets what the npc is fighting
 	-- @server
-	-- @return entity Entity the npc is fighting
+	-- @return Entity Entity the npc is fighting
 	function npc_methods:getEnemy()
 		return owrap(getnpc(self):GetEnemy())
 	end
@@ -150,7 +150,7 @@ if SERVER then
 
 	--- Makes the npc walk to a destination
 	-- @server
-	-- @param vector vec The position of the destination
+	-- @param Vector vec The position of the destination
 	function npc_methods:goWalk(vec)
 		local npc = getnpc(self)
 		checkpermission(instance, npc, "npcs.modify")
@@ -160,7 +160,7 @@ if SERVER then
 
 	--- Makes the npc run to a destination
 	-- @server
-	-- @param vector vec The position of the destination
+	-- @param Vector vec The position of the destination
 	function npc_methods:goRun(vec)
 		local npc = getnpc(self)
 		checkpermission(instance, npc, "npcs.modify")

--- a/lua/starfall/libs_sh/npc.lua
+++ b/lua/starfall/libs_sh/npc.lua
@@ -13,6 +13,7 @@ end
 -- @name Npc
 -- @class type
 -- @libtbl npc_methods
+-- @libtbl npc_meta
 SF.RegisterType("Npc", false, true, debug.getregistry().NPC, "Entity")
 
 return function(instance)
@@ -37,8 +38,8 @@ local function getnpc(self)
 	end
 end
 
---- tostring metamethod
--- @return string String representation of the npc
+--- Turns a NPC object into a string.
+-- @return string String representing the NPC.
 function npc_meta:__tostring()
 	local ent = unwrap(self)
 	if not ent then return "(null entity)"

--- a/lua/starfall/libs_sh/npc.lua
+++ b/lua/starfall/libs_sh/npc.lua
@@ -37,6 +37,8 @@ local function getnpc(self)
 	end
 end
 
+--- tostring metamethod
+-- @return string String representation of the npc
 function npc_meta:__tostring()
 	local ent = unwrap(self)
 	if not ent then return "(null entity)"
@@ -47,7 +49,7 @@ end
 if SERVER then
 	--- Adds a relationship to the npc
 	-- @server
-	-- @param str The relationship string. http://wiki.facepunch.com/gmod/NPC:AddRelationship
+	-- @param string str The relationship string. http://wiki.facepunch.com/gmod/NPC:AddRelationship
 	function npc_methods:addRelationship(str)
 		local npc = getnpc(self)
 		checkpermission(instance, npc, "npcs.modify")
@@ -68,9 +70,9 @@ if SERVER then
 	}
 	--- Adds a relationship to the npc with an entity
 	-- @server
-	-- @param ent The target entity
-	-- @param disp String of the relationship. (hate fear like neutral)
-	-- @param priority number how strong the relationship is. Higher number is stronger
+	-- @param entity ent The target entity
+	-- @param string disp String of the relationship. ("hate", "fear", "like", "neutral")
+	-- @param number priority How strong the relationship is. Higher number is stronger
 	function npc_methods:addEntityRelationship(ent, disp, priority)
 		local npc = getnpc(self)
 		local target = getent(ent)
@@ -82,15 +84,15 @@ if SERVER then
 
 	--- Gets the npc's relationship to the target
 	-- @server
-	-- @param ent Target entity
-	-- @return string relationship of the npc with the target
+	-- @param entity ent Target entity
+	-- @return string Relationship of the npc with the target
 	function npc_methods:getRelationship(ent)
 		return dispositions[getnpc(self):Disposition(getent(ent))]
 	end
 
 	--- Gives the npc a weapon
 	-- @server
-	-- @param wep The classname of the weapon
+	-- @param weapon wep The classname of the weapon
 	function npc_methods:giveWeapon(wep)
 		checkluatype(wep, TYPE_STRING)
 
@@ -108,7 +110,7 @@ if SERVER then
 
 	--- Tell the npc to fight this
 	-- @server
-	-- @param ent Target entity
+	-- @param entity ent Target entity
 	function npc_methods:setEnemy(ent)
 		local npc = getnpc(self)
 		checkpermission(instance, npc, "npcs.modify")
@@ -117,7 +119,7 @@ if SERVER then
 
 	--- Gets what the npc is fighting
 	-- @server
-	-- @return Entity the npc is fighting
+	-- @return entity Entity the npc is fighting
 	function npc_methods:getEnemy()
 		return owrap(getnpc(self):GetEnemy())
 	end
@@ -148,7 +150,7 @@ if SERVER then
 
 	--- Makes the npc walk to a destination
 	-- @server
-	-- @param vec The position of the destination
+	-- @param vector vec The position of the destination
 	function npc_methods:goWalk(vec)
 		local npc = getnpc(self)
 		checkpermission(instance, npc, "npcs.modify")
@@ -158,7 +160,7 @@ if SERVER then
 
 	--- Makes the npc run to a destination
 	-- @server
-	-- @param vec The position of the destination
+	-- @param vector vec The position of the destination
 	function npc_methods:goRun(vec)
 		local npc = getnpc(self)
 		checkpermission(instance, npc, "npcs.modify")

--- a/lua/starfall/libs_sh/npc.lua
+++ b/lua/starfall/libs_sh/npc.lua
@@ -93,7 +93,7 @@ if SERVER then
 
 	--- Gives the npc a weapon
 	-- @server
-	-- @param Weapon wep The classname of the weapon
+	-- @param string wep The classname of the weapon
 	function npc_methods:giveWeapon(wep)
 		checkluatype(wep, TYPE_STRING)
 

--- a/lua/starfall/libs_sh/physenv.lua
+++ b/lua/starfall/libs_sh/physenv.lua
@@ -19,7 +19,7 @@ function physenv_lib.getAirDensity()
 end
 
 --- Gets the gravity vector
--- @return vector Vector Gravity Vector ( eg Vector(0,0,-600) )
+-- @return Vector Vector Gravity Vector ( eg Vector(0,0,-600) )
 function physenv_lib.getGravity()
 	return vwrap(physenv.GetGravity())
 end

--- a/lua/starfall/libs_sh/physenv.lua
+++ b/lua/starfall/libs_sh/physenv.lua
@@ -24,7 +24,7 @@ function physenv_lib.getGravity()
 	return vwrap(physenv.GetGravity())
 end
 
---- Gets the performance settings.</br>
+--- Gets the performance settings.
 -- See http://wiki.facepunch.com/gmod/Structures/PhysEnvPerformanceSettings for table structure.
 -- @return table Performance Settings Table.
 function physenv_lib.getPerformanceSettings()

--- a/lua/starfall/libs_sh/physenv.lua
+++ b/lua/starfall/libs_sh/physenv.lua
@@ -19,7 +19,7 @@ function physenv_lib.getAirDensity()
 end
 
 --- Gets the gravity vector
--- @return Vector Gravity Vector ( eg Vector(0,0,-600) )
+-- @return vector Vector Gravity Vector ( eg Vector(0,0,-600) )
 function physenv_lib.getGravity()
 	return vwrap(physenv.GetGravity())
 end

--- a/lua/starfall/libs_sh/physenv.lua
+++ b/lua/starfall/libs_sh/physenv.lua
@@ -19,7 +19,7 @@ function physenv_lib.getAirDensity()
 end
 
 --- Gets the gravity vector
--- @return Vector Vector Gravity Vector ( eg Vector(0,0,-600) )
+-- @return Vector Gravity Vector ( eg Vector(0,0,-600) )
 function physenv_lib.getGravity()
 	return vwrap(physenv.GetGravity())
 end

--- a/lua/starfall/libs_sh/physobj.lua
+++ b/lua/starfall/libs_sh/physobj.lua
@@ -39,43 +39,43 @@ end
 
 --- Gets the entity attached to the physics object
 -- @shared
--- @return entity The entity attached to the physics object
+-- @return Entity The entity attached to the physics object
 function physobj_methods:getEntity()
 	return ewrap(unwrap(self):GetEntity())
 end
 
 --- Gets the position of the physics object
 -- @shared
--- @return vector Vector position of the physics object
+-- @return Vector Vector position of the physics object
 function physobj_methods:getPos()
 	return vwrap(unwrap(self):GetPos())
 end
 
 --- Returns the world transform matrix of the physobj
 -- @shared
--- @return vmatrix The matrix
+-- @return VMatrix The matrix
 function physobj_methods:getMatrix()
 	return mwrap(unwrap(self):GetPositionMatrix())
 end
 
 --- Gets the angles of the physics object
 -- @shared
--- @return angle Angle angles of the physics object
+-- @return Angle Angle angles of the physics object
 function physobj_methods:getAngles()
 	return awrap(unwrap(self):GetAngles())
 end
 
 --- Gets the velocity of the physics object
 -- @shared
--- @return vector Vector velocity of the physics object
+-- @return Vector Vector velocity of the physics object
 function physobj_methods:getVelocity()
 	return vwrap(unwrap(self):GetVelocity())
 end
 
 --- Gets the axis aligned bounding box of the physics object
 -- @shared
--- @return vector The mins of the AABB
--- @return vector The maxs of the AABB
+-- @return Vector The mins of the AABB
+-- @return Vector The maxs of the AABB
 function physobj_methods:getAABB()
 	local a, b = unwrap(self):GetAABB()
 	return vwrap(a), vwrap(b)
@@ -84,15 +84,15 @@ end
 --- Gets the velocity of the physics object at an arbitrary point in its local reference frame
 --- This includes velocity at the point induced by rotational velocity
 -- @shared
--- @param vector vec The point to get velocity of in local reference frame
--- @return vector Vector Local velocity of the physics object at the point
+-- @param Vector vec The point to get velocity of in local reference frame
+-- @return Vector Vector Local velocity of the physics object at the point
 function physobj_methods:getVelocityAtPoint(vec)
 	return vwrap(unwrap(self):GetVelocityAtPoint(vunwrap(vec)))
 end
 
 --- Gets the angular velocity of the physics object
 -- @shared
--- @return vector Vector angular velocity of the physics object
+-- @return Vector Vector angular velocity of the physics object
 function physobj_methods:getAngleVelocity()
 	return vwrap(unwrap(self):GetAngleVelocity())
 end
@@ -106,14 +106,14 @@ end
 
 --- Gets the center of mass of the physics object in the local reference frame.
 -- @shared
--- @return vector Center of mass vector in the physobject's local reference frame.
+-- @return Vector Center of mass vector in the physobject's local reference frame.
 function physobj_methods:getMassCenter()
 	return vwrap(unwrap(self):GetMassCenter())
 end
 
 --- Gets the inertia of the physics object
 -- @shared
--- @return vector Vector Inertia of the physics object
+-- @return Vector Vector Inertia of the physics object
 function physobj_methods:getInertia()
 	return vwrap(unwrap(self):GetInertia())
 end
@@ -126,29 +126,29 @@ function physobj_methods:getMaterial()
 end
 
 --- Returns a vector in the local reference frame of the physicsobject from the world frame
--- @param vector vec The vector to transform
--- @return vector The transformed vector
+-- @param Vector vec The vector to transform
+-- @return Vector The transformed vector
 function physobj_methods:worldToLocal(vec)
 	return vwrap(unwrap(self):WorldToLocal(vunwrap(vec)))
 end
 
 --- Returns a vector in the reference frame of the world from the local frame of the physicsobject
--- @param vector vec The vector to transform
--- @return vector The transformed vector
+-- @param Vector vec The vector to transform
+-- @return Vector The transformed vector
 function physobj_methods:localToWorld(vec)
 	return vwrap(unwrap(self):LocalToWorld(vunwrap(vec)))
 end
 
 --- Returns a normal vector in the local reference frame of the physicsobject from the world frame
--- @param vector vec The normal vector to transform
--- @return vector The transformed vector
+-- @param Vector vec The normal vector to transform
+-- @return Vector The transformed vector
 function physobj_methods:worldToLocalVector(vec)
 	return vwrap(unwrap(self):WorldToLocalVector(vunwrap(vec)))
 end
 
 --- Returns a normal vector in the reference frame of the world from the local frame of the physicsobject
--- @param vector vec The normal vector to transform
--- @return vector The transformed vector
+-- @param Vector vec The normal vector to transform
+-- @return Vector The transformed vector
 function physobj_methods:localToWorldVector(vec)
 	return vwrap(unwrap(self):LocalToWorldVector(vunwrap(vec)))
 end
@@ -183,7 +183,7 @@ end
 if SERVER then
 	--- Sets the position of the physics object. Will cause interpolation of the entity in clientside, use entity.setPos to avoid this.
 	-- @server
-	-- @param vector pos The position vector to set it to
+	-- @param Vector pos The position vector to set it to
 	function physobj_methods:setPos(pos)
 
 		pos = vunwrap(pos)
@@ -196,7 +196,7 @@ if SERVER then
 
 	--- Sets the angles of the physics object. Will cause interpolation of the entity in clientside, use entity.setAngles to avoid this.
 	-- @server
-	-- @param angle ang The angle to set it to
+	-- @param Angle ang The angle to set it to
 	function physobj_methods:setAngles(ang)
 
 		ang = aunwrap(ang)
@@ -209,7 +209,7 @@ if SERVER then
 
 	--- Sets the velocity of the physics object
 	-- @server
-	-- @param vector vel The velocity vector to set it to
+	-- @param Vector vel The velocity vector to set it to
 	function physobj_methods:setVelocity(vel)
 
 		vel = vunwrap(vel)
@@ -237,7 +237,7 @@ if SERVER then
 
 	--- Applys a force to the center of the physics object
 	-- @server
-	-- @param vector force The force vector to apply
+	-- @param Vector force The force vector to apply
 	function physobj_methods:applyForceCenter(force)
 
 		force = vunwrap(force)
@@ -250,8 +250,8 @@ if SERVER then
 
 	--- Applys an offset force to a physics object
 	-- @server
-	-- @param vector force The force vector in world coordinates
-	-- @param vector position The force position in world coordinates
+	-- @param Vector force The force vector in world coordinates
+	-- @param Vector position The force position in world coordinates
 	function physobj_methods:applyForceOffset(force, position)
 
 		force = vunwrap(force)
@@ -266,7 +266,7 @@ if SERVER then
 
 	--- Sets the angular velocity of an object
 	-- @server
-	-- @param vector angvel The local angvel vector to set
+	-- @param Vector angvel The local angvel vector to set
 	function physobj_methods:setAngleVelocity(angvel)
 		angvel = vunwrap(angvel)
 		checkvector(angvel)
@@ -279,7 +279,7 @@ if SERVER then
 
 	--- Applys a angular velocity to an object
 	-- @server
-	-- @param vector angvel The local angvel vector to apply
+	-- @param Vector angvel The local angvel vector to apply
 	function physobj_methods:addAngleVelocity(angvel)
 		angvel = vunwrap(angvel)
 		checkvector(angvel)
@@ -292,7 +292,7 @@ if SERVER then
 
 	--- Applys a torque to a physics object
 	-- @server
-	-- @param vector torque The world torque vector to apply
+	-- @param Vector torque The world torque vector to apply
 	function physobj_methods:applyTorque(torque)
 		torque = vunwrap(torque)
 		checkvector(torque)
@@ -318,7 +318,7 @@ if SERVER then
 
 	--- Sets the inertia of a physics object
 	-- @server
-	-- @param vector inertia The inertia vector to set it to
+	-- @param Vector inertia The inertia vector to set it to
 	function physobj_methods:setInertia(inertia)
 		local phys = unwrap(self)
 		checkpermission(instance, phys:GetEntity(), "entities.setInertia")

--- a/lua/starfall/libs_sh/physobj.lua
+++ b/lua/starfall/libs_sh/physobj.lua
@@ -32,50 +32,50 @@ local mtx_meta, mwrap, munwrap = instance.Types.VMatrix, instance.Types.VMatrix.
 
 --- Checks if the physics object is valid
 -- @shared
--- @return boolean if the physics object is valid
+-- @return boolean If the physics object is valid
 function physobj_methods:isValid()
 	return unwrap(self):IsValid()
 end
 
 --- Gets the entity attached to the physics object
 -- @shared
--- @return The entity attached to the physics object
+-- @return entity The entity attached to the physics object
 function physobj_methods:getEntity()
 	return ewrap(unwrap(self):GetEntity())
 end
 
 --- Gets the position of the physics object
 -- @shared
--- @return Vector position of the physics object
+-- @return vector Vector position of the physics object
 function physobj_methods:getPos()
 	return vwrap(unwrap(self):GetPos())
 end
 
 --- Returns the world transform matrix of the physobj
 -- @shared
--- @return The matrix
+-- @return vmatrix The matrix
 function physobj_methods:getMatrix()
 	return mwrap(unwrap(self):GetPositionMatrix())
 end
 
 --- Gets the angles of the physics object
 -- @shared
--- @return Angle angles of the physics object
+-- @return angle Angle angles of the physics object
 function physobj_methods:getAngles()
 	return awrap(unwrap(self):GetAngles())
 end
 
 --- Gets the velocity of the physics object
 -- @shared
--- @return Vector velocity of the physics object
+-- @return vector Vector velocity of the physics object
 function physobj_methods:getVelocity()
 	return vwrap(unwrap(self):GetVelocity())
 end
 
 --- Gets the axis aligned bounding box of the physics object
 -- @shared
--- @return The mins of the AABB
--- @return The maxs of the AABB
+-- @return vector The mins of the AABB
+-- @return vector The maxs of the AABB
 function physobj_methods:getAABB()
 	local a, b = unwrap(self):GetAABB()
 	return vwrap(a), vwrap(b)
@@ -84,91 +84,91 @@ end
 --- Gets the velocity of the physics object at an arbitrary point in its local reference frame
 --- This includes velocity at the point induced by rotational velocity
 -- @shared
--- @param vec The point to get velocity of in local reference frame
--- @return Vector Local velocity of the physics object at the point
+-- @param vector vec The point to get velocity of in local reference frame
+-- @return vector Vector Local velocity of the physics object at the point
 function physobj_methods:getVelocityAtPoint(vec)
 	return vwrap(unwrap(self):GetVelocityAtPoint(vunwrap(vec)))
 end
 
 --- Gets the angular velocity of the physics object
 -- @shared
--- @return Vector angular velocity of the physics object
+-- @return vector Vector angular velocity of the physics object
 function physobj_methods:getAngleVelocity()
 	return vwrap(unwrap(self):GetAngleVelocity())
 end
 
 --- Gets the mass of the physics object
 -- @shared
--- @return mass of the physics object
+-- @return number Mass of the physics object
 function physobj_methods:getMass()
 	return unwrap(self):GetMass()
 end
 
 --- Gets the center of mass of the physics object in the local reference frame.
 -- @shared
--- @return Center of mass vector in the physobject's local reference frame.
+-- @return vector Center of mass vector in the physobject's local reference frame.
 function physobj_methods:getMassCenter()
 	return vwrap(unwrap(self):GetMassCenter())
 end
 
 --- Gets the inertia of the physics object
 -- @shared
--- @return Vector Inertia of the physics object
+-- @return vector Vector Inertia of the physics object
 function physobj_methods:getInertia()
 	return vwrap(unwrap(self):GetInertia())
 end
 
 --- Gets the material of the physics object
 -- @shared
--- @return The physics material of the physics object
+-- @return string The physics material of the physics object
 function physobj_methods:getMaterial()
 	return unwrap(self):GetMaterial()
 end
 
 --- Returns a vector in the local reference frame of the physicsobject from the world frame
--- @param vec The vector to transform
--- @return The transformed vector
+-- @param vector vec The vector to transform
+-- @return vector The transformed vector
 function physobj_methods:worldToLocal(vec)
 	return vwrap(unwrap(self):WorldToLocal(vunwrap(vec)))
 end
 
 --- Returns a vector in the reference frame of the world from the local frame of the physicsobject
--- @param vec The vector to transform
--- @return The transformed vector
+-- @param vector vec The vector to transform
+-- @return vector The transformed vector
 function physobj_methods:localToWorld(vec)
 	return vwrap(unwrap(self):LocalToWorld(vunwrap(vec)))
 end
 
 --- Returns a normal vector in the local reference frame of the physicsobject from the world frame
--- @param vec The normal vector to transform
--- @return The transformed vector
+-- @param vector vec The normal vector to transform
+-- @return vector The transformed vector
 function physobj_methods:worldToLocalVector(vec)
 	return vwrap(unwrap(self):WorldToLocalVector(vunwrap(vec)))
 end
 
 --- Returns a normal vector in the reference frame of the world from the local frame of the physicsobject
--- @param vec The normal vector to transform
--- @return The transformed vector
+-- @param vector vec The normal vector to transform
+-- @return vector The transformed vector
 function physobj_methods:localToWorldVector(vec)
 	return vwrap(unwrap(self):LocalToWorldVector(vunwrap(vec)))
 end
 
 --- Returns a table of MeshVertex structures where each 3 vertices represent a triangle. See: http://wiki.facepunch.com/gmod/Structures/MeshVertex
--- @return table of MeshVertex structures
+-- @return table Table of MeshVertex structures
 function physobj_methods:getMesh()
 	local mesh = unwrap(self):GetMesh()
 	return instance.Sanitize(mesh)
 end
 
 --- Returns a structured table, the physics mesh of the physics object. See: http://wiki.facepunch.com/gmod/Structures/MeshVertex
--- @return table of MeshVertex structures
+-- @return table Table of MeshVertex structures
 function physobj_methods:getMeshConvexes()
 	local mesh = unwrap(self):GetMeshConvexes()
 	return instance.Sanitize(mesh)
 end
 
 --- Sets the physical material of a physics object
--- @param material The physical material to set it to
+-- @param string materialName The physical material to set it to
 function physobj_methods:setMaterial(material)
 	checkluatype (material, TYPE_STRING)
 	local phys = unwrap(self)
@@ -183,7 +183,7 @@ end
 if SERVER then
 	--- Sets the position of the physics object. Will cause interpolation of the entity in clientside, use entity.setPos to avoid this.
 	-- @server
-	-- @param pos The position vector to set it to
+	-- @param vector pos The position vector to set it to
 	function physobj_methods:setPos(pos)
 
 		pos = vunwrap(pos)
@@ -196,7 +196,7 @@ if SERVER then
 
 	--- Sets the angles of the physics object. Will cause interpolation of the entity in clientside, use entity.setAngles to avoid this.
 	-- @server
-	-- @param ang The angle to set it to
+	-- @param angle ang The angle to set it to
 	function physobj_methods:setAngles(ang)
 
 		ang = aunwrap(ang)
@@ -209,7 +209,7 @@ if SERVER then
 
 	--- Sets the velocity of the physics object
 	-- @server
-	-- @param vel The velocity vector to set it to
+	-- @param vector vel The velocity vector to set it to
 	function physobj_methods:setVelocity(vel)
 
 		vel = vunwrap(vel)
@@ -222,7 +222,7 @@ if SERVER then
 
 	--- Sets the buoyancy ratio of a physobject
 	-- @server
-	-- @param ratio The buoyancy ratio to use
+	-- @param number ratio The buoyancy ratio to use
 	function physobj_methods:setBuoyancyRatio(ratio)
 		checkluatype(ratio, TYPE_NUMBER)
 
@@ -237,7 +237,7 @@ if SERVER then
 
 	--- Applys a force to the center of the physics object
 	-- @server
-	-- @param force The force vector to apply
+	-- @param vector force The force vector to apply
 	function physobj_methods:applyForceCenter(force)
 
 		force = vunwrap(force)
@@ -250,8 +250,8 @@ if SERVER then
 
 	--- Applys an offset force to a physics object
 	-- @server
-	-- @param force The force vector in world coordinates
-	-- @param position The force position in world coordinates
+	-- @param vector force The force vector in world coordinates
+	-- @param vector position The force position in world coordinates
 	function physobj_methods:applyForceOffset(force, position)
 
 		force = vunwrap(force)
@@ -266,7 +266,7 @@ if SERVER then
 
 	--- Sets the angular velocity of an object
 	-- @server
-	-- @param angvel The local angvel vector to set
+	-- @param vector angvel The local angvel vector to set
 	function physobj_methods:setAngleVelocity(angvel)
 		angvel = vunwrap(angvel)
 		checkvector(angvel)
@@ -279,7 +279,7 @@ if SERVER then
 
 	--- Applys a angular velocity to an object
 	-- @server
-	-- @param angvel The local angvel vector to apply
+	-- @param vector angvel The local angvel vector to apply
 	function physobj_methods:addAngleVelocity(angvel)
 		angvel = vunwrap(angvel)
 		checkvector(angvel)
@@ -292,7 +292,7 @@ if SERVER then
 
 	--- Applys a torque to a physics object
 	-- @server
-	-- @param torque The world torque vector to apply
+	-- @param vector torque The world torque vector to apply
 	function physobj_methods:applyTorque(torque)
 		torque = vunwrap(torque)
 		checkvector(torque)
@@ -305,7 +305,7 @@ if SERVER then
 
 	--- Sets the mass of a physics object
 	-- @server
-	-- @param mass The mass to set it to
+	-- @param number mass The mass to set it to
 	function physobj_methods:setMass(mass)
 		checkluatype(mass, TYPE_NUMBER)
 		local phys = unwrap(self)
@@ -318,7 +318,7 @@ if SERVER then
 
 	--- Sets the inertia of a physics object
 	-- @server
-	-- @param inertia The inertia vector to set it to
+	-- @param vector inertia The inertia vector to set it to
 	function physobj_methods:setInertia(inertia)
 		local phys = unwrap(self)
 		checkpermission(instance, phys:GetEntity(), "entities.setInertia")
@@ -342,7 +342,7 @@ if SERVER then
 	-- FVPHYSICS.NO_IMPACT_DMG
 	-- FVPHYSICS.NO_NPC_IMPACT_DMG
 	-- FVPHYSICS.NO_PLAYER_PICKUP
-	-- @param flags The flags to add. FVPHYSICS enum.
+	-- @param number flags The flags to add. FVPHYSICS enum.
 	function physobj_methods:addGameFlags(flags)
 		checkluatype(flags, TYPE_NUMBER)
 		local phys = unwrap(self)
@@ -362,7 +362,7 @@ if SERVER then
 	-- FVPHYSICS.NO_IMPACT_DMG
 	-- FVPHYSICS.NO_NPC_IMPACT_DMG
 	-- FVPHYSICS.NO_PLAYER_PICKUP
-	-- @param flags The flags to add. FVPHYSICS enum.
+	-- @param number flags The flags to clear. FVPHYSICS enum.
 	function physobj_methods:clearGameFlags(flags)
 		checkluatype(flags, TYPE_NUMBER)
 		local phys = unwrap(self)
@@ -376,7 +376,7 @@ if SERVER then
 	end
 	
 	--- Returns whether the game flags of the physics object are set.
-	-- @param flags The flags to test. FVPHYSICS enum.
+	-- @param number flags The flags to test. FVPHYSICS enum.
 	-- @return boolean If the flags are set
 	function physobj_methods:hasGameFlags(flags)
 		checkluatype(flags, TYPE_NUMBER)
@@ -385,7 +385,7 @@ if SERVER then
 	end
 	
 	--- Sets bone gravity
-	-- @param grav Bool should the bone respect gravity?
+	-- @param boolean grav Should the bone respect gravity?
 	function physobj_methods:enableGravity(grav)
 		local phys = unwrap(self)
 		checkpermission(instance, phys:GetEntity(), "entities.enableGravity")
@@ -394,7 +394,7 @@ if SERVER then
 	end
 
 	--- Sets the bone drag state
-	-- @param drag Bool should the bone have air resistence?
+	-- @param boolean drag Should the bone have air resistence?
 	function physobj_methods:enableDrag(drag)
 		local phys = unwrap(self)
 		checkpermission(instance, phys:GetEntity(), "entities.enableDrag")
@@ -409,7 +409,7 @@ if SERVER then
 	end
 
 	--- Sets coefficient of air resistance affecting the bone. Air resistance depends on the cross-section of the object.
-	-- @param coeff Number how much drag affects the bone
+	-- @param number coeff How much drag affects the bone
 	function physobj_methods:setDragCoefficient(coeff)
 		checkluatype(coeff, TYPE_NUMBER)
 		local phys = unwrap(self)
@@ -418,7 +418,7 @@ if SERVER then
 	end
 
 	--- Sets coefficient of air resistance affecting the bone when rotating. Air resistance depends on the cross-section of the object.
-	-- @param coeff Number how much drag affects the bone when rotating
+	-- @param number coeff How much drag affects the bone when rotating
 	function physobj_methods:setAngleDragCoefficient(coeff)
 		checkluatype(coeff, TYPE_NUMBER)
 		local phys = unwrap(self)
@@ -427,26 +427,26 @@ if SERVER then
 	end
 
 	--- Returns Movement damping of the bone.
-	-- @return Linear damping
-	-- @return Angular damping
+	-- @return number Linear damping
+	-- @return number Angular damping
 	function physobj_methods:getDamping()
 		local phys = unwrap(self)
 		return phys:GetDamping()
 	end
 	
 	--- Sets the movement damping of the bone. Unlike air drag, it doesn't take into account the cross-section of the object.
-	-- @param linear Number of the linear damping
-	-- @param angular Number of the angular damping
+	-- @param number linear Number of the linear damping
+	-- @param number angular Number of the angular damping
 	function physobj_methods:setDamping(linear, angular)
 		checkluatype(linear, TYPE_NUMBER)
 		checkluatype(angular, TYPE_NUMBER)
 		local phys = unwrap(self)
 		checkpermission(instance, phys:GetEntity(), "entities.setDamping")
-		return phys:SetDamping(linear, angular)
+		phys:SetDamping(linear, angular)
 	end
 	
 	--- Sets the bone movement state
-	-- @param move Bool should the bone move?
+	-- @param boolean move Should the bone move?
 	function physobj_methods:enableMotion(move)
 		local phys = unwrap(self)
 		checkpermission(instance, phys:GetEntity(), "entities.enableMotion")
@@ -456,7 +456,7 @@ if SERVER then
 
 	--- Returns whether the physobj is asleep
 	-- @server
-	-- @return boolean if the physobj is asleep
+	-- @return boolean If the physobj is asleep
 	function physobj_methods:isAsleep()
 		local phys = unwrap(self)
 		return phys:IsAsleep()
@@ -480,7 +480,7 @@ if SERVER then
 	
 	--- Returns table of tables of friction data of a contact against the physobj
 	-- @server
-	-- @return Table of tables of data. Each table will contain:
+	-- @return table Table of tables of data. Each table will contain:
 	-- PhysObj Other - The other physics object we came in contact with
 	-- number EnergyAbsorbed -
 	-- number FrictionCoefficient -

--- a/lua/starfall/libs_sh/players.lua
+++ b/lua/starfall/libs_sh/players.lua
@@ -507,35 +507,35 @@ if SERVER then
 
 		ent:SetEyeAngles(ang)
 	end
-	
+
 	--- Returns the packet loss of the client
 	-- @server
 	-- @return number Packets lost
 	function player_methods:getPacketLoss()
 		return getply(self):PacketLoss()
 	end
-	
+
 	--- Returns the time in seconds since the player connected
 	-- @server
 	-- @return number Time connected
 	function player_methods:getTimeConnected()
 		return getply(self):TimeConnected()
 	end
-	
+
 	--- Returns the number of seconds that the player has been timing out for
 	-- @server
 	-- @return number Timeout seconds
 	function player_methods:getTimeoutSeconds()
 		return getply(self):GetTimeoutSeconds()
 	end
-	
+
 	--- Returns true if the player is timing out
 	-- @server
 	-- @return boolean isTimingOut
 	function player_methods:isTimingOut()
 		return getply(self):IsTimingOut()
 	end
-	
+
 	--- Forces the player to say the first argument
 	-- Only works on the chip's owner.
 	-- @server
@@ -548,7 +548,7 @@ if SERVER then
 		if instance.player ~= ply then SF.Throw("Player say can only be used on yourself!", 2) end
 		if CurTime() < (ply.sf_say_cd or 0) then SF.Throw("Player say must wait 0.5s between calls!", 2) end
 		ply.sf_say_cd = CurTime() + 0.5
-		ply:Say(text, teamOnly) 
+		ply:Say(text, teamOnly)
 	end
 end
 
@@ -577,7 +577,7 @@ if CLIENT then
 	function player_methods:isMuted()
 		return getply(self):IsMuted()
 	end
-	
+
 	--- Returns whether the player is heard by the local player.
 	-- @client
 	-- @return boolean Whether they are speaking and able to be heard by LocalPlayer
@@ -591,26 +591,26 @@ if CLIENT then
 	function player_methods:voiceVolume()
 		return getply(self):VoiceVolume()
 	end
-	
+
 	--- Plays gesture animations on a player
 	-- @client
-	-- @param any animation Sequence string or act number. https://wiki.facepunch.com/gmod/Enums/ACT
+	-- @param string|number animation Sequence string or act number. https://wiki.facepunch.com/gmod/Enums/ACT
 	-- @param boolean? loop Optional boolean (Default true), should the gesture loop
 	-- @param number? slot Optional int (Default GESTURE_SLOT.CUSTOM), the gesture slot to use. GESTURE_SLOT table values
 	-- @param number? weight Optional float (Default 1), the weight of the gesture. Ranging from 0-1
 	function player_methods:playGesture(animation, loop, slot, weight)
 		local ply = getply(self)
 		checkpermission(instance, ply, "entities.setPlayerRenderProperty")
-		
+
 		if slot == nil then slot = GESTURE_SLOT_CUSTOM else checkluatype(slot, TYPE_NUMBER) end
 		if weight == nil then weight = 1 else checkluatype(weight, TYPE_NUMBER) end
-		
+
 		if isstring(animation) then
 			animation = ply:GetSequenceActivity(ply:LookupSequence(animation))
 		elseif not isnumber(animation) then
 			SF.ThrowTypeError("number or string", SF.GetType(animation), 2)
 		end
-		
+
 		ply:AnimResetGestureSlot(slot)
 		ply:AnimRestartGesture(slot, animation, not loop)
 		ply:AnimSetGestureWeight(slot, weight)
@@ -622,12 +622,12 @@ if CLIENT then
 	function player_methods:resetGesture(slot)
 		local ply = getply(self)
 		checkpermission(instance, ply, "entities.setPlayerRenderProperty")
-		
+
 		if slot == nil then slot = GESTURE_SLOT_CUSTOM else checkluatype(slot, TYPE_NUMBER) end
-		
+
 		ply:AnimResetGestureSlot(slot)
 	end
-	
+
 	--- Sets the weight of the gesture animation in the given gesture slot
 	-- @client
 	-- @param number? slot Optional int (Default GESTURE_SLOT.CUSTOM), the gesture slot to use. GESTURE_SLOT table values
@@ -635,16 +635,16 @@ if CLIENT then
 	function player_methods:setGestureWeight(slot, weight)
 		local ply = getply(self)
 		checkpermission(instance, ply, "entities.setPlayerRenderProperty")
-		
+
 		if slot == nil then slot = GESTURE_SLOT_CUSTOM else checkluatype(slot, TYPE_NUMBER) end
 		if weight == nil then weight = 1 else checkluatype(weight, TYPE_NUMBER) end
-		
+
 		ply:AnimSetGestureWeight(slot, weight)
 	end
-	
+
 	--- Plays an animation on the player
 	-- @client
-	-- @param any sequence Sequence number or string name
+	-- @param number|string sequence Sequence number or string name
 	-- @param number? progress Optional float (Default 0), the progress of the animation. Ranging from 0-1
 	-- @param number? rate Optional float (Default 1), the playback rate of the animation
 	-- @param boolean? loop Optional boolean (Default false), should the animation loop
@@ -653,18 +653,18 @@ if CLIENT then
 	function player_methods:setAnimation(seq, progress, rate, loop, auto_advance, act)
 		local ply = getply(self)
 		checkpermission(instance, ply, "entities.setPlayerRenderProperty")
-		
+
 		if isstring(seq) then
 			seq = ply:LookupSequence(seq)
 		elseif not isnumber(seq) then
 			SF.ThrowTypeError("number or string", SF.GetType(seq), 2)
 		end
-		
+
 		if progress == nil then progress = 0 else checkluatype(progress, TYPE_NUMBER) end
 		if rate == nil then rate = 1 else checkluatype(rate, TYPE_NUMBER) end
 		if loop == nil then loop = false else checkluatype(loop, TYPE_BOOL) end
 		if auto_advance == nil then auto_advance = true else checkluatype(auto_advance, TYPE_BOOL) end
-		
+
 		if act ~= nil then
 			if isstring(act) then
 				act = ply:LookupSequence(act)
@@ -672,9 +672,9 @@ if CLIENT then
 				SF.ThrowTypeError("number, string or nil", SF.GetType(act), 2)
 			end
 		end
-		
+
 		ply:SetCycle(progress)
-		
+
 		local anim = playerAnimAdd(ply, {})
 		anim.sequence = seq
 		anim.activity = act
@@ -684,130 +684,130 @@ if CLIENT then
 		anim.bounce = false
 		anim.min = 0
 		anim.max = 1
-		
+
 		anim.range = 1
 		anim.progress = progress
 		anim.duration = ply:SequenceDuration(seq)
 	end
-	
+
 	--- Resets the animation
 	-- @client
 	function player_methods:resetAnimation()
 		local ply = getply(self)
 		checkpermission(instance, ply, "entities.setPlayerRenderProperty")
-		
+
 		playerAnimRemove(ply)
 	end
-	
+
 	--- Sets the animation activity
 	-- @client
-	-- @param any activity number or string name, keep empty to use the animation sequence
+	-- @param number?|string? activity Activity, nil to use the current animation sequence
 	function player_methods:setAnimationActivity(act)
 		local ply = getply(self)
 		checkpermission(instance, ply, "entities.setPlayerRenderProperty")
-		
+
 		local anim = playerAnimGet(ply)
 		if not anim then SF.Throw("No animation is playing.", 2) end
-		
+
 		if isstring(act) then
 			act = ply:LookupSequence(act)
 		elseif act ~= nil and not isnumber(act) then
 			SF.ThrowTypeError("number, string or nil", SF.GetType(act), 2)
 		end
-		
+
 		anim.activity = act
 	end
-	
+
 	--- Sets the animation progress
 	-- @client
 	-- @param number progress The progress of the animation. Ranging from 0-1
 	function player_methods:setAnimationProgress(progress)
 		local ply = getply(self)
 		checkpermission(instance, ply, "entities.setPlayerRenderProperty")
-		
+
 		local anim = playerAnimGet(ply)
 		if not anim then SF.Throw("No animation is playing.", 2) end
-		
+
 		checkluatype(progress, TYPE_NUMBER)
-		
+
 		anim.progress = progress
 	end
-	
+
 	--- Sets the animation time
 	-- @client
 	-- @param number time The time of the animation in seconds. Float
 	function player_methods:setAnimationTime(time)
 		local ply = getply(self)
 		checkpermission(instance, ply, "entities.setPlayerRenderProperty")
-		
+
 		local anim = playerAnimGet(ply)
 		if not anim then SF.Throw("No animation is playing.", 2) end
-		
+
 		checkluatype(time, TYPE_NUMBER)
-		
+
 		anim.progress = (time / anim.duration - anim.min) * (1 / anim.range)
 	end
-	
+
 	--- Sets the animation playback rate
 	-- @client
 	-- @param number rate The playback rate of the animation. Float
 	function player_methods:setAnimationRate(rate)
 		local ply = getply(self)
 		checkpermission(instance, ply, "entities.setPlayerRenderProperty")
-		
+
 		local anim = playerAnimGet(ply)
 		if not anim then SF.Throw("No animation is playing.", 2) end
-		
+
 		checkluatype(rate, TYPE_NUMBER)
-		
+
 		anim.rate = rate
 	end
-	
+
 	--- Sets the animation audo advance
 	-- @client
 	-- @param boolean auto_advance Should the animation handle advancing itself?
 	function player_methods:setAnimationAutoAdvance(auto_advance)
 		local ply = getply(self)
 		checkpermission(instance, ply, "entities.setPlayerRenderProperty")
-		
+
 		local anim = playerAnimGet(ply)
 		if not anim then SF.Throw("No animation is playing.", 2) end
-		
+
 		checkluatype(auto_advance, TYPE_BOOL)
-		
+
 		anim.auto = auto_advance
 	end
-	
+
 	--- Sets the animation bounce
 	-- @client
 	-- @param boolean bounce Should the animation bounce instead of loop?
 	function player_methods:setAnimationBounce(bounce)
 		local ply = getply(self)
 		checkpermission(instance, ply, "entities.setPlayerRenderProperty")
-		
+
 		local anim = playerAnimGet(ply)
 		if not anim then SF.Throw("No animation is playing.", 2) end
-		
+
 		checkluatype(bounce, TYPE_BOOL)
-		
+
 		anim.bounce = bounce
 	end
-	
+
 	--- Sets the animation loop
 	-- @client
 	-- @param boolean loop Should the animation loop?
 	function player_methods:setAnimationLoop(loop)
 		local ply = getply(self)
 		checkpermission(instance, ply, "entities.setPlayerRenderProperty")
-		
+
 		local anim = playerAnimGet(ply)
 		if not anim then SF.Throw("No animation is playing.", 2) end
-		
+
 		checkluatype(loop, TYPE_BOOL)
-		
+
 		anim.loop = loop
 	end
-	
+
 	--- Sets the animation range
 	-- @client
 	-- @param number min Min. Ranging from 0-1
@@ -815,18 +815,18 @@ if CLIENT then
 	function player_methods:setAnimationRange(min, max)
 		local ply = getply(self)
 		checkpermission(instance, ply, "entities.setPlayerRenderProperty")
-		
+
 		local anim = playerAnimGet(ply)
 		if not anim then SF.Throw("No animation is playing.", 2) end
-		
+
 		checkluatype(min, TYPE_NUMBER)
 		checkluatype(max, TYPE_NUMBER)
-		
+
 		anim.min = math.max(min, 0)
 		anim.max = math.min(max, 1)
 		anim.range = anim.max - anim.min
 	end
-	
+
 	--- Gets whether a animation is playing
 	-- @client
 	-- @return boolean If an animation is playing
@@ -834,25 +834,25 @@ if CLIENT then
 		local ply = getply(self)
 		return playerAnimGet(ply) ~= nil
 	end
-	
+
 	--- Gets the progress of the animation ranging 0-1
 	-- @client
 	-- @return number Progress ranging 0-1
 	function player_methods:getAnimationProgress()
 		local ply = getply(self)
 		local anim = playerAnimGet(ply)
-		
+
 		if not anim then return 0 end
 		return anim.progress
 	end
-	
+
 	--- Gets the animation time
 	-- @client
 	-- @return number Time in seconds
 	function player_methods:getAnimationTime()
 		local ply = getply(self)
 		local anim = playerAnimGet(ply)
-		
+
 		if not anim then return 0 end
 		return (anim.progress * anim.range + anim.min) * anim.duration
 	end

--- a/lua/starfall/libs_sh/players.lua
+++ b/lua/starfall/libs_sh/players.lua
@@ -649,7 +649,7 @@ if CLIENT then
 	-- @param number? rate Optional float (Default 1), the playback rate of the animation
 	-- @param boolean? loop Optional boolean (Default false), should the animation loop
 	-- @param boolean? auto_advance Optional boolean (Default true), should the animation handle advancing itself
-	-- @param string?|number? act Optional number or string name (Default sequence value), the activity the player should use
+	-- @param string|number|nil act Optional number or string name (Default sequence value), the activity the player should use
 	function player_methods:setAnimation(seq, progress, rate, loop, auto_advance, act)
 		local ply = getply(self)
 		checkpermission(instance, ply, "entities.setPlayerRenderProperty")
@@ -701,7 +701,7 @@ if CLIENT then
 
 	--- Sets the animation activity
 	-- @client
-	-- @param number?|string? activity Activity, nil to use the current animation sequence
+	-- @param number|string|nil activity Activity, nil to use the current animation sequence
 	function player_methods:setAnimationActivity(act)
 		local ply = getply(self)
 		checkpermission(instance, ply, "entities.setPlayerRenderProperty")

--- a/lua/starfall/libs_sh/players.lua
+++ b/lua/starfall/libs_sh/players.lua
@@ -182,14 +182,14 @@ end
 
 --- Returns the name of the player's active weapon
 -- @shared
--- @return weapon The weapon
+-- @return Weapon The weapon
 function player_methods:getActiveWeapon()
 	return wwrap(getply(self):GetActiveWeapon())
 end
 
 --- Returns the player's aim vector
 -- @shared
--- @return vector Aim vector
+-- @return Vector Aim vector
 function player_methods:getAimVector()
 	return vwrap(getply(self):GetAimVector())
 end
@@ -238,14 +238,14 @@ end
 
 --- Returns the entity the player is currently using, like func_tank mounted turrets or +use prop pickups.
 -- @shared
--- @return entity Entity
+-- @return Entity Entity
 function player_methods:getEntityInUse()
 	return owrap(getply(self):GetEntityInUse())
 end
 
 --- Returns the player's shoot position
 -- @shared
--- @return vector Shoot position
+-- @return Vector Shoot position
 function player_methods:getShootPos()
 	return vwrap(getply(self):GetShootPos())
 end
@@ -259,7 +259,7 @@ end
 
 --- Returns the vehicle the player is driving
 -- @shared
--- @return vehicle Vehicle if player in vehicle or nil
+-- @return Vehicle Vehicle if player in vehicle or nil
 function player_methods:getVehicle()
 	return vhwrap(getply(self):GetVehicle())
 end
@@ -373,7 +373,7 @@ end
 
 --- Returns the player's current view entity
 -- @shared
--- @return entity Player's current view entity
+-- @return Entity Player's current view entity
 function player_methods:getViewEntity()
 	return owrap(getply(self):GetViewEntity())
 end
@@ -381,13 +381,13 @@ end
 --- Returns the player's view model
 -- In the Client realm, other players' viewmodels are not available unless they are being spectated
 -- @shared
--- @return entity Player's view model
+-- @return Entity Player's view model
 function player_methods:getViewModel()
 	return owrap(getply(self):GetViewModel(0))
 end
 
 --- Returns the camera punch offset angle
--- @return angle The angle of the view offset
+-- @return Angle The angle of the view offset
 function player_methods:getViewPunchAngles()
 	return awrap(getply(self):GetViewPunchAngles())
 end
@@ -402,7 +402,7 @@ end
 --- Returns the specified weapon or nil if the player doesn't have it
 -- @shared
 -- @param string wep Weapon class name
--- @return weapon Weapon
+-- @return Weapon Weapon
 function player_methods:getWeapon(wep)
 	checkluatype(wep, TYPE_STRING)
 	return wwrap(getply(self):GetWeapon(wep))
@@ -410,7 +410,7 @@ end
 
 --- Returns the entity that the player is standing on
 -- @shared
--- @return entity Ground entity
+-- @return Entity Ground entity
 function player_methods:getGroundEntity()
 	return owrap(getply(self):GetGroundEntity())
 end
@@ -452,7 +452,7 @@ if SERVER then
 
 	--- Sets the view entity of the player. Only works if they are linked to a hud.
 	-- @server
-	-- @param entity ent Entity to set the player's view entity to, or nothing to reset it
+	-- @param Entity ent Entity to set the player's view entity to, or nothing to reset it
 	function player_methods:setViewEntity(ent)
 		local ply = getply(self)
 		if ent~=nil then ent = getent(ent) end
@@ -472,8 +472,8 @@ if SERVER then
 	--- Drops the players' weapon
 	-- @server
 	-- @param any weapon The weapon instance or class name of the weapon to drop
-	-- @param vector? target If set, launches the weapon at the given position
-	-- @param vector? velocity If set and target is unset, launches the weapon with the given velocity
+	-- @param Vector? target If set, launches the weapon at the given position
+	-- @param Vector? velocity If set and target is unset, launches the weapon with the given velocity
 	function player_methods:dropWeapon(weapon, target, velocity)
 		local ply = getply(self)
 		checkpermission(instance, ply, "player.dropweapon")
@@ -498,7 +498,7 @@ if SERVER then
 
 	--- Sets a player's eye angles
 	-- @server
-	-- @param angle ang New angles
+	-- @param Angle ang New angles
 	function player_methods:setEyeAngles(ang)
 		local ent = getent(self)
 		local ang = aunwrap(ang)

--- a/lua/starfall/libs_sh/players.lua
+++ b/lua/starfall/libs_sh/players.lua
@@ -417,7 +417,7 @@ end
 
 --- Gets the amount of ammo the player has.
 -- @shared
--- @param any idOrName The string ammo name or number id of the ammo
+-- @param string|number idOrName The string ammo name or number id of the ammo
 -- @return number The amount of ammo player has in reserve.
 function player_methods:getAmmoCount(id)
 	if not isnumber(id) and not isstring(id) then SF.ThrowTypeError("number or string", SF.GetType(id), 2) end
@@ -471,16 +471,16 @@ if SERVER then
 
 	--- Drops the players' weapon
 	-- @server
-	-- @param any weapon The weapon instance or class name of the weapon to drop
+	-- @param Weapon|string weapon The weapon instance or class name of the weapon to drop
 	-- @param Vector? target If set, launches the weapon at the given position
 	-- @param Vector? velocity If set and target is unset, launches the weapon with the given velocity
 	function player_methods:dropWeapon(weapon, target, velocity)
 		local ply = getply(self)
 		checkpermission(instance, ply, "player.dropweapon")
-		
+
 		if target~=nil then target = vunwrap(target) end
 		if velocity~=nil then velocity = vunwrap(velocity) end
-		
+
 		if isstring(weapon) then
 			ply:DropNamedWeapon(weapon, target, velocity)
 		else
@@ -488,7 +488,7 @@ if SERVER then
 			ply:DropWeapon(weapon, target, velocity)
 		end
 	end
-	
+
 	--- Returns the hitgroup where the player was last hit.
 	-- @server
 	-- @return number Hitgroup, see https://wiki.facepunch.com/gmod/Enums/HITGROUP
@@ -649,7 +649,7 @@ if CLIENT then
 	-- @param number? rate Optional float (Default 1), the playback rate of the animation
 	-- @param boolean? loop Optional boolean (Default false), should the animation loop
 	-- @param boolean? auto_advance Optional boolean (Default true), should the animation handle advancing itself
-	-- @param any? act Optional number or string name (Default sequence value), the activity the player should use
+	-- @param string?|number? act Optional number or string name (Default sequence value), the activity the player should use
 	function player_methods:setAnimation(seq, progress, rate, loop, auto_advance, act)
 		local ply = getply(self)
 		checkpermission(instance, ply, "entities.setPlayerRenderProperty")

--- a/lua/starfall/libs_sh/players.lua
+++ b/lua/starfall/libs_sh/players.lua
@@ -126,239 +126,245 @@ end
 -- ------------------------------------------------------------------------- --
 --- Returns whether the player is alive
 -- @shared
--- @return True if player alive
+-- @return boolean True if player alive
 function player_methods:isAlive()
 	return getply(self):Alive()
 end
 
 --- Returns the players armor
 -- @shared
--- @return Armor
+-- @return number Armor
 function player_methods:getArmor()
 	return getply(self):Armor()
 end
 
 --- Returns maximum armor capacity
 -- @shared
--- @return Armor limit
+-- @return number Armor limit
 function player_methods:getMaxArmor()
 	return getply(self):GetMaxArmor()
 end
 
 --- Returns whether the player is crouching
 -- @shared
--- @return True if player crouching
+-- @return boolean True if player crouching
 function player_methods:isCrouching()
 	return getply(self):Crouching()
 end
 
 --- Returns the amount of deaths of the player
 -- @shared
--- @return Amount of deaths
+-- @return number Amount of deaths
 function player_methods:getDeaths()
 	return getply(self):Deaths()
 end
 
 --- Returns whether the player's flashlight is on
 -- @shared
--- @return True if player has flashlight on
+-- @return boolean True if player has flashlight on
 function player_methods:isFlashlightOn()
 	return getply(self):FlashlightIsOn()
 end
 
 --- Returns true if the player is noclipped
 -- @shared
--- @return true if the player is noclipped
+-- @return boolean True if the player is noclipped
 function player_methods:isNoclipped()
 	return getply(self):GetMoveType() == MOVETYPE_NOCLIP
 end
 
 --- Returns the amount of kills of the player
 -- @shared
--- @return Amount of kills
+-- @return number Amount of kills
 function player_methods:getFrags()
 	return getply(self):Frags()
 end
 
 --- Returns the name of the player's active weapon
 -- @shared
--- @return The weapon
+-- @return weapon The weapon
 function player_methods:getActiveWeapon()
 	return wwrap(getply(self):GetActiveWeapon())
 end
 
 --- Returns the player's aim vector
 -- @shared
--- @return Aim vector
+-- @return vector Aim vector
 function player_methods:getAimVector()
 	return vwrap(getply(self):GetAimVector())
 end
 
 --- Returns the player's field of view
 -- @shared
--- @return Field of view
+-- @return number Field of view as a float
 function player_methods:getFOV()
 	return getply(self):GetFOV()
 end
 
 --- Returns the player's jump power
 -- @shared
--- @return Jump power
+-- @return number Jump power
 function player_methods:getJumpPower()
 	return getply(self):GetJumpPower()
 end
 
 --- Returns the player's maximum speed
 -- @shared
--- @return Maximum speed
+-- @return number Maximum speed
 function player_methods:getMaxSpeed()
 	return getply(self):GetMaxSpeed()
 end
 
 --- Returns the player's name
 -- @shared
--- @return Name
+-- @return string Name
 function player_methods:getName()
 	return getply(self):GetName()
 end
 
 --- Returns the player's running speed
 -- @shared
--- @return Running speed
+-- @return number Running speed
 function player_methods:getRunSpeed()
 	return getply(self):GetRunSpeed()
 end
 
---- Returns the player's duck speed 
+--- Returns the player's duck speed
 -- @shared
--- @return Duck speed in seconds
+-- @return number Duck speed in seconds
 function player_methods:getDuckSpeed()
 	return getply(self):GetDuckSpeed()
 end
 
 --- Returns the entity the player is currently using, like func_tank mounted turrets or +use prop pickups.
 -- @shared
--- @return Entity
+-- @return entity Entity
 function player_methods:getEntityInUse()
 	return owrap(getply(self):GetEntityInUse())
 end
 
 --- Returns the player's shoot position
 -- @shared
--- @return Shoot position
+-- @return vector Shoot position
 function player_methods:getShootPos()
 	return vwrap(getply(self):GetShootPos())
 end
 
 --- Returns whether the player is in a vehicle
 -- @shared
--- @return True if player in vehicle
+-- @return boolean True if player in vehicle
 function player_methods:inVehicle()
 	return getply(self):InVehicle()
 end
 
 --- Returns the vehicle the player is driving
 -- @shared
--- @return Vehicle if player in vehicle or nil
+-- @return vehicle Vehicle if player in vehicle or nil
 function player_methods:getVehicle()
 	return vhwrap(getply(self):GetVehicle())
 end
 
 --- Returns whether the player is an admin
 -- @shared
--- @return True if player is admin
+-- @return boolean True if player is admin
 function player_methods:isAdmin()
 	return getply(self):IsAdmin()
 end
 
 --- Returns whether the player is a bot
 -- @shared
--- @return True if player is a bot
+-- @return boolean True if player is a bot
 function player_methods:isBot()
 	return getply(self):IsBot()
 end
 
 --- Returns whether the player is connected
 -- @shared
--- @return True if player is connected
+-- @return boolean True if player is connected
 function player_methods:isConnected()
 	return getply(self):IsConnected()
 end
 
 --- Returns whether the player is frozen
 -- @shared
--- @return True if player is frozen
+-- @return boolean True if player is frozen
 function player_methods:isFrozen()
 	return getply(self):IsFrozen()
 end
 
 --- Returns whether the player is a super admin
 -- @shared
--- @return True if player is super admin
+-- @return boolean True if player is super admin
 function player_methods:isSuperAdmin()
 	return getply(self):IsSuperAdmin()
 end
 
 --- Returns whether the player belongs to a usergroup
 -- @shared
--- @param group Group to check against
--- @return True if player belongs to group
+-- @param string groupName Group to check against
+-- @return boolean True if player belongs to group
 function player_methods:isUserGroup(group)
 	return getply(self):IsUserGroup(group)
 end
 
 --- Returns the player's current ping
 -- @shared
--- @return ping
+-- @return number The player's ping
 function player_methods:getPing()
 	return getply(self):Ping()
 end
 
---- Returns the player's steam ID
+--- Returns the player's SteamID
 -- @shared
--- @return steam ID
+-- @return string SteamID
 function player_methods:getSteamID()
 	return getply(self):SteamID()
 end
 
---- Returns the player's community ID
+--- Returns the player's SteamID64 / Community ID
+-- In singleplayer, this will return no value serverside.
+-- For bots, this will return 90071996842377216 (equivalent to STEAM_0:0:0) for the first bot to join, and adds 1 to the id for the bot id.
+-- Returns no value for bots clientside.
 -- @shared
--- @return community ID
+-- @return string SteamID64 aka Community ID
 function player_methods:getSteamID64()
 	return getply(self):SteamID64()
 end
 
 --- Returns the player's current team
 -- @shared
--- @return team
+-- @return number Team Index, from TEAM enums or custom teams
 function player_methods:getTeam()
 	return getply(self):Team()
 end
 
 --- Returns the name of the player's current team
 -- @shared
--- @return team name
+-- @return string Team Name
 function player_methods:getTeamName()
 	return team.GetName(getply(self):Team())
 end
 
---- Returns the player's unique ID
+--- Returns the player's unique ID. Returns 1 in singleplayer.
+-- Returns a Int32 that remains constant for a player across joins/leaves and across different servers.
+-- This can be used when a string is inappropriate - e.g. in a database primary key.
+-- Deprecated! You should use the SteamID functions instead.
 -- @shared
--- @return unique ID
+-- @return number UniqueID
 function player_methods:getUniqueID()
 	return getply(self):UniqueID()
 end
 
---- Returns the player's user ID
+--- Returns the player's UserID
 -- @shared
--- @return user ID
+-- @return number UserID
 function player_methods:getUserID()
 	return getply(self):UserID()
 end
 
 --- Returns a table with information of what the player is looking at
 -- @shared
--- @return table trace data https://wiki.facepunch.com/gmod/Structures/TraceResult
+-- @return table Trace data https://wiki.facepunch.com/gmod/Structures/TraceResult
 function player_methods:getEyeTrace()
 	checkpermission(instance, nil, "trace")
 
@@ -367,7 +373,7 @@ end
 
 --- Returns the player's current view entity
 -- @shared
--- @return Player's current view entity
+-- @return entity Player's current view entity
 function player_methods:getViewEntity()
 	return owrap(getply(self):GetViewEntity())
 end
@@ -375,28 +381,28 @@ end
 --- Returns the player's view model
 -- In the Client realm, other players' viewmodels are not available unless they are being spectated
 -- @shared
--- @return Player's view model
+-- @return entity Player's view model
 function player_methods:getViewModel()
 	return owrap(getply(self):GetViewModel(0))
 end
 
 --- Returns the camera punch offset angle
--- @return The angle of the view offset
+-- @return angle The angle of the view offset
 function player_methods:getViewPunchAngles()
 	return awrap(getply(self):GetViewPunchAngles())
 end
 
 --- Returns a table of weapons the player is carrying
 -- @shared
--- @return Table of weapons
+-- @return table Table of weapons
 function player_methods:getWeapons()
 	return instance.Sanitize(getply(self):GetWeapons())
 end
 
 --- Returns the specified weapon or nil if the player doesn't have it
 -- @shared
--- @param wep String weapon class
--- @return weapon
+-- @param string wep Weapon class name
+-- @return weapon Weapon
 function player_methods:getWeapon(wep)
 	checkluatype(wep, TYPE_STRING)
 	return wwrap(getply(self):GetWeapon(wep))
@@ -404,15 +410,15 @@ end
 
 --- Returns the entity that the player is standing on
 -- @shared
--- @return Ground entity
+-- @return entity Ground entity
 function player_methods:getGroundEntity()
 	return owrap(getply(self):GetGroundEntity())
 end
 
 --- Gets the amount of ammo the player has.
 -- @shared
--- @param id The string or number id of the ammo
--- @return The amount of ammo player has in reserve.
+-- @param any idOrName The string ammo name or number id of the ammo
+-- @return number The amount of ammo player has in reserve.
 function player_methods:getAmmoCount(id)
 	if not isnumber(id) and not isstring(id) then SF.ThrowTypeError("number or string", SF.GetType(id), 2) end
 
@@ -421,21 +427,21 @@ end
 
 --- Returns whether the player is typing in their chat
 -- @shared
--- @return bool true/false
+-- @return boolean Whether they are typing in the chat
 function player_methods:isTyping()
 	return getply(self):IsTyping()
 end
 
 --- Returns whether the player is sprinting
 -- @shared
--- @return bool true/false
+-- @return boolean Whether they are sprinting
 function player_methods:isSprinting()
 	return getply(self):IsSprinting()
 end
 
 if SERVER then
 	--- Lets you change the size of yourself if the server has sf_permissions_entity_owneraccess 1
-    -- @param scale The scale to apply (min 0.001, max 100)
+    -- @param number scale The scale to apply (min 0.001, max 100)
 	-- @server
 	function player_methods:setModelScale(scale)
 		checkluatype(scale, TYPE_NUMBER)
@@ -446,7 +452,7 @@ if SERVER then
 
 	--- Sets the view entity of the player. Only works if they are linked to a hud.
 	-- @server
-	-- @param ent Entity to set the player's view entity to, or nothing to reset it
+	-- @param entity ent Entity to set the player's view entity to, or nothing to reset it
 	function player_methods:setViewEntity(ent)
 		local ply = getply(self)
 		if ent~=nil then ent = getent(ent) end
@@ -458,16 +464,16 @@ if SERVER then
 
 	--- Returns whether or not the player has godmode
 	-- @server
-	-- @return True if the player has godmode
+	-- @return boolean True if the player has godmode
 	function player_methods:hasGodMode()
 		return getply(self):HasGodMode()
 	end
 
 	--- Drops the players' weapon
 	-- @server
-	-- @param weapon The weapon entity or class to drop
-	-- @param target If set, launches the weapon at the given position
-	-- @param velocity If set and target is unset, launches the weapon with the given velocity
+	-- @param any weapon The weapon instance or class name of the weapon to drop
+	-- @param vector? target If set, launches the weapon at the given position
+	-- @param vector? velocity If set and target is unset, launches the weapon with the given velocity
 	function player_methods:dropWeapon(weapon, target, velocity)
 		local ply = getply(self)
 		checkpermission(instance, ply, "player.dropweapon")
@@ -485,14 +491,14 @@ if SERVER then
 	
 	--- Returns the hitgroup where the player was last hit.
 	-- @server
-	-- @return Hitgroup, see https://wiki.facepunch.com/gmod/Enums/HITGROUP
+	-- @return number Hitgroup, see https://wiki.facepunch.com/gmod/Enums/HITGROUP
 	function player_methods:lastHitGroup()
 		return getply(self):LastHitGroup()
 	end
 
 	--- Sets a player's eye angles
 	-- @server
-	-- @param ang New angles
+	-- @param angle ang New angles
 	function player_methods:setEyeAngles(ang)
 		local ent = getent(self)
 		local ang = aunwrap(ang)
@@ -525,7 +531,7 @@ if SERVER then
 	
 	--- Returns true if the player is timing out
 	-- @server
-	-- @return bool isTimingOut
+	-- @return boolean isTimingOut
 	function player_methods:isTimingOut()
 		return getply(self):IsTimingOut()
 	end
@@ -533,8 +539,8 @@ if SERVER then
 	--- Forces the player to say the first argument
 	-- Only works on the chip's owner.
 	-- @server
-	-- @param text The text to force the player to say
-	-- @param teamOnly bool Team chat only?, Defaults to false.
+	-- @param string text The text to force the player to say
+	-- @param boolean? teamOnly Team chat only?, Defaults to false.
 	function player_methods:say(text, teamOnly)
 		checkluatype(text, TYPE_STRING)
 		if teamOnly~=nil then checkluatype(teamOnly, TYPE_BOOL) end
@@ -548,8 +554,8 @@ end
 
 --- Returns whether or not the player is pushing the key.
 -- @shared
--- @param key Key to check. IN_KEY table values
--- @return True or false
+-- @param number key Key to check. IN_KEY table values
+-- @return boolean Whether they key is down
 function player_methods:keyDown(key)
 	checkluatype(key, TYPE_NUMBER)
 
@@ -559,7 +565,7 @@ end
 if CLIENT then
 	--- Returns the relationship of the player to the local client
 	-- @client
-	-- @return One of: "friend", "blocked", "none", "requested"
+	-- @return string One of: "friend", "blocked", "none", "requested"
 	function player_methods:getFriendStatus()
 		checkpermission(instance, nil, "player.getFriendStatus")
 		return getply(self):GetFriendStatus()
@@ -567,31 +573,31 @@ if CLIENT then
 
 	--- Returns whether the local player has muted the player
 	-- @client
-	-- @return True if the player was muted
+	-- @return boolean True if the player was muted
 	function player_methods:isMuted()
 		return getply(self):IsMuted()
 	end
 	
 	--- Returns whether the player is heard by the local player.
 	-- @client
-	-- @return bool true/false
+	-- @return boolean Whether they are speaking and able to be heard by LocalPlayer
 	function player_methods:isSpeaking()
 		return getply(self):IsSpeaking()
 	end
 
 	--- Returns the voice volume of the player
 	-- @client
-	-- @return Returns the players voice volume, how loud the player's voice communication currently is, as a normal number. Doesn't work on local player unless the voice_loopback convar is set to 1.
+	-- @return number Returns the players voice volume, how loud the player's voice communication currently is, as a normal number. Doesn't work on local player unless the voice_loopback convar is set to 1.
 	function player_methods:voiceVolume()
 		return getply(self):VoiceVolume()
 	end
 	
 	--- Plays gesture animations on a player
 	-- @client
-	-- @param animation sequence string or act number. https://wiki.facepunch.com/gmod/Enums/ACT
-	-- @param loop Optional bool (Default true), should the gesture loop
-	-- @param slot Optional int (Default GESTURE_SLOT.CUSTOM), the gesture slot to use. GESTURE_SLOT table values
-	-- @param weight Optional float (Default 1), the weight of the gesture. Ranging from 0-1
+	-- @param any animation Sequence string or act number. https://wiki.facepunch.com/gmod/Enums/ACT
+	-- @param boolean? loop Optional boolean (Default true), should the gesture loop
+	-- @param number? slot Optional int (Default GESTURE_SLOT.CUSTOM), the gesture slot to use. GESTURE_SLOT table values
+	-- @param number? weight Optional float (Default 1), the weight of the gesture. Ranging from 0-1
 	function player_methods:playGesture(animation, loop, slot, weight)
 		local ply = getply(self)
 		checkpermission(instance, ply, "entities.setPlayerRenderProperty")
@@ -612,7 +618,7 @@ if CLIENT then
 
 	--- Resets gesture animations on a player
 	-- @client
-	-- @param slot Optional int (Default GESTURE_SLOT.CUSTOM), the gesture slot to use. GESTURE_SLOT table values
+	-- @param number? slot Optional int (Default GESTURE_SLOT.CUSTOM), the gesture slot to use. GESTURE_SLOT table values
 	function player_methods:resetGesture(slot)
 		local ply = getply(self)
 		checkpermission(instance, ply, "entities.setPlayerRenderProperty")
@@ -624,8 +630,8 @@ if CLIENT then
 	
 	--- Sets the weight of the gesture animation in the given gesture slot
 	-- @client
-	-- @param slot Optional int (Default GESTURE_SLOT.CUSTOM), the gesture slot to use. GESTURE_SLOT table values
-	-- @param weight Optional float (Default 1), the weight of the gesture. Ranging from 0-1
+	-- @param number? slot Optional int (Default GESTURE_SLOT.CUSTOM), the gesture slot to use. GESTURE_SLOT table values
+	-- @param number? weight Optional float (Default 1), the weight of the gesture. Ranging from 0-1
 	function player_methods:setGestureWeight(slot, weight)
 		local ply = getply(self)
 		checkpermission(instance, ply, "entities.setPlayerRenderProperty")
@@ -638,12 +644,12 @@ if CLIENT then
 	
 	--- Plays an animation on the player
 	-- @client
-	-- @param sequence Sequence number or string name
-	-- @param progress Optional float (Default 0), the progress of the animation. Ranging from 0-1
-	-- @param rate Optional float (Default 1), the playback rate of the animation
-	-- @param loop Optional bool (Default false), should the animation loop
-	-- @param auto_advance Optional bool (Default true), should the animation handle advancing itself
-	-- @param act Optional number or string name (Default sequence value), the activity the player should use
+	-- @param any sequence Sequence number or string name
+	-- @param number? progress Optional float (Default 0), the progress of the animation. Ranging from 0-1
+	-- @param number? rate Optional float (Default 1), the playback rate of the animation
+	-- @param boolean? loop Optional boolean (Default false), should the animation loop
+	-- @param boolean? auto_advance Optional boolean (Default true), should the animation handle advancing itself
+	-- @param any? act Optional number or string name (Default sequence value), the activity the player should use
 	function player_methods:setAnimation(seq, progress, rate, loop, auto_advance, act)
 		local ply = getply(self)
 		checkpermission(instance, ply, "entities.setPlayerRenderProperty")
@@ -695,7 +701,7 @@ if CLIENT then
 	
 	--- Sets the animation activity
 	-- @client
-	-- @param activity number or string name, keep empty to use the animation sequence
+	-- @param any activity number or string name, keep empty to use the animation sequence
 	function player_methods:setAnimationActivity(act)
 		local ply = getply(self)
 		checkpermission(instance, ply, "entities.setPlayerRenderProperty")
@@ -714,7 +720,7 @@ if CLIENT then
 	
 	--- Sets the animation progress
 	-- @client
-	-- @param progress The progress of the animation. Ranging from 0-1
+	-- @param number progress The progress of the animation. Ranging from 0-1
 	function player_methods:setAnimationProgress(progress)
 		local ply = getply(self)
 		checkpermission(instance, ply, "entities.setPlayerRenderProperty")
@@ -729,7 +735,7 @@ if CLIENT then
 	
 	--- Sets the animation time
 	-- @client
-	-- @param time The time of the animation in seconds. Float
+	-- @param number time The time of the animation in seconds. Float
 	function player_methods:setAnimationTime(time)
 		local ply = getply(self)
 		checkpermission(instance, ply, "entities.setPlayerRenderProperty")
@@ -744,7 +750,7 @@ if CLIENT then
 	
 	--- Sets the animation playback rate
 	-- @client
-	-- @param rate The playback rate of the animation. Float
+	-- @param number rate The playback rate of the animation. Float
 	function player_methods:setAnimationRate(rate)
 		local ply = getply(self)
 		checkpermission(instance, ply, "entities.setPlayerRenderProperty")
@@ -759,7 +765,7 @@ if CLIENT then
 	
 	--- Sets the animation audo advance
 	-- @client
-	-- @param auto_advance Should the animation handle advancing itself. Bool
+	-- @param boolean auto_advance Should the animation handle advancing itself?
 	function player_methods:setAnimationAutoAdvance(auto_advance)
 		local ply = getply(self)
 		checkpermission(instance, ply, "entities.setPlayerRenderProperty")
@@ -774,7 +780,7 @@ if CLIENT then
 	
 	--- Sets the animation bounce
 	-- @client
-	-- @param bounce Should the animation bounce instead of loop. Bool
+	-- @param boolean bounce Should the animation bounce instead of loop?
 	function player_methods:setAnimationBounce(bounce)
 		local ply = getply(self)
 		checkpermission(instance, ply, "entities.setPlayerRenderProperty")
@@ -789,7 +795,7 @@ if CLIENT then
 	
 	--- Sets the animation loop
 	-- @client
-	-- @param loop Should the animation loop. Bool
+	-- @param boolean loop Should the animation loop?
 	function player_methods:setAnimationLoop(loop)
 		local ply = getply(self)
 		checkpermission(instance, ply, "entities.setPlayerRenderProperty")
@@ -804,8 +810,8 @@ if CLIENT then
 	
 	--- Sets the animation range
 	-- @client
-	-- @param min Min. Ranging from 0-1
-	-- @param max Max. Ranging from 0-1
+	-- @param number min Min. Ranging from 0-1
+	-- @param number max Max. Ranging from 0-1
 	function player_methods:setAnimationRange(min, max)
 		local ply = getply(self)
 		checkpermission(instance, ply, "entities.setPlayerRenderProperty")
@@ -823,7 +829,7 @@ if CLIENT then
 	
 	--- Gets whether a animation is playing
 	-- @client
-	-- @return True or false
+	-- @return boolean If an animation is playing
 	function player_methods:isPlayingAnimation()
 		local ply = getply(self)
 		return playerAnimGet(ply) ~= nil
@@ -831,7 +837,7 @@ if CLIENT then
 	
 	--- Gets the progress of the animation ranging 0-1
 	-- @client
-	-- @return Progress ranging 0-1
+	-- @return number Progress ranging 0-1
 	function player_methods:getAnimationProgress()
 		local ply = getply(self)
 		local anim = playerAnimGet(ply)
@@ -842,7 +848,7 @@ if CLIENT then
 	
 	--- Gets the animation time
 	-- @client
-	-- @return Time in seconds
+	-- @return number Time in seconds
 	function player_methods:getAnimationTime()
 		local ply = getply(self)
 		local anim = playerAnimGet(ply)

--- a/lua/starfall/libs_sh/quaternion.lua
+++ b/lua/starfall/libs_sh/quaternion.lua
@@ -189,11 +189,11 @@ instance.Types.Quaternion.QuaternionMultiply = getQuatMul
 --- Creates a Quaternion
 -- @name builtins_library.Quaternion
 -- @class function
--- @param r R (real) component
--- @param i I component
--- @param j J component
--- @param k K component
--- @return Quaternion object
+-- @param number r R (real) component
+-- @param number i I component
+-- @param number j J component
+-- @param number k K component
+-- @return Quaternion Quaternion object
 function instance.env.Quaternion(r, i, j, k)
 	if r ~= nil then checkluatype(r, TYPE_NUMBER) else r = 0 end
 	if i ~= nil then checkluatype(i, TYPE_NUMBER) else i = 0 end
@@ -206,7 +206,9 @@ end
 
 local rijk = { r = 1, i = 2, j = 3, k = 4 }
 
---- newindex metamethod
+--- Newindex metamethod
+-- @param number|string Key
+-- @param number Value to set
 function quat_meta.__newindex(t, k, v)
 	if rijk[k] then
 		rawset(t, rijk[k], v)
@@ -237,9 +239,9 @@ function quat_meta.__newindex(t, k, v)
 	end
 end
 
---- index metamethod
+--- Index metamethod
 -- Can be indexed with: 1, 2, 3, 4, r, i, j, k, rr, ri, rj, rk, rrr, rijk, kjir, etc. Numerical lookup is the most efficient
--- @param number Key
+-- @param number|string Key
 -- @return number Found value
 function quat_meta.__index(t, k)
 	local method = quat_methods[k]
@@ -273,19 +275,19 @@ function quat_meta.__mul(lhs, rhs)
 		lhs = clone(lhs)
 		quatMulNum(lhs, rhs)
 		return lhs
-		
+
 	elseif isnumber(lhs) then -- N * Q
 		rhs = clone(rhs)
 		quatMulNum(rhs, lhs)
 		return rhs
 	end
-	
+
 	local lhs_meta = dgetmeta(lhs)
 	local rhs_meta = dgetmeta(rhs)
-	
+
 	if lhs_meta == quat_meta and rhs_meta == quat_meta then -- Q * Q
 		return wrap(getQuatMul(lhs, rhs))
-		
+
 	elseif lhs_meta == quat_meta and rhs_meta == vec_meta then -- Q * V
 		local lhs1, lhs2, lhs3, lhs4 = quatUnpack(lhs)
 		local rhs2, rhs3, rhs4 = rhs[1], rhs[2], rhs[3]
@@ -295,7 +297,7 @@ function quat_meta.__mul(lhs, rhs)
 			lhs1 * rhs3 + lhs4 * rhs2 - lhs2 * rhs4,
 			lhs1 * rhs4 + lhs2 * rhs3 - lhs3 * rhs2
 		})
-		
+
 	elseif lhs_meta == quat_meta then
 		checkluatype(rhs, TYPE_NUMBER)
 	else

--- a/lua/starfall/libs_sh/quaternion.lua
+++ b/lua/starfall/libs_sh/quaternion.lua
@@ -265,8 +265,8 @@ end
 -------------------------------------
 
 --- Multiplication metamethod
--- @param any lhs Left side of equation. Quaternion or number
--- @param any rhs Right side of equation. Quaternion or number
+-- @param Quaternion|number lhs Left side of equation. Quaternion or number
+-- @param Quaternion|number rhs Right side of equation. Quaternion or number
 -- @return Quaternion Product
 function quat_meta.__mul(lhs, rhs)
 	if isnumber(rhs) then -- Q * N
@@ -304,8 +304,8 @@ function quat_meta.__mul(lhs, rhs)
 end
 
 --- Division metamethod
--- @param any lhs Left side of equation. Quaternion or number
--- @param any rhs Right side of equation. Quaternion or number
+-- @param Quaternion|number lhs Left side of equation. Quaternion or number
+-- @param Quaternion|number rhs Right side of equation. Quaternion or number
 -- @return Quaternion Quotient
 function quat_meta.__div(lhs, rhs)
 	if isnumber(rhs) then -- Q / N
@@ -339,8 +339,8 @@ function quat_meta.__div(lhs, rhs)
 end
 
 --- Involution metamethod
--- @param any lhs Left side of equation. Quaternion or number
--- @param any rhs Right side of equation. Quaternion or number
+-- @param Quaternion|number lhs Left side of equation. Quaternion or number
+-- @param Quaternion|number rhs Right side of equation. Quaternion or number
 -- @return Quaternion Power
 function quat_meta.__pow(lhs, rhs)
 	if isnumber(rhs) then -- Q ^ N
@@ -370,8 +370,8 @@ function quat_meta.__pow(lhs, rhs)
 end
 
 --- Addition metamethod
--- @param any lhs Left side of equation. Quaternion or number
--- @param any rhs Right side of equation. Quaternion or number
+-- @param Quaternion|number lhs Left side of equation. Quaternion or number
+-- @param Quaternion|number rhs Right side of equation. Quaternion or number
 -- @return Quaternion Sum
 function quat_meta.__add(lhs, rhs)
 	if isnumber(rhs) then -- Q + N
@@ -397,8 +397,8 @@ function quat_meta.__add(lhs, rhs)
 end
 
 --- Subtraction metamethod
--- @param any lhs Left side of equation. Quaternion or number
--- @param any rhs Right side of equation. Quaternion or number
+-- @param Quaternion|number lhs Left side of equation. Quaternion or number
+-- @param Quaternion|number rhs Right side of equation. Quaternion or number
 -- @return Quaternion Difference
 function quat_meta.__sub(lhs, rhs)
 	if isnumber(rhs) then -- Q - N

--- a/lua/starfall/libs_sh/quaternion.lua
+++ b/lua/starfall/libs_sh/quaternion.lua
@@ -267,7 +267,7 @@ end
 --- Multiplication metamethod
 -- @param any lhs Left side of equation. Quaternion or number
 -- @param any rhs Right side of equation. Quaternion or number
--- @return quaternion Product
+-- @return Quaternion Product
 function quat_meta.__mul(lhs, rhs)
 	if isnumber(rhs) then -- Q * N
 		lhs = clone(lhs)
@@ -306,7 +306,7 @@ end
 --- Division metamethod
 -- @param any lhs Left side of equation. Quaternion or number
 -- @param any rhs Right side of equation. Quaternion or number
--- @return quaternion Quotient
+-- @return Quaternion Quotient
 function quat_meta.__div(lhs, rhs)
 	if isnumber(rhs) then -- Q / N
 		return wrap({ lhs[1] / rhs, lhs[2] / rhs, lhs[3] / rhs, lhs[4] / rhs })
@@ -341,7 +341,7 @@ end
 --- Involution metamethod
 -- @param any lhs Left side of equation. Quaternion or number
 -- @param any rhs Right side of equation. Quaternion or number
--- @return quaternion Power
+-- @return Quaternion Power
 function quat_meta.__pow(lhs, rhs)
 	if isnumber(rhs) then -- Q ^ N
 		local out = clone(lhs)
@@ -372,7 +372,7 @@ end
 --- Addition metamethod
 -- @param any lhs Left side of equation. Quaternion or number
 -- @param any rhs Right side of equation. Quaternion or number
--- @return quaternion Sum
+-- @return Quaternion Sum
 function quat_meta.__add(lhs, rhs)
 	if isnumber(rhs) then -- Q + N
 		local out = clone(lhs)
@@ -399,7 +399,7 @@ end
 --- Subtraction metamethod
 -- @param any lhs Left side of equation. Quaternion or number
 -- @param any rhs Right side of equation. Quaternion or number
--- @return quaternion Difference
+-- @return Quaternion Difference
 function quat_meta.__sub(lhs, rhs)
 	if isnumber(rhs) then -- Q - N
 		return wrap({ lhs[1] - rhs, lhs[2], lhs[3], lhs[4] })
@@ -418,20 +418,20 @@ function quat_meta.__sub(lhs, rhs)
 end
 
 --- Unary minus metamethod
--- @return quaternion Negated quaternion
+-- @return Quaternion Negated quaternion
 function quat_meta.__unm(q)
 	return wrap({ -q[1], -q[2], -q[3], -q[4] })
 end
 
 --- Equivalence metamethod
--- @param quaternion rhs Quaternion to compare to
+-- @param Quaternion rhs Quaternion to compare to
 -- @return boolean True if both sides are equal
 function quat_meta.__eq(lhs, rhs)
 	return lhs[1] == rhs[1] and lhs[2] == rhs[2] and lhs[3] == rhs[3] and lhs[4] == rhs[4]
 end
 
 --- Tostring metamethod
--- @param quaternion q Quaternion
+-- @param Quaternion q Quaternion
 -- @return string Quaternion represented as a string
 function quat_meta.__tostring(q)
 	return table.concat(q, " ", 1, 4)
@@ -459,21 +459,21 @@ function quat_methods:unpack()
 end
 
 --- Creates a copy of the quaternion
--- @return quaternion Duplicate quaternion
+-- @return Quaternion Duplicate quaternion
 function quat_methods:clone()
 	return clone(self)
 end
 
 --- Copies components of the second quaternion to the first quaternion.
 -- Self-Modifies. Does not return anything
--- @param quaternion quat Quaternion to copy from
+-- @param Quaternion quat Quaternion to copy from
 function quat_methods:set(quat)
 	quatPack(self, quatUnpack(quat))
 end
 
 --- Sets R (real) component of the quaternion and returns self after modification
 -- @param number r Value of the R component
--- @return quaternion self
+-- @return Quaternion self
 function quat_methods:setR(r)
 	self[1] = r
 	return self
@@ -481,7 +481,7 @@ end
 
 --- Sets I component of the quaternion and returns self after modification
 -- @param number i Value of the I component
--- @return quaternion self
+-- @return Quaternion self
 function quat_methods:setI(i)
 	self[2] = i
 	return self
@@ -489,7 +489,7 @@ end
 
 --- Sets J component of the quaternion and returns self after modification
 -- @param number j Value of the J component
--- @return quaternion self
+-- @return Quaternion self
 function quat_methods:setJ(j)
 	self[3] = j
 	return self
@@ -497,7 +497,7 @@ end
 
 --- Sets K component of the quaternion and returns self after modification
 -- @param number k Value of the K component
--- @return quaternion self
+-- @return Quaternion self
 function quat_methods:setK(k)
 	self[4] = k
 	return self
@@ -506,7 +506,7 @@ end
 -------------------------------------
 
 --- Raises Euler's constant e to the quaternion's power
--- @return quaternion Constant e raised to the quaternion
+-- @return Quaternion Constant e raised to the quaternion
 function quat_methods:getExp()
 	local ret = clone(self)
 	quatExp(ret)
@@ -520,7 +520,7 @@ function quat_methods:exp()
 end
 
 --- Calculates natural logarithm of the quaternion
--- @return quaternion Logarithmic quaternion
+-- @return Quaternion Logarithmic quaternion
 function quat_methods:getLog()
 	local ret = clone(self)
 	quatLog(ret)
@@ -536,7 +536,7 @@ end
 -------------------------------------
 
 --- Calculates upward direction of the quaternion
--- @return vector Vector pointing up
+-- @return Vector Vector pointing up
 function quat_methods:getUp()
 	local q1, q2, q3, q4 = quatUnpack(self)
 	local t2, t3, t4 = q2 * 2, q3 * 2, q4 * 2
@@ -548,7 +548,7 @@ function quat_methods:getUp()
 end
 
 --- Calculates right direction of the quaternion
--- @return vector Vector pointing right
+-- @return Vector Vector pointing right
 function quat_methods:getRight()
 	local q1, q2, q3, q4 = quatUnpack(self)
 	local t2, t3, t4 = q2 * 2, q3 * 2, q4 * 2
@@ -560,7 +560,7 @@ function quat_methods:getRight()
 end
 
 --- Calculates forward direction of the quaternion
--- @return vector Vector pointing forward
+-- @return Vector Vector pointing forward
 function quat_methods:getForward()
 	local q1, q2, q3, q4 = quatUnpack(self)
 	local t2, t3, t4 = q2 * 2, q3 * 2, q4 * 2
@@ -574,13 +574,13 @@ end
 -------------------------------------
 
 --- Returns absolute value of the quaternion
--- @return vector Absolute value
+-- @return Vector Absolute value
 function quat_methods:getAbsolute()
 	return getQuatLenSqr(self)
 end
 
 --- Returns conjugate of the quaternion
--- @return quaternion Quaternion's conjugate
+-- @return Quaternion Quaternion's conjugate
 function quat_methods:getConjugate()
 	local ret = clone(self)
 	quatConj(ret)
@@ -594,7 +594,7 @@ function quat_methods:conjugate()
 end
 
 --- Calculates inverse of the quaternion
--- @return quaternion Inverse of the quaternion
+-- @return Quaternion Inverse of the quaternion
 function quat_methods:getInverse()
 	local ret = clone(self)
 	quatInv(ret)
@@ -608,7 +608,7 @@ function quat_methods:inverse()
 end
 
 --- Gets the quaternion representing rotation contained within an angle between 0 and 180 degrees
--- @return quaternion Quaternion with contained rotation
+-- @return Quaternion Quaternion with contained rotation
 function quat_methods:getMod()
 	local ret = clone(self)
 	quatMod(ret)
@@ -622,7 +622,7 @@ function quat_methods:mod()
 end
 
 --- Returns new normalized quaternion
--- @return quaternion Normalized quaternion
+-- @return Quaternion Normalized quaternion
 function quat_methods:getNormalized()
 	local ret = clone(self)
 	quatNorm(ret)
@@ -636,7 +636,7 @@ function quat_methods:normalize()
 end
 
 --- Returns dot product of two quaternions
--- @param quaternion quat Second quaternion
+-- @param Quaternion quat Second quaternion
 -- @return number The dot product
 function quat_methods:dot(quat)
 	return getQuatDot(self, quat)
@@ -645,7 +645,7 @@ end
 -------------------------------------
 
 --- Converts quaternion to a vector by dropping the R (real) component
--- @return vector Vector from the quaternion
+-- @return Vector Vector from the quaternion
 function quat_methods:getVector()
 	return vwrap(Vector(self[2], self[3], self[4]))
 end
@@ -653,7 +653,7 @@ end
 -- credits: Malte Clasen (https://stackoverflow.com/a/1556470)
 --- Converts quaternion to a matrix
 -- @param boolean? Optional bool, normalizes the quaternion
--- @return vmatrix Transformation matrix
+-- @return VMatrix Transformation matrix
 function quat_methods:getMatrix(normalize)
 	local quat
 	if normalize then
@@ -676,7 +676,7 @@ function quat_methods:getMatrix(normalize)
 end
 
 --- Returns the euler angle of rotation in degrees
--- @return angle Angle object
+-- @return Angle Angle object
 function quat_methods:getEulerAngle()
 	local len_sqrt = getQuatLen(self)
 	if len_sqrt == 0 then
@@ -730,7 +730,7 @@ end
 
 -- credits: https://github.com/cder0xff
 --- Returns the axis of rotation
--- @return vector Vector axis
+-- @return Vector Vector axis
 function quat_methods:getRotationAxis()
 	local ilen = getQuatImaginaryLenSqr(self)
 	if ilen == 0 then
@@ -743,7 +743,7 @@ end
 
 -- credits: https://github.com/cder0xff
 --- Returns the rotation vector - rotation axis where magnitude is the angle of rotation in degrees
--- @return vector Rotation vector
+-- @return Vector Rotation vector
 function quat_methods:getRotationVector()
 	local len = getQuatLenSqr(self)
 	local ilen_max = math_max(getQuatImaginaryLenSqr(self), 0)
@@ -764,8 +764,8 @@ end
 -------------------------------------
 
 --- Converts vector to quaternion
--- @param vector up Upward direction. If specified, the original vector will act like a forward pointing one
--- @return quaternion Quaternion from the given vector
+-- @param Vector up Upward direction. If specified, the original vector will act like a forward pointing one
+-- @return Quaternion Quaternion from the given vector
 function vec_methods:getQuaternion(up)
 	if up then
 		local x = vunwrap(self)
@@ -792,7 +792,7 @@ end
 
 --- Returns quaternion for rotation about axis represented by the vector by an angle
 -- @param number ang Number rotation angle
--- @return quaternion Rotated quaternion
+-- @return Quaternion Rotated quaternion
 function vec_methods:getQuaternionFromAxis(ang)
 	local axis = vunwrap(self):GetNormalized()
 	local rang = math_rad(ang) * 0.5
@@ -802,7 +802,7 @@ end
 
 -- credits: https://github.com/cder0xff
 --- Constructs a quaternion from the rotation vector. Vector direction is axis of rotation, it's magnitude is angle in degrees
--- @return quaternion Rotated quaternion
+-- @return Quaternion Rotated quaternion
 function vec_methods:getQuaternionFromRotation()
 	local vec_len = self:getLengthSqr()
 	if vec_len == 0 then
@@ -818,23 +818,23 @@ function vec_methods:getQuaternionFromRotation()
 end
 
 --- Converts angle to a quaternion
--- @return quaternion Constructed quaternion
+-- @return Quaternion Constructed quaternion
 function ang_methods:getQuaternion()
 	return wrap(quatFromAngle(aunwrap(self)))
 end
 
 --- Converts entity angles to a quaternion
--- @return quaternion Constructed quaternion
+-- @return Quaternion Constructed quaternion
 function ents_methods:getQuaternion()
 	local ang = getent(self):GetAngles()
 	return wrap(quatFromAngle(ang))
 end
 
 --- Performs spherical linear interpolation between two quaternions
--- @param quaternion quat1 Quaternion to start with
--- @param quaternion quat2 Quaternion to end with
+-- @param Quaternion quat1 Quaternion to start with
+-- @param Quaternion quat2 Quaternion to end with
 -- @param number t Ratio, 0 = quat1; 1 = quat2
--- @return quaternion Interpolated quaternion
+-- @return Quaternion Interpolated quaternion
 function math_library.slerpQuaternion(quat1, quat2, t)
 	checkluatype(t, TYPE_NUMBER)
 
@@ -859,10 +859,10 @@ function math_library.slerpQuaternion(quat1, quat2, t)
 end
 
 --- Performs normalized linear interpolation between two quaternions
--- @param quaternion quat1 Quaternion to start with
--- @param quaternion quat2 Quaternion to end with
+-- @param Quaternion quat1 Quaternion to start with
+-- @param Quaternion quat2 Quaternion to end with
 -- @param number t Ratio, 0 = quat1; 1 = quat2
--- @return quaternion Interpolated quaternion
+-- @return Quaternion Interpolated quaternion
 function math_library.nlerpQuaternion(quat1, quat2, t)
 	checkluatype(t, TYPE_NUMBER)
 

--- a/lua/starfall/libs_sh/quaternion.lua
+++ b/lua/starfall/libs_sh/quaternion.lua
@@ -765,6 +765,7 @@ end
 
 -------------------------------------
 
+
 --- Converts vector to quaternion
 -- @param Vector up Upward direction. If specified, the original vector will act like a forward pointing one
 -- @return Quaternion Quaternion from the given vector

--- a/lua/starfall/libs_sh/quaternion.lua
+++ b/lua/starfall/libs_sh/quaternion.lua
@@ -78,10 +78,10 @@ end
 local function quatExp(q)
 	local ilen_sqrt = getQuatImaginaryLen(q)
 	local real_exp = math_exp(q[1])
-	
+
 	if ilen_sqrt ~= 0 then
 		local sin_ilen_sqrt = math_sin(ilen_sqrt)
-		
+
 		q[1] = real_exp * math_cos(ilen_sqrt)
 		q[2] = real_exp * (q[2] * sin_ilen_sqrt / ilen_sqrt)
 		q[3] = real_exp * (q[3] * sin_ilen_sqrt / ilen_sqrt)
@@ -98,11 +98,11 @@ local function quatLog(q)
 	else
 		quatNorm(q)
 		local q1, q2, q3, q4 = quatUnpack(q)
-		
+
 		local acos = math_acos(q1)
 		local ilen = getQuatImaginaryLen(q)
 		local ilen_log = math_log(len_sqrt)
-		
+
 		if ilen ~= 0 then
 			quatPack(q, ilen_log, acos * q2 / ilen, acos * q3 / ilen, acos * q4 / ilen)
 		else
@@ -142,7 +142,7 @@ local function quatFromAngleComponents(p, y, r)
 	p = math_rad(p) * 0.5
 	y = math_rad(y) * 0.5
 	r = math_rad(r) * 0.5
-	
+
 	return getQuatMul({math_cos(y), 0, 0, math_sin(y)}, getQuatMul({ math_cos(p), 0, math_sin(p), 0 }, {math_cos(r), math_sin(r), 0, 0}))
 end
 
@@ -199,7 +199,7 @@ function instance.env.Quaternion(r, i, j, k)
 	if i ~= nil then checkluatype(i, TYPE_NUMBER) else i = 0 end
 	if j ~= nil then checkluatype(j, TYPE_NUMBER) else j = 0 end
 	if k ~= nil then checkluatype(k, TYPE_NUMBER) else k = 0 end
-	
+
 	return wrap({ r, i, j, k })
 end
 
@@ -213,25 +213,25 @@ function quat_meta.__newindex(t, k, v)
 
 	elseif (#k == 2 and rijk[k[1]] and rijk[k[2]])  then
 		checktype(v, quat_meta)
-		
+
 		rawset(t, rijk[k[1]], rawget(v, 1))
 		rawset(t, rijk[k[2]], rawget(v, 2))
-		
+
 	elseif (#k == 3 and rijk[k[1]] and rijk[k[2]] and rijk[k[3]]) then
 		checktype(v, quat_meta)
-		
+
 		rawset(t, rijk[k[1]], rawget(v, 1))
 		rawset(t, rijk[k[2]], rawget(v, 2))
 		rawset(t, rijk[k[3]], rawget(v, 3))
-		
+
 	elseif (#k == 4 and rijk[k[1]] and rijk[k[2]] and rijk[k[3]] and rijk[k[4]]) then
 		checktype(v, quat_meta)
-		
+
 		rawset(t, rijk[k[1]], rawget(v, 1))
 		rawset(t, rijk[k[2]], rawget(v, 2))
 		rawset(t, rijk[k[3]], rawget(v, 3))
 		rawset(t, rijk[k[4]], rawget(v, 4))
-		
+
 	else
 		rawset(t, k, v)
 	end
@@ -239,13 +239,15 @@ end
 
 --- index metamethod
 -- Can be indexed with: 1, 2, 3, 4, r, i, j, k, rr, ri, rj, rk, rrr, rijk, kjir, etc. Numerical lookup is the most efficient
+-- @param number Key
+-- @return number Found value
 function quat_meta.__index(t, k)
 	local method = quat_methods[k]
 	if method ~= nil then
 		return method
 	elseif rijk[k] then
 		return rawget(t, rijk[k])
-	else 
+	else
 		-- Swizzle support
 		local q = { 0, 0, 0, 0 }
 		for i = 1, math_min(#k, 4)do
@@ -262,10 +264,10 @@ end
 
 -------------------------------------
 
---- multiplication metamethod
--- @param lhs Left side of equation
--- @param rhs Right side of equation
--- @return Product
+--- Multiplication metamethod
+-- @param any lhs Left side of equation. Quaternion or number
+-- @param any rhs Right side of equation. Quaternion or number
+-- @return quaternion Product
 function quat_meta.__mul(lhs, rhs)
 	if isnumber(rhs) then -- Q * N
 		lhs = clone(lhs)
@@ -301,14 +303,14 @@ function quat_meta.__mul(lhs, rhs)
 	end
 end
 
---- division metamethod
--- @param lhs Left side of equation
--- @param rhs Right side of equation
--- @return Quotient
+--- Division metamethod
+-- @param any lhs Left side of equation. Quaternion or number
+-- @param any rhs Right side of equation. Quaternion or number
+-- @return quaternion Quotient
 function quat_meta.__div(lhs, rhs)
 	if isnumber(rhs) then -- Q / N
 		return wrap({ lhs[1] / rhs, lhs[2] / rhs, lhs[3] / rhs, lhs[4] / rhs })
-		
+
 	elseif isnumber(lhs) then -- N / Q
 		local len = getQuatLenSqr(rhs)
 		return wrap({
@@ -317,7 +319,7 @@ function quat_meta.__div(lhs, rhs)
 			(-lhs * rhs[3]) / len,
 			(-lhs * rhs[4]) / len
 		})
-		
+
 	elseif dgetmeta(lhs) == quat_meta and dgetmeta(rhs) == quat_meta then -- Q / Q
 		local lhs1, lhs2, lhs3, lhs4 = quatUnpack(lhs)
 		local rhs1, rhs2, rhs3, rhs4 = quatUnpack(rhs)
@@ -328,7 +330,7 @@ function quat_meta.__div(lhs, rhs)
 			(-lhs1 * rhs3 + lhs3 * rhs1 - lhs4 * rhs2 + lhs2 * rhs4) / len,
 			(-lhs1 * rhs4 + lhs4 * rhs1 - lhs2 * rhs3 + lhs3 * rhs2) / len
 		})
-		
+
 	elseif dgetmeta(lhs) == quat_meta then
 		checkluatype(rhs, TYPE_NUMBER)
 	else
@@ -336,30 +338,30 @@ function quat_meta.__div(lhs, rhs)
 	end
 end
 
---- involution metamethod
--- @param lhs Left side of equation
--- @param rhs Right side of equation
--- @return Power
+--- Involution metamethod
+-- @param any lhs Left side of equation. Quaternion or number
+-- @param any rhs Right side of equation. Quaternion or number
+-- @return quaternion Power
 function quat_meta.__pow(lhs, rhs)
 	if isnumber(rhs) then -- Q ^ N
 		local out = clone(lhs)
 		quatLog(out)
 		quatMulNum(out, rhs)
 		quatExp(out)
-		
+
 		return out
-		
+
 	elseif isnumber(lhs) then -- N ^ Q
 		if lhs == 0 then
 			return wrap({ 0, 0, 0, 0 })
 		end
-		
+
 		local out = clone(rhs)
 		quatMulNum(out, math_log(lhs))
 		quatExp(out)
-		
+
 		return out
-		
+
 	elseif dgetmeta(lhs) == quat_meta then
 		checkluatype(rhs, TYPE_NUMBER)
 	else
@@ -367,26 +369,26 @@ function quat_meta.__pow(lhs, rhs)
 	end
 end
 
---- addition metamethod
--- @param lhs Left side of equation
--- @param rhs Right side of equation
--- @return Sum
+--- Addition metamethod
+-- @param any lhs Left side of equation. Quaternion or number
+-- @param any rhs Right side of equation. Quaternion or number
+-- @return quaternion Sum
 function quat_meta.__add(lhs, rhs)
 	if isnumber(rhs) then -- Q + N
 		local out = clone(lhs)
 		out[1] = out[1] + rhs
-		
+
 		return out
-		
+
 	elseif isnumber(lhs) then -- N + Q
 		local out = clone(rhs)
 		out[1] = out[1] + lhs
-		
+
 		return out
-		
+
 	elseif dgetmeta(lhs) == quat_meta and dgetmeta(rhs) == quat_meta then -- Q + Q
 		return wrap({ lhs[1] + rhs[1], lhs[2] + rhs[2], lhs[3] + rhs[3], lhs[4] + rhs[4] })
-		
+
 	elseif dgetmeta(lhs) == quat_meta then
 		checkluatype(rhs, TYPE_NUMBER)
 	else
@@ -394,20 +396,20 @@ function quat_meta.__add(lhs, rhs)
 	end
 end
 
---- subtraction metamethod
--- @param lhs Left side of equation
--- @param rhs Right side of equation
--- @return Difference
+--- Subtraction metamethod
+-- @param any lhs Left side of equation. Quaternion or number
+-- @param any rhs Right side of equation. Quaternion or number
+-- @return quaternion Difference
 function quat_meta.__sub(lhs, rhs)
 	if isnumber(rhs) then -- Q - N
 		return wrap({ lhs[1] - rhs, lhs[2], lhs[3], lhs[4] })
-		
+
 	elseif isnumber(lhs) then -- N - Q
 		return wrap({ lhs - rhs[1], -rhs[2], -rhs[3], -rhs[4] })
-		
+
 	elseif dgetmeta(lhs) == quat_meta and dgetmeta(rhs) == quat_meta then -- Q - Q
 		return wrap({ lhs[1] - rhs[1], lhs[2] - rhs[2], lhs[3] - rhs[3], lhs[4] - rhs[4] })
-		
+
 	elseif dgetmeta(lhs) == quat_meta then
 		checkluatype(rhs, TYPE_NUMBER)
 	else
@@ -415,24 +417,22 @@ function quat_meta.__sub(lhs, rhs)
 	end
 end
 
---- unary minus metamethod
--- @param q Quaternion
--- @return Negated quaternion
+--- Unary minus metamethod
+-- @return quaternion Negated quaternion
 function quat_meta.__unm(q)
 	return wrap({ -q[1], -q[2], -q[3], -q[4] })
 end
 
---- equivalence metamethod
--- @param lhs Left side of equation
--- @param rhs Right side of equation
--- @return True if both sides are equal
+--- Equivalence metamethod
+-- @param quaternion rhs Quaternion to compare to
+-- @return boolean True if both sides are equal
 function quat_meta.__eq(lhs, rhs)
 	return lhs[1] == rhs[1] and lhs[2] == rhs[2] and lhs[3] == rhs[3] and lhs[4] == rhs[4]
 end
 
---- tostring metamethod
--- @param q Quaternion
--- @return Quaternion represented as a string
+--- Tostring metamethod
+-- @param quaternion q Quaternion
+-- @return string Quaternion represented as a string
 function quat_meta.__tostring(q)
 	return table.concat(q, " ", 1, 4)
 end
@@ -440,58 +440,64 @@ end
 -------------------------------------
 
 --- Set components of the quaternion
--- @param r R component
--- @param i I component
--- @param j J component
--- @param k K component
+-- Self-Modifies. Does not return anything
+-- @param number r R component
+-- @param number i I component
+-- @param number j J component
+-- @param number k K component
 function quat_methods:pack(r, i, j, k)
 	quatPack(self, r, i, j, k)
 end
+
 --- Returns components of the quaternion
--- @return r, i, j, k
+-- @return number r
+-- @return number i
+-- @return number j
+-- @return number k
 function quat_methods:unpack()
 	return quatUnpack(self)
 end
 
 --- Creates a copy of the quaternion
--- @return Duplicate quaternion
+-- @return quaternion Duplicate quaternion
 function quat_methods:clone()
 	return clone(self)
 end
 
---- Copies components of the second quaternion to the first quaternion. Self-modifies
--- @param quat Quaternion to copy from
+--- Copies components of the second quaternion to the first quaternion.
+-- Self-Modifies. Does not return anything
+-- @param quaternion quat Quaternion to copy from
 function quat_methods:set(quat)
 	quatPack(self, quatUnpack(quat))
 end
 
---- Sets R (real) component of the quaternion
--- @param r Value of the R component
--- @return self
+--- Sets R (real) component of the quaternion and returns self after modification
+-- @param number r Value of the R component
+-- @return quaternion self
 function quat_methods:setR(r)
 	self[1] = r
 	return self
 end
 
---- Sets I component of the quaternion
--- @param i Value of the I component
--- @return self
+--- Sets I component of the quaternion and returns self after modification
+-- @param number i Value of the I component
+-- @return quaternion self
 function quat_methods:setI(i)
 	self[2] = i
 	return self
 end
 
---- Sets J component of the quaternion
--- @param j Value of the J component
--- @return self
+--- Sets J component of the quaternion and returns self after modification
+-- @param number j Value of the J component
+-- @return quaternion self
 function quat_methods:setJ(j)
 	self[3] = j
 	return self
 end
 
---- Sets K component of the quaternion
--- @param k Value of the K component
--- @return self
+--- Sets K component of the quaternion and returns self after modification
+-- @param number k Value of the K component
+-- @return quaternion self
 function quat_methods:setK(k)
 	self[4] = k
 	return self
@@ -500,27 +506,29 @@ end
 -------------------------------------
 
 --- Raises Euler's constant e to the quaternion's power
--- @return Constant e raised to the quaternion
+-- @return quaternion Constant e raised to the quaternion
 function quat_methods:getExp()
 	local ret = clone(self)
 	quatExp(ret)
 	return ret
 end
 
---- Raises Euler's constant e to the quaternion's power. Self-modifies
+--- Raises Euler's constant e to the quaternion's power.
+-- Self-Modifies. Does not return anything
 function quat_methods:exp()
 	quatExp(self)
 end
 
 --- Calculates natural logarithm of the quaternion
--- @return Logarithmic quaternion
+-- @return quaternion Logarithmic quaternion
 function quat_methods:getLog()
 	local ret = clone(self)
 	quatLog(ret)
 	return ret
 end
 
---- Calculates natural logarithm of the quaternion. Self-modifies
+--- Calculates natural logarithm of the quaternion.
+-- Self-Modifies. Does not return anything
 function quat_methods:log()
 	quatLog(self)
 end
@@ -528,7 +536,7 @@ end
 -------------------------------------
 
 --- Calculates upward direction of the quaternion
--- @return Vector pointing up
+-- @return vector Vector pointing up
 function quat_methods:getUp()
 	local q1, q2, q3, q4 = quatUnpack(self)
 	local t2, t3, t4 = q2 * 2, q3 * 2, q4 * 2
@@ -540,7 +548,7 @@ function quat_methods:getUp()
 end
 
 --- Calculates right direction of the quaternion
--- @return Vector pointing right
+-- @return vector Vector pointing right
 function quat_methods:getRight()
 	local q1, q2, q3, q4 = quatUnpack(self)
 	local t2, t3, t4 = q2 * 2, q3 * 2, q4 * 2
@@ -552,7 +560,7 @@ function quat_methods:getRight()
 end
 
 --- Calculates forward direction of the quaternion
--- @return Vector pointing forward
+-- @return vector Vector pointing forward
 function quat_methods:getForward()
 	local q1, q2, q3, q4 = quatUnpack(self)
 	local t2, t3, t4 = q2 * 2, q3 * 2, q4 * 2
@@ -566,13 +574,13 @@ end
 -------------------------------------
 
 --- Returns absolute value of the quaternion
--- @return Absolute value
+-- @return vector Absolute value
 function quat_methods:getAbsolute()
 	return getQuatLenSqr(self)
 end
 
 --- Returns conjugate of the quaternion
--- @return Quaternion's conjugate
+-- @return quaternion Quaternion's conjugate
 function quat_methods:getConjugate()
 	local ret = clone(self)
 	quatConj(ret)
@@ -580,52 +588,56 @@ function quat_methods:getConjugate()
 end
 
 --- Conjugates the quaternion.
+-- Self-Modifies. Does not return anything
 function quat_methods:conjugate()
 	quatConj(self)
 end
 
 --- Calculates inverse of the quaternion
--- @return Inverse of the quaternion
+-- @return quaternion Inverse of the quaternion
 function quat_methods:getInverse()
 	local ret = clone(self)
 	quatInv(ret)
 	return ret
 end
 
---- Calculates inverse of the quaternon. Self-modifies
+--- Calculates inverse of the quaternon.
+-- Self-Modifies. Does not return anything
 function quat_methods:inverse()
 	quatInv(self)
 end
 
 --- Gets the quaternion representing rotation contained within an angle between 0 and 180 degrees
--- @return Quaternion with contained rotation
+-- @return quaternion Quaternion with contained rotation
 function quat_methods:getMod()
 	local ret = clone(self)
 	quatMod(ret)
 	return ret
 end
 
---- Contains quaternion's represented rotation within an angle between 0 and 180 degrees. Self-modifies
+--- Contains quaternion's represented rotation within an angle between 0 and 180 degrees.
+-- Self-Modifies. Does not return anything
 function quat_methods:mod()
 	quatMod(self)
 end
 
 --- Returns new normalized quaternion
--- @return Normalized quaternion
+-- @return quaternion Normalized quaternion
 function quat_methods:getNormalized()
 	local ret = clone(self)
 	quatNorm(ret)
 	return ret
 end
 
---- Normalizes the quaternion. Self-modifies
+--- Normalizes the quaternion.
+-- Self-Modifies. Does not return anything
 function quat_methods:normalize()
 	quatNorm(self)
 end
 
 --- Returns dot product of two quaternions
--- @param quat Second quaternion
--- @return The dot product
+-- @param quaternion quat Second quaternion
+-- @return number The dot product
 function quat_methods:dot(quat)
 	return getQuatDot(self, quat)
 end
@@ -633,15 +645,15 @@ end
 -------------------------------------
 
 --- Converts quaternion to a vector by dropping the R (real) component
--- @return Vector from the quaternion
+-- @return vector Vector from the quaternion
 function quat_methods:getVector()
 	return vwrap(Vector(self[2], self[3], self[4]))
 end
 
 -- credits: Malte Clasen (https://stackoverflow.com/a/1556470)
 --- Converts quaternion to a matrix
--- @param Optional bool, normalizes the quaternion
--- @return Transformation matrix
+-- @param boolean? Optional bool, normalizes the quaternion
+-- @return vmatrix Transformation matrix
 function quat_methods:getMatrix(normalize)
 	local quat
 	if normalize then
@@ -651,7 +663,7 @@ function quat_methods:getMatrix(normalize)
 	else
 		quat = self
 	end
-	
+
 	local w, x, y, z = quatUnpack(quat)
 	local m = Matrix()
 	m:SetUnpacked(
@@ -659,12 +671,12 @@ function quat_methods:getMatrix(normalize)
 		2*x*y + 2*z*w,		1 - 2*x*y - 2*z*z,	2*y*z - 2*x*w,		0,
 		2*x*z - 2*y*w,		2*y*z + 2*x*w,		1 - 2*x*x - 2*y*y,	0,
 		0,					0,					0,					0)
-	
+
 	return mwrap(m)
 end
 
 --- Returns the euler angle of rotation in degrees
--- @return Angle object
+-- @return angle Angle object
 function quat_methods:getEulerAngle()
 	local len_sqrt = getQuatLen(self)
 	if len_sqrt == 0 then
@@ -672,38 +684,38 @@ function quat_methods:getEulerAngle()
 	else
 		local q1, q2, q3, q4 = quatUnpack(self)
 		q1, q2, q3, q4 = q1 / len_sqrt, q2 / len_sqrt, q3 / len_sqrt, q4 / len_sqrt
-		
+
 		local x = Vector(q1*q1 + q2*q2 - q3*q3 - q4*q4, 2*q3*q2 + 2*q4*q1, 2*q4*q2 - 2*q3*q1)
 		local y = Vector(2*q2*q3 - 2*q4*q1, q1*q1 - q2*q2 + q3*q3 - q4*q4, 2*q2*q1 + 2*q3*q4)
-		
+
 		local ang = x:Angle()
 		if ang[1] > 180 then ang[1] = ang[1] - 360 end
 		if ang[2] > 180 then ang[2] = ang[2] - 360 end
-		
+
 		local yaw = Vector(0, 1, 0)
 		yaw:Rotate(Angle(0, ang[2], 0))
-		
+
 		ang[3] = math_deg(math_acos(math_clamp(y:Dot(yaw), -1, 1)))
 		local dot = q1*q2 + q3*q4
 		if dot < 0 then
 			ang[3] = -ang[3]
 		end
-		
+
 		return awrap(ang)
 	end
 end
 
 -- credits: https://github.com/coder0xff
 --- Returns the angle of rotation in degrees
--- @param full Optional bool, if true returned angle will be between -180 and 180, otherwise between 0 and 360
--- @return Angle number
+-- @param boolean? full Optional bool, if true returned angle will be between -180 and 180, otherwise between 0 and 360
+-- @return number Angle number
 function quat_methods:getRotationAngle(full)
 	local len = getQuatLenSqr(self)
 	if len == 0 then
 		return 0
 	else
 		local ang = math_deg(2 * math_acos(math_clamp(self[1] / math_sqrt(len), -1, 1)))
-		
+
 		if full then
 			checkluatype(full, TYPE_BOOL)
 			return ang
@@ -718,7 +730,7 @@ end
 
 -- credits: https://github.com/cder0xff
 --- Returns the axis of rotation
--- @return Vector axis
+-- @return vector Vector axis
 function quat_methods:getRotationAxis()
 	local ilen = getQuatImaginaryLenSqr(self)
 	if ilen == 0 then
@@ -731,11 +743,11 @@ end
 
 -- credits: https://github.com/cder0xff
 --- Returns the rotation vector - rotation axis where magnitude is the angle of rotation in degrees
--- @return Rotation vector
+-- @return vector Rotation vector
 function quat_methods:getRotationVector()
 	local len = getQuatLenSqr(self)
 	local ilen_max = math_max(getQuatImaginaryLenSqr(self), 0)
-	
+
 	if len == 0 or ilen_max == 0 then
 		return vwrap(Vector(0, 0, 0))
 	else
@@ -744,7 +756,7 @@ function quat_methods:getRotationVector()
 			ang = ang - 360
 		end
 		ang = ang / math_sqrt(ilen_max)
-		
+
 		return vwrap(Vector(self[2] * ang, self[3] * ang, self[4] * ang))
 	end
 end
@@ -752,26 +764,26 @@ end
 -------------------------------------
 
 --- Converts vector to quaternion
--- @param up Upward direction. If specified, the original vector will act like a forward pointing one
--- @return Quaternion from the given vector
+-- @param vector up Upward direction. If specified, the original vector will act like a forward pointing one
+-- @return quaternion Quaternion from the given vector
 function vec_methods:getQuaternion(up)
 	if up then
 		local x = vunwrap(self)
 		local z = vunwrap(up)
 		local y = z:Cross(x):GetNormalized()
-		
+
 		local ang = x:Angle()
 		if ang[1] > 180 then ang[1] = ang[1] - 360 end
 		if ang[2] > 180 then ang[2] = ang[2] - 360 end
-		
+
 		local yaw = Vector(0, 1, 0)
 		yaw:Rotate(Angle(0, ang[2], 0))
-		
+
 		local roll = math_deg(math_acos(math_clamp(y:Dot(yaw), -1, 1)))
 		if y[3] < 0 then
 			roll = -roll
 		end
-		
+
 		return wrap(quatFromAngleComponents(ang[1], ang[2], roll))
 	else
 		return wrap({ 0, self[1], self[2], self[3] })
@@ -779,18 +791,18 @@ function vec_methods:getQuaternion(up)
 end
 
 --- Returns quaternion for rotation about axis represented by the vector by an angle
--- @param ang Number rotation angle
--- @return Rotated quaternion
+-- @param number ang Number rotation angle
+-- @return quaternion Rotated quaternion
 function vec_methods:getQuaternionFromAxis(ang)
 	local axis = vunwrap(self):GetNormalized()
 	local rang = math_rad(ang) * 0.5
-	
+
 	return wrap({ math_cos(rang), axis[1] * math_sin(rang), axis[2] * math_sin(rang), axis[3] * math_sin(rang) })
 end
 
 -- credits: https://github.com/cder0xff
 --- Constructs a quaternion from the rotation vector. Vector direction is axis of rotation, it's magnitude is angle in degrees
--- @return Rotated quaternion
+-- @return quaternion Rotated quaternion
 function vec_methods:getQuaternionFromRotation()
 	local vec_len = self:getLengthSqr()
 	if vec_len == 0 then
@@ -800,32 +812,32 @@ function vec_methods:getQuaternionFromRotation()
 		local norm = (vec_len_sqrt + 180) % 360 - 180
 		local ang = math_rad(norm) * 0.5
 		local anglen = math_sin(ang) / vec_len_sqrt
-		
+
 		return wrap({ math_cos(ang), self[1] * anglen, self[2] * anglen, self[3] * anglen })
 	end
 end
 
 --- Converts angle to a quaternion
--- @return Constructed quaternion
+-- @return quaternion Constructed quaternion
 function ang_methods:getQuaternion()
 	return wrap(quatFromAngle(aunwrap(self)))
 end
 
 --- Converts entity angles to a quaternion
--- @return Constructed quaternion
+-- @return quaternion Constructed quaternion
 function ents_methods:getQuaternion()
 	local ang = getent(self):GetAngles()
 	return wrap(quatFromAngle(ang))
 end
 
 --- Performs spherical linear interpolation between two quaternions
--- @param quat1 Quaternion to start with
--- @param quat2 Quaternion to end with
--- @param t Ratio, 0 = quat1; 1 = quat2
--- @return Interpolated quaternion
+-- @param quaternion quat1 Quaternion to start with
+-- @param quaternion quat2 Quaternion to end with
+-- @param number t Ratio, 0 = quat1; 1 = quat2
+-- @return quaternion Interpolated quaternion
 function math_library.slerpQuaternion(quat1, quat2, t)
 	checkluatype(t, TYPE_NUMBER)
-	
+
 	if getQuatLenSqr(quat1) == 0 then
 		return wrap({ 0, 0, 0, 0})
 	else
@@ -833,7 +845,7 @@ function math_library.slerpQuaternion(quat1, quat2, t)
 		if getQuatDot(quat1, quat2) < 0 then
 			quatFlip(new)
 		end
-		
+
 		local out = clone(quat1)
 		quatInv(out)
 		quatConj(out)
@@ -841,19 +853,19 @@ function math_library.slerpQuaternion(quat1, quat2, t)
 		quatLog(out)
 		quatMulNum(out, t)
 		quatExp(out)
-		
+
 		return wrap(getQuatMul(quat1, out))
 	end
 end
 
 --- Performs normalized linear interpolation between two quaternions
--- @param quat1 Quaternion to start with
--- @param quat2 Quaternion to end with
--- @param t Ratio, 0 = quat1; 1 = quat2
--- @return Interpolated quaternion
+-- @param quaternion quat1 Quaternion to start with
+-- @param quaternion quat2 Quaternion to end with
+-- @param number t Ratio, 0 = quat1; 1 = quat2
+-- @return quaternion Interpolated quaternion
 function math_library.nlerpQuaternion(quat1, quat2, t)
 	checkluatype(t, TYPE_NUMBER)
-	
+
 	local t1 = 1 - t
 	local new
 	if getQuatDot(quat1, quat2) < 0 then
@@ -861,7 +873,7 @@ function math_library.nlerpQuaternion(quat1, quat2, t)
 	else
 		new = { quat1[1] * t1 + quat2[1] * t, quat1[2] * t1 + quat2[2] * t, quat1[3] * t1 + quat2[3] * t, quat1[4] * t1 + quat2[4] * t }
 	end
-	
+
 	quatNorm(new)
 	return wrap(new)
 end

--- a/lua/starfall/libs_sh/sounds.lua
+++ b/lua/starfall/libs_sh/sounds.lua
@@ -60,10 +60,10 @@ local ent_meta, ewrap, eunwrap = instance.Types.Entity, instance.Types.Entity.Wr
 
 
 --- Creates a sound and attaches it to an entity
--- @param entity ent Entity to attach sound to.
+-- @param Entity ent Entity to attach sound to.
 -- @param string path Filepath to the sound file.
 -- @param boolean? nofilter (Optional) Boolean Make the sound play for everyone regardless of range or location. Only affects Server-side sounds.
--- @return sound Sound Object
+-- @return Sound Sound Object
 function sounds_library.create(ent, path, nofilter)
 	checkluatype(path, TYPE_STRING)
 	if nofilter~=nil then checkluatype(nofilter, TYPE_BOOL) end

--- a/lua/starfall/libs_sh/sounds.lua
+++ b/lua/starfall/libs_sh/sounds.lua
@@ -106,6 +106,14 @@ function sounds_library.soundsLeft()
 	return math.min(plyCount:check(instance.player), plySoundBurst:check(instance.player))
 end
 
+--- Returns the sound duration in seconds. May not work for all file-types on linux/macos
+-- @param path String path to the sound file
+-- @return Number duration in seconds
+function sounds_library.duration(path)
+    checkluatype(path, TYPE_STRING)
+    return SoundDuration(path)
+end
+
 --------------------------------------------------
 
 --- Starts to play the sound.

--- a/lua/starfall/libs_sh/sounds.lua
+++ b/lua/starfall/libs_sh/sounds.lua
@@ -181,6 +181,7 @@ function sound_methods:setPitch(pitch, fade)
 end
 
 --- Returns whether the sound is being played.
+-- @return boolean Whether the sound is playing or not
 function sound_methods:isPlaying()
 	return unwrap(self):IsPlaying()
 end

--- a/lua/starfall/libs_sh/sounds.lua
+++ b/lua/starfall/libs_sh/sounds.lua
@@ -60,10 +60,10 @@ local ent_meta, ewrap, eunwrap = instance.Types.Entity, instance.Types.Entity.Wr
 
 
 --- Creates a sound and attaches it to an entity
--- @param ent Entity to attach sound to.
--- @param path Filepath to the sound file.
--- @param nofilter (Optional) Boolean Make the sound play for everyone regardless of range or location. Only affects Server-side sounds.
--- @return Sound Object
+-- @param entity ent Entity to attach sound to.
+-- @param string path Filepath to the sound file.
+-- @param boolean? nofilter (Optional) Boolean Make the sound play for everyone regardless of range or location. Only affects Server-side sounds.
+-- @return sound Sound Object
 function sounds_library.create(ent, path, nofilter)
 	checkluatype(path, TYPE_STRING)
 	if nofilter~=nil then checkluatype(nofilter, TYPE_BOOL) end
@@ -95,20 +95,20 @@ end
 
 
 --- Returns if a sound is able to be created
--- @return If it is possible to make a sound
+-- @return boolean If it is possible to make a sound
 function sounds_library.canCreate()
 	return plyCount:check(instance.player) > 0 and plySoundBurst:check(instance.player) >= 1
 end
 
 --- Returns the number of sounds left that can be created
--- @return The number of sounds left
+-- @return number The number of sounds left
 function sounds_library.soundsLeft()
 	return math.min(plyCount:check(instance.player), plySoundBurst:check(instance.player))
 end
 
 --- Returns the sound duration in seconds. May not work for all file-types on linux/macos
--- @param path String path to the sound file
--- @return Number duration in seconds
+-- @param string path String path to the sound file
+-- @return number Number duration in seconds
 function sounds_library.duration(path)
     checkluatype(path, TYPE_STRING)
     return SoundDuration(path)
@@ -123,7 +123,7 @@ function sound_methods:play()
 end
 
 --- Stops the sound from being played.
--- @param fade Time in seconds to fade out, if nil or 0 the sound stops instantly.
+-- @param number? fade Time in seconds to fade out, if nil or 0 the sound stops instantly.
 function sound_methods:stop(fade)
 	checkpermission(instance, nil, "sound.modify")
 	if fade~=nil then
@@ -150,8 +150,8 @@ function sound_methods:destroy()
 end
 
 --- Sets the volume of the sound. Won't work unless the sound is playing.
--- @param vol Volume to set to, between 0 and 1.
--- @param fade Time in seconds to transition to this new volume.
+-- @param number vol Volume to set to, between 0 and 1.
+-- @param number? fade Time in seconds to transition to this new volume. Default 0
 function sound_methods:setVolume(vol, fade)
 	checkpermission(instance, nil, "sound.modify")
 	checkluatype(vol, TYPE_NUMBER)
@@ -168,8 +168,8 @@ function sound_methods:setVolume(vol, fade)
 end
 
 --- Sets the pitch of the sound. Won't work unless the sound is playing.
--- @param pitch Pitch to set to, between 0 and 255.
--- @param fade Time in seconds to transition to this new pitch.
+-- @param number pitch Pitch to set to, between 0 and 255.
+-- @param number? fade Time in seconds to transition to this new pitch. Default 0
 function sound_methods:setPitch(pitch, fade)
 	checkpermission(instance, nil, "sound.modify")
 	checkluatype(pitch, TYPE_NUMBER)
@@ -191,7 +191,7 @@ function sound_methods:isPlaying()
 end
 
 --- Sets the sound level in dB. Won't work unless the sound is playing.
--- @param level dB level, see <a href='https://developer.valvesoftware.com/wiki/Soundscripts#SoundLevel'> Vale Dev Wiki</a>, for information on the value to use.
+-- @param number level dB level, see <a href='https://developer.valvesoftware.com/wiki/Soundscripts#SoundLevel'> Vale Dev Wiki</a>, for information on the value to use.
 function sound_methods:setSoundLevel(level)
 	checkpermission(instance, nil, "sound.modify")
 	checkluatype(level, TYPE_NUMBER)

--- a/lua/starfall/libs_sh/string.lua
+++ b/lua/starfall/libs_sh/string.lua
@@ -95,7 +95,7 @@ string_library.format = sfstring.format
 -- @class function
 -- @param number time The time in seconds to format
 -- @param string? format An optional formatting to use. If no format it specified, a table will be returned instead
--- @return any Formatted string or a table
+-- @return string|table Formatted string or a table
 string_library.formattedTime = sfstring.FormattedTime
 
 --- Returns char value from the specified index in the supplied string. (DEPRECATED! You should use string.sub instead)
@@ -141,7 +141,7 @@ string_library.gmatch = sfstring.gmatch
 -- @class function
 -- @param string str String which should be modified.
 -- @param string pattern The pattern that defines what should be matched and eventually be replaced.
--- @param any replacement If string: matched sequence will be replaced with it; If table: matched sequence will be used as key; If function: matches will be passed as parameters to the function (return to replace)
+-- @param string|table|function replacement If string: matched sequence will be replaced with it; If table: matched sequence will be used as key; If function: matches will be passed as parameters to the function (return to replace)
 -- @param number? max Optional maximum number of replacements to be made
 -- @return string String with replaced parts
 -- @return number Replacements count
@@ -361,7 +361,7 @@ string_library.utf8force = utf8.force
 -- @param string str The string to calculate the length of
 -- @param number? startPos The starting position to get the length from
 -- @param number? endPos The ending position to get the length from
--- @return any The number of UTF-8 characters in the string. If there are invalid bytes, this will be false
+-- @return number|boolean The number of UTF-8 characters in the string. If there are invalid bytes, this will be false
 -- @return number? The position of the first invalid byte. If there were no invalid bytes, this will be nil
 string_library.utf8len = utf8.len
 

--- a/lua/starfall/libs_sh/string.lua
+++ b/lua/starfall/libs_sh/string.lua
@@ -16,312 +16,312 @@ local sfstring = SF.SafeStringLib
 
 --- Converts color to a string.
 -- @class function
--- @param color The color to put in the string
--- @return String with the color RGBA values separated by spaces
+-- @param color col The color to put in the string
+-- @return string String with the color RGBA values separated by spaces
 function string_library.fromColor(color)
 	return string.FromColor(cunwrap(color))
 end
 
 --- Converts string with RGBA values separated by spaces into a color.
 -- @class function
--- @param str The string to convert from
--- @return The color object
+-- @param string str The string to convert from
+-- @return color The color object
 function string_library.toColor(str)
 	return cwrap(string.ToColor(str))
 end
 
 --- Returns the given string's characters in their numeric ASCII representation.
 -- @class function
--- @param str The string to get the chars from
--- @param start The first character of the string to get the byte of
--- @param end The last character of the string to get the byte of
--- @return Vararg numerical bytes
+-- @param string str The string to get the chars from
+-- @param number start The first character of the string to get the byte of
+-- @param number end The last character of the string to get the byte of
+-- @return ... Vararg numerical bytes
 string_library.byte = sfstring.byte
 
 --- Takes the given numerical bytes and converts them to a string.
 -- @class function
--- @param ... The bytes to create the string from
--- @return String built from given bytes
+-- @param ... bytes The bytes to create the string from
+-- @return string String built from given bytes
 string_library.char = sfstring.char
 
 --- Inserts commas for every third digit.
 -- @class function
--- @param num The number to be separated by commas
--- @return String with commas inserted
+-- @param number num The number to be separated by commas
+-- @return string String with commas inserted
 string_library.comma = sfstring.Comma
 
 --- Returns the binary bytecode of the given function.
 -- @class function
--- @param func The function to get the bytecode of
--- @param strip True to strip the debug data, false to keep it. Defaults to false
--- @return The bytecode
+-- @param function func The function to get the bytecode of
+-- @param boolean? strip True to strip the debug data, false to keep it. Defaults to false
+-- @return string The bytecode
 string_library.dump = sfstring.dump
 
 --- Whether or not the second passed string matches the end of the first.
 -- @class function
--- @param str The string whose end is to be checked
--- @param end The string to be matched with the end of the first
--- @return True if the first string ends with the second, or the second is empty
+-- @param string str The string whose end is to be checked
+-- @param string end The string to be matched with the end of the first
+-- @return boolean True if the first string ends with the second, or the second is empty
 string_library.endsWith = sfstring.EndsWith
 
 --- Splits a string up wherever it finds the given separator
 -- @class function
--- @param separator The separator that will split the string
--- @param str The string to split up
--- @param patterns Set this to true if your separator is a pattern. Defaults to false
--- @return Table with the separated strings in numerical sequential order
+-- @param string separator The separator that will split the string
+-- @param string str The string to split up
+-- @param boolean? patterns Set this to true if your separator is a pattern. Defaults to false
+-- @return table Table with the separated strings in numerical sequential order
 string_library.explode = sfstring.Explode
 
 --- Attempts to find the specified substring in a string, uses Patterns by default. https://wiki.facepunch.com/gmod/Patterns
 -- @class function
--- @param haystack The string to search in
--- @param needle The string to find, can contain patterns if enabled
--- @param start The position to start the search from, negative start position will be relative to the end position
--- @param noPatterns Disable patterns. Defaults to false
--- @return Starting position of the found text, or nil if the text wasn't found
--- @return Ending position of found text, or nil if the text wasn't found
--- @return Matched text for each group if patterns are enabled and used, or nil if the text wasn't found
+-- @param string haystack The string to search in
+-- @param string needle The string to find, can contain patterns if enabled
+-- @param number start The position to start the search from, negative start position will be relative to the end position
+-- @param boolean? noPatterns Disable patterns. Defaults to false
+-- @return number? Starting position of the found text, or nil if the text wasn't found
+-- @return number? Ending position of found text, or nil if the text wasn't found
+-- @return string? Matched text for each group if patterns are enabled and used, or nil if the text wasn't found
 string_library.find = sfstring.find
 
 --- Formats the specified values into the string given. http://www.cplusplus.com/reference/cstdio/printf/
 -- @class function
--- @param str The string to be formatted
--- @param ... Vararg values to be formatted into the string
--- @return The formatted string
+-- @param string str The string to be formatted
+-- @param ... params Vararg values to be formatted into the string
+-- @return string The formatted string
 string_library.format = sfstring.format
 
 --- Returns the time as a formatted string or table. http://www.cplusplus.com/reference/cstdio/printf/
 -- If format is not specified, the table will contain the following keys: ms (miliseconds); s (seconds); m (minutes); h (hours).
 -- @class function
--- @param time The time in seconds to format
--- @param format An optional formatting to use. If no format it specified, a table will be returned instead
--- @return Formatted string or a table
+-- @param number time The time in seconds to format
+-- @param string? format An optional formatting to use. If no format it specified, a table will be returned instead
+-- @return any Formatted string or a table
 string_library.formattedTime = sfstring.FormattedTime
 
 --- Returns char value from the specified index in the supplied string. (DEPRECATED! You should use string.sub instead)
 -- @class function
--- @param str The string that you will be searching with the supplied index
--- @param index The index's value of the string to be returned
--- @return The selected character
+-- @param string str The string that you will be searching with the supplied index
+-- @param number index The index's value of the string to be returned
+-- @return string The selected character
 string_library.getChar = sfstring.GetChar
 
 --- Returns extension of the file-path.
 -- @class function
--- @param str File-path to get the file extensions from
--- @return The extension
+-- @param string str File-path to get the file extensions from
+-- @return string The extension
 string_library.getExtensionFromFilename = sfstring.GetExtensionFromFilename
 
 --- Returns file name and extension.
 -- @class function
--- @param str File-path to get the file extensions from
--- @return The filename along with it's extension
+-- @param string str File-path to get the file extensions from
+-- @return string The filename along with it's extension
 string_library.getFileFromFilename = sfstring.GetFileFromFilename
 
 --- Returns the path only from a file's path, excluding the file itself.
 -- @class function
--- @param str File-path to get the file extensions from
--- @return The path
+-- @param string str File-path to get the file extensions from
+-- @return string The path
 string_library.getPathFromFilename = sfstring.GetPathFromFilename
 
 --- Returns an iterator function that is called for every complete match of the pattern, all sub matches will be passed as to the loop. (DEPRECATED! You should use string.gmatch instead)
 -- @class function
--- @param data The string to search in
--- @param pattern The pattern to search for
--- @return The iterator function that can be used in a for-in loop
+-- @param string data The string to search in
+-- @param string pattern The pattern to search for
+-- @return function The iterator function that can be used in a for-in loop
 string_library.gfind = sfstring.gfind
 
 --- Using Patterns, returns an iterator which will return either one value if no capture groups are defined, or any capture group matches.
 -- @class function
--- @param data The string to search in
--- @param pattern The pattern to search for
--- @return The iterator function that can be used in a for-in loop
+-- @param string data The string to search in
+-- @param string pattern The pattern to search for
+-- @return function The iterator function that can be used in a for-in loop
 string_library.gmatch = sfstring.gmatch
 
 --- This functions main purpose is to replace certain character sequences in a string using Patterns.
 -- @class function
--- @param str String which should be modified.
--- @param pattern The pattern that defines what should be matched and eventually be replaced.
--- @param replacement If string: matched sequence will be replaced with it; If table: matched sequence will be used as key; If function: matches will be passed as parameters to the function (return to replace)
--- @param max Optional maximum number of replacements to be made
--- @return String with replaced parts
--- @return Replacements count
+-- @param string str String which should be modified.
+-- @param string pattern The pattern that defines what should be matched and eventually be replaced.
+-- @param any replacement If string: matched sequence will be replaced with it; If table: matched sequence will be used as key; If function: matches will be passed as parameters to the function (return to replace)
+-- @param number? max Optional maximum number of replacements to be made
+-- @return string String with replaced parts
+-- @return number Replacements count
 string_library.gsub = sfstring.gsub
 
 --- Joins the values of a table together to form a string. (DEPRECATED! You should use table.concat instead)
 -- @class function
--- @param separator The separator to insert between each piece
--- @param pieces The table of pieces to concatenate. The keys for these must be numeric and sequential
--- @return Imploded string
+-- @param string separator The separator to insert between each piece
+-- @param table pieces The table of pieces to concatenate. The keys for these must be numeric and sequential
+-- @return string Imploded string
 string_library.implode = sfstring.Implode
 
 --- Escapes special characters for JavaScript in a string, making the string safe for inclusion in to JavaScript strings.
 -- @class function
--- @param str The string that should be escaped
--- @return The safe string
+-- @param string str The string that should be escaped
+-- @return string The safe string
 string_library.javascriptSafe = sfstring.javascriptSafe
 
 --- Returns everything left of supplied place of that string.
 -- @class function
--- @param str The string to extract from
--- @param num Amount of chars relative to the beginning (starting from 1)
--- @return Returns a string containing a specified number of characters from the left side of a string
+-- @param string str The string to extract from
+-- @param number num Amount of chars relative to the beginning (starting from 1)
+-- @return string Returns a string containing a specified number of characters from the left side of a string
 string_library.left = sfstring.Left
 
 --- Counts the number of characters in the string. This is equivalent to using the # operator.
 -- @class function
--- @param str The string to find the length of
--- @return Length of the string
+-- @param string str The string to find the length of
+-- @return number Length of the string
 string_library.len = sfstring.len
 
 --- Changes any upper-case letters in a string to lower-case letters.
 -- @class function
--- @param str The string to convert
--- @return String with all uppercase letters replaced with their lowercase variants
+-- @param string str The string to convert
+-- @return string String with all uppercase letters replaced with their lowercase variants
 string_library.lower = sfstring.lower
 
 --- Finds a Pattern in a string.
 -- @class function
--- @param str String which should be searched in for matches
--- @param pattern The pattern that defines what should be matched
--- @param start The start index to start the matching from, negative to start the match from a position relative to the end
--- @return Vararg matched string(s)
+-- @param string str String which should be searched in for matches
+-- @param string pattern The pattern that defines what should be matched
+-- @param number? start The start index to start the matching from, negative to start the match from a position relative to the end. Default 1
+-- @return ... Vararg matched string(s)
 string_library.match = sfstring.match
 
 --- Converts a digital filesize to human-readable text.
 -- @class function
--- @param size The filesize in bytes
--- @return The human-readable filesize, in Bytes/KB/MB/GB (whichever is appropriate)
+-- @param number size The filesize in bytes
+-- @return string The human-readable filesize, in Bytes/KB/MB/GB (whichever is appropriate)
 string_library.niceSize = sfstring.NiceSize
 
 --- Formats the supplied number (in seconds) to the highest possible time unit
 -- @class function
--- @param time The number to format, in seconds
--- @return A nicely formatted time string
+-- @param number time The number to format, in seconds
+-- @return string A nicely formatted time string
 string_library.niceTime = sfstring.NiceTime
 
 --- Escapes all special characters within a string, making the string safe for inclusion in a Lua pattern.
 -- @class function
--- @param str The string to be sanitized
--- @return The sanitized string
+-- @param string str The string to be sanitized
+-- @return string The sanitized string
 string_library.patternSafe = sfstring.patternSafe
 
 --- Repeats the given string n times
 -- @class function
--- @param str The string to repeat
--- @param rep Number of times to repeat the string
--- @param sep (Optional) seperator string between each repeated string
--- @return String result
+-- @param string str The string to repeat
+-- @param number rep Number of times to repeat the string
+-- @param string? sep (Optional) seperator string between each repeated string
+-- @return string String result
 string_library.rep = sfstring.rep
 
 --- Replaces all occurrences of the supplied second string.
 -- @class function
--- @param str The string we are seeking to replace an occurrence(s)
--- @param find What we are seeking to replace
--- @param replace What to replace find with
--- @return String with parts replaced
+-- @param string str The string we are seeking to replace an occurrence(s)
+-- @param string find What we are seeking to replace
+-- @param string replace What to replace find with
+-- @return string String with parts replaced
 string_library.replace = sfstring.Replace
 
 --- Reverses a string.
 -- @class function
--- @param str String to be reversed
--- @return Reversed string
+-- @param string str String to be reversed
+-- @return string Reversed string
 string_library.reverse = sfstring.reverse
 
 --- Returns the last n-th characters of the string.
 -- @class function
--- @param str The string to extract from
--- @param num Amount of chars relative to the end (starting from 1)
--- @return String containing a specified number of characters from the right side of a string
+-- @param string str The string to extract from
+-- @param number num Amount of chars relative to the end (starting from 1)
+-- @return string String containing a specified number of characters from the right side of a string
 string_library.right = sfstring.Right
 
 --- Sets the character at the specific index of the string.
 -- @class function
--- @param str The input string
--- @param index The character index, 1 is the first from left
--- @param replacement String to replace with
--- @return Modified string
+-- @param string str The input string
+-- @param number index The character index, 1 is the first from left
+-- @param string replacement String to replace with
+-- @return string Modified string
 string_library.setChar = sfstring.SetChar
 
 --- Splits the string into a table of strings, separated by the second argument
 -- @class function
--- @param str String to split
--- @param separator Character(s) to split with
--- @return Table with the separated strings in numerical sequential order 
+-- @param string str String to split
+-- @param string separator Character(s) to split with
+-- @return table Table with the separated strings in numerical sequential order
 string_library.split = sfstring.Split
 
 --- Whether or not the first string starts with the second
 -- @class function
--- @param str String to be checked
--- @param start String to check with
--- @return True if the first string starts with the second
+-- @param string str String to be checked
+-- @param string start String to check with
+-- @return boolean True if the first string starts with the second
 string_library.startWith = sfstring.StartWith
 
 --- Removes the extension of a path
 -- @class function
--- @param path The file-path to change
--- @return Path without the extension
+-- @param string path The file-path to change
+-- @return string Path without the extension
 string_library.stripExtension = sfstring.StripExtension
 
 ---Returns a sub-string, starting from the character at position startPos of the string (inclusive)
 -- and optionally ending at the character at position endPos of the string (also inclusive).
 -- If EndPos is not given, the rest of the string is returned.
 -- @class function
--- @param str The string you'll take a sub-string out of
--- @param startPos The position of the first character that will be included in the sub-string
--- @param endPos The position of the last character to be included in the sub-string. It can be negative to count from the end
+-- @param string str The string you'll take a sub-string out of
+-- @param number startPos The position of the first character that will be included in the sub-string
+-- @param number? endPos The position of the last character to be included in the sub-string. It can be negative to count from the end
 string_library.sub = sfstring.sub
 
 --- Converts time to minutes and seconds string.
 -- @class function
--- @param time Time in seconds
--- @return Given time in "MM:SS" format
+-- @param number time Time in seconds
+-- @return string Given time in "MM:SS" format
 string_library.toMinutesSeconds = sfstring.ToMinutesSeconds
 
 --- Converts time to minutes, seconds and miliseconds string.
 -- @class function
--- @param time Time in seconds
--- @return Returns given time in "MM:SS:MS" format
+-- @param number time Time in seconds
+-- @return string Returns given time in "MM:SS:MS" format
 string_library.toMinutesSecondsMilliseconds = sfstring.ToMinutesSecondsMilliseconds
 
 --- Splits the string into characters and creates a sequential table of characters.
 -- As a result of the encoding, non-ASCII characters will be split into more than one character in the output table.
 -- Each character value in the output table will always be 1 byte.
 -- @class function
--- @param str The string to turn into a table
--- @return A sequential table where each value is a character from the given string
+-- @param string str The string to turn into a table
+-- @return table A sequential table where each value is a character from the given string
 string_library.toTable = sfstring.ToTable
 
 --- Removes leading and trailing spaces/characters of a string
 -- @class function
--- @param str The string to trim
--- @param char Optional character to be trimmed. Defaults to space character
--- @return Trimmed string
+-- @param string str The string to trim
+-- @param string? char Optional character to be trimmed. Defaults to space character
+-- @return string Trimmed string
 string_library.trim = sfstring.Trim
 
 --- Removes leading spaces/characters from a string
 -- @class function
--- @param str The string to trim
--- @param char Optional character to be trimmed. Defaults to space character
--- @return Trimmed string
+-- @param string str The string to trim
+-- @param string? char Optional character to be trimmed. Defaults to space character
+-- @return string Trimmed string
 string_library.trimLeft = sfstring.TrimLeft
 
 --- Removes trailing spaces/characters from a string.
 -- @class function
--- @param str The string to trim
--- @param char Optional character to be trimmed. Defaults to space character
--- @return Trimmed string
+-- @param string str The string to trim
+-- @param string char Optional character to be trimmed. Defaults to space character
+-- @return string Trimmed string
 string_library.trimRight = sfstring.TrimRight
 
 --- Changes any lower-case letters in a string to upper-case letters.
 -- @class function
--- @param str The string to convert
--- @return String with all letters upper case
+-- @param string str The string to convert
+-- @return string String with all letters upper case
 string_library.upper = sfstring.upper
 
 --- Returns a path with all .. accounted for
 -- @class function
--- @param str Path
--- @return Path with all .. replaced
+-- @param string str Path
+-- @return string Path with all .. replaced
 string_library.normalizePath = SF.NormalizePath
 
 
@@ -329,50 +329,50 @@ string_library.normalizePath = SF.NormalizePath
 --- Receives zero or more integers, converts each one to its corresponding UTF-8 byte sequence
 -- and returns a string with the concatenation of all these sequences
 -- @class function
--- @param ... Unicode code points to be converted in to a UTF-8 string
--- @return UTF-8 string generated from given arguments
+-- @param ... codepoints Unicode code points to be converted in to a UTF-8 string
+-- @return string UTF-8 string generated from given arguments
 string_library.utf8char = utf8.char
 
 --- Returns the codepoints (as numbers) from all characters in the given string that start between byte position startPos and endPos.
 -- It raises an error if it meets any invalid byte sequence.
 -- @class function
--- @param str The string that you will get the code(s) from
--- @param startPos The starting byte of the string to get the codepoint of
--- @param endPos The ending byte of the string to get the codepoint of
--- @return The codepoint number(s)
+-- @param string str The string that you will get the code(s) from
+-- @param number? startPos The starting byte of the string to get the codepoint of
+-- @param number? endPos The ending byte of the string to get the codepoint of
+-- @return ... The codepoint number(s)
 string_library.utf8codepoint = utf8.codepoint
 
 --- Returns an iterator (like string.gmatch) which returns both the position and codepoint of each utf8 character in the string.
 -- It raises an error if it meets any invalid byte sequence.
 -- @class function
--- @param str The string that you will get the codes from
--- @return The iterator (to be used in a for loop)
+-- @param string str The string that you will get the codes from
+-- @return function The iterator (to be used in a for loop)
 string_library.utf8codes = utf8.codes
 
 --- Forces a string to contain only valid UTF-8 data. Invalid sequences are replaced with U+FFFD (the Unicode replacement character).
 -- @class function
--- @param str The string that will become a valid UTF-8 string
--- @return The UTF-8 string
+-- @param string str The string that will become a valid UTF-8 string
+-- @return string The UTF-8 string
 string_library.utf8force = utf8.force
 
 --- Returns the number of UTF-8 sequences in the given string between positions startPos and endPos (both inclusive).
 -- If it finds any invalid UTF-8 byte sequence, returns false as well as the position of the first invalid byte.
 -- @class function
--- @param str The string to calculate the length of
--- @param startPos The starting position to get the length from
--- @param endPos The ending position to get the length from
--- @return The number of UTF-8 characters in the string. If there are invalid bytes, this will be false
--- @return The position of the first invalid byte. If there were no invalid bytes, this will be nil
+-- @param string str The string to calculate the length of
+-- @param number? startPos The starting position to get the length from
+-- @param number? endPos The ending position to get the length from
+-- @return any The number of UTF-8 characters in the string. If there are invalid bytes, this will be false
+-- @return number? The position of the first invalid byte. If there were no invalid bytes, this will be nil
 string_library.utf8len = utf8.len
 
 --- Returns the byte-index of the n'th UTF-8-character after the given startPos (nil if none).
 -- startPos defaults to 1 when n is positive and -1 when n is negative. If n is zero,
 -- this function instead returns the byte-index of the UTF-8-character startPos lies within.
 -- @class function
--- @param str The string that you will get the byte position from
--- @param n The position to get the beginning byte position from
--- @param startPos The offset for n. Defaults to 1 if n >= 0, otherwise -1
--- @return Starting byte-index of the given position
+-- @param string str The string that you will get the byte position from
+-- @param number n The position to get the beginning byte position from
+-- @param number? startPos The offset for n. Defaults to 1 if n >= 0, otherwise -1
+-- @return number Starting byte-index of the given position
 string_library.utf8offset = utf8.offset
 
 

--- a/lua/starfall/libs_sh/string.lua
+++ b/lua/starfall/libs_sh/string.lua
@@ -16,7 +16,7 @@ local sfstring = SF.SafeStringLib
 
 --- Converts color to a string.
 -- @class function
--- @param color col The color to put in the string
+-- @param Color col The color to put in the string
 -- @return string String with the color RGBA values separated by spaces
 function string_library.fromColor(color)
 	return string.FromColor(cunwrap(color))
@@ -25,7 +25,7 @@ end
 --- Converts string with RGBA values separated by spaces into a color.
 -- @class function
 -- @param string str The string to convert from
--- @return color The color object
+-- @return Color The color object
 function string_library.toColor(str)
 	return cwrap(string.ToColor(str))
 end

--- a/lua/starfall/libs_sh/surfaceinfo.lua
+++ b/lua/starfall/libs_sh/surfaceinfo.lua
@@ -8,7 +8,7 @@
 
 SF.RegisterType("SurfaceInfo",true,false,debug.getregistry().SurfaceInfo)
 
-return function(instance) 
+return function(instance)
 
 local surfaceinfo_methods, surfaceinfo_meta, swrap, sunwrap = instance.Types.SurfaceInfo.Methods, instance.Types.SurfaceInfo, instance.Types.SurfaceInfo.Wrap, instance.Types.SurfaceInfo.Unwrap
 
@@ -24,7 +24,7 @@ local vec_meta, vwrap, vunwrap = instance.Types.Vector, instance.Types.Vector.Wr
 if SERVER then
 	--- Returns the brush surface's material.
 	-- @shared
-	-- @return In SERVER, the material name, and in CLIENT, the Material object.
+	-- @return any In SERVER, the material name, and in CLIENT, the Material object.
 	function surfaceinfo_methods:getMaterial()
 		return sunwrap(self):GetMaterial():GetName()
 	end
@@ -38,7 +38,7 @@ end
 
 --- Returns a list of vertices the brush surface is built from.
 -- @shared
--- @return A list of Vector points. This will usually be 4 corners of a quadrilateral in counter-clockwise order.
+-- @return table List of Vector points. This will usually be 4 corners of a quadrilateral in counter-clockwise order.
 function surfaceinfo_methods:getVertices()
     local t = sunwrap(self):GetVertices()
     local out = {}
@@ -52,7 +52,7 @@ end
 --- Checks if the brush surface is a nodraw surface, meaning it will not be drawn by the engine.
 -- This internally checks the SURFDRAW_NODRAW flag.
 -- @shared
--- @return Returns true if this surface won't be drawn.
+-- @return boolean If this surface won't be drawn.
 function surfaceinfo_methods:isNoDraw()
     return sunwrap(self):IsNoDraw()
 end
@@ -60,7 +60,7 @@ end
 --- Checks if the brush surface is displaying the skybox.
 -- This internally checks the SURFDRAW_SKY flag.
 -- @shared
--- @return Returns true if the surface is the sky.
+-- @return boolean If the surface is the sky.
 function surfaceinfo_methods:isSky()
     return sunwrap(self):IsSky()
 end
@@ -68,7 +68,7 @@ end
 --- Checks if the brush surface is water.
 -- This internally checks the SURFDRAW_WATER flag.
 -- @shared
--- @return Returns true if the surface is water.
+-- @return boolean If the surface is water.
 function surfaceinfo_methods:isWater()
     return sunwrap(self):IsWater()
 end

--- a/lua/starfall/libs_sh/surfaceinfo.lua
+++ b/lua/starfall/libs_sh/surfaceinfo.lua
@@ -24,7 +24,7 @@ local vec_meta, vwrap, vunwrap = instance.Types.Vector, instance.Types.Vector.Wr
 if SERVER then
 	--- Returns the brush surface's material.
 	-- @shared
-	-- @return any In SERVER, the material name, and in CLIENT, the Material object.
+	-- @return string|Material In SERVER, the material name, and in CLIENT, the Material object.
 	function surfaceinfo_methods:getMaterial()
 		return sunwrap(self):GetMaterial():GetName()
 	end

--- a/lua/starfall/libs_sh/table.lua
+++ b/lua/starfall/libs_sh/table.lua
@@ -13,247 +13,248 @@ local table_library = instance.Libraries.table
 
 --- Adds the contents from one table into another. The target table will be modified.
 -- @class function
--- @param target The table to insert the new values into
--- @param source The table to retrieve the values from
--- @return The target table
+-- @param table target The table to insert the new values into
+-- @param table source The table to retrieve the values from
+-- @return table The target table
 table_library.add = table.Add
 
 --- Changes all keys to sequential integers. This creates a new table object and does not affect the original.
 -- @class function
--- @param tbl The original table to modify
--- @param saveKeys Optional save the keys within each member table. This will insert a new field __key into each value, and should not be used if the table contains non-table values. Defaults to false
--- @return Table with integer keys
+-- @param table tbl The original table to modify
+-- @param boolean? saveKeys Optional save the keys within each member table. This will insert a new field __key into each value, and should not be used if the table contains non-table values. Defaults to false
+-- @return table Table with integer keys
 table_library.clearKeys = table.ClearKeys
 
 --- Collapses a table with keyvalue structure
 -- @class function
--- @param tbl The input table
--- @return Output table
+-- @param table tbl The input table
+-- @return table Output table
 table_library.collapseKeyValue = table.CollapseKeyValue
 
 --- Concatenates the contents of a table to a string.
 -- @class function
--- @param tbl The table to concatenate
--- @param concatenator A seperator to insert between each string
--- @param startPos Optional key to start at. Defaults to 1
--- @param endPos Optional key to end at. Defaults to #tbl
--- @return Concatenated string
+-- @param table tbl The table to concatenate
+-- @param string concatenator A seperator to insert between each string
+-- @param number? startPos Optional key to start at. Defaults to 1
+-- @param number? endPos Optional key to end at. Defaults to #tbl
+-- @return string Concatenated string
 table_library.concat = table.concat
 
 --- Empties the target table, and merges all values from the source table into it.
 -- @class function
--- @param source The table to copy from
--- @param target The table to write to
+-- @param target source The table to copy from
+-- @param target target The table to write to
 table_library.copyFromTo = table.CopyFromTo
 
 --- Counts the amount of keys in a table. This should only be used when a table is not numerically and sequentially indexed, for those table consider # operator
 -- @class function
--- @param tbl The table to count the keys of
--- @return The number of keyvalue pairs
+-- @param table tbl The table to count the keys of
+-- @return number The number of keyvalue pairs
 table_library.count = table.Count
 
 --- Removes all values from a table
 -- @class function
--- @param tbl The table to empty
+-- @param table tbl The table to empty
 table_library.empty = table.Empty
 
 --- Returns the value positioned after the supplied value in a table. If it isn't found then the first element in the table is returned.
 -- (DEPRECATED! Iterate the table using ipairs or increment from the previous index using next(). Non-numerically indexed tables are not ordered)
 -- @class function
--- @param tbl Table to search
--- @param val Any value to return element after
--- @return Found element
+-- @param table tbl Table to search
+-- @param any val Any value to return element after
+-- @return any Found element
 table_library.findNext = table.FindNext
 
 --- Returns the value positioned before the supplied value in a table. If it isn't found then the last element in the table is returned.
 -- (DEPRECATED! Iterate the table using ipairs, storing the previous value and checking for the target). Non-numerically indexed tables are not ordered)
 -- @class function
--- @param tbl Table to search
--- @param val Value to return element before
--- @return Found element
+-- @param table tbl Table to search
+-- @param any val Value to return element before
+-- @return any Found element
 table_library.findPrev = table.FindPrev
 
 --- Inserts a value in to the given table even if the table is non-existent
 -- @class function
--- @param tbl Table to insert value in to. If not supplied, will create a table
--- @param val Value to insert
--- @return The supplied or created table
+-- @param table tbl Table to insert value in to. If not supplied, will create a table
+-- @param any val Value to insert
+-- @return table The supplied or created table
 table_library.forceInsert = table.ForceInsert
 
 --- Iterates for each key-value pair in the table, calling the function with the key and value of the pair. If the function returns anything, the loop is broken.
 -- (DEPRECATED! You should use pairs() instead)
 -- @class function
--- @param tbl The table to iterate over
--- @param func The function to run for each key and value
+-- @param table tbl The table to iterate over
+-- @param function func The function to run for each key and value
 table_library.forEach = table.ForEach
 
 --- Iterates for each numeric index in the table in order (DEPRECATED! You should use ipairs() instead)
 -- @class function
--- @param tbl The table to iterate over
--- @param func The function to run for each index
+-- @param table tbl The table to iterate over
+-- @param function func The function to run for each index
 table_library.foreachi = table.foreachi
 
 --- Returns first key of the table (DEPRECATED! It may be changed or removed in a future update. Instead, expect the first key to be 1)
 -- Non-numerically indexed tables are not ordered and do not have a first key.
 -- @class function
--- @param tbl Table to retrieve key from
--- @return First key
+-- @param table tbl Table to retrieve key from
+-- @return any First key
 table_library.getFirstKey = table.GetFirstKey
 
 --- Returns first value found in the table. (DEPRECATED! It may be changed or removed in a future update. Instead, index the table with a key of 1)
 -- Non-numerically indexed tables are not ordered and do not have a first key.
 -- @class function
--- @param tbl Table to retrieve value from
+-- @param table tbl Table to retrieve value from
+-- @return any The first value found
 table_library.getFirstValue = table.GetFirstValue
 
 --- Returns all keys of a table
 -- @class function
--- @param tbl The table to get keys of
--- @return Table of keys
+-- @param table tbl The table to get keys of
+-- @return table Table of keys
 table_library.getKeys = table.GetKeys
 
 --- Returns the last key found in the given table. (DEPRECATED! Use the # operator instead)
 -- Non-numerically indexed tables are not ordered and do not have a last key
 -- @class function
--- @param tbl The table to get key of
--- @return Last key
+-- @param table tbl The table to get key of
+-- @return any Last key
 table_library.getLastKey = table.GetLastKey
 
 --- Returns the last value found in the given table. (DEPRECATED! Use the # operator instead)
 -- Non-numerically indexed tables are not ordered and do not have a last key
 -- @class function
--- @param tbl The table to get value of
--- @return Last Value
+-- @param table tbl The table to get value of
+-- @return any Last Value
 table_library.getLastValue = table.GetLastValue
 
 --- Returns the length of the table. (DEPRECATED! Use the # operator instead)
 -- @class function
--- @param tbl The table to check
--- @return Sequential length
+-- @param table tbl The table to check
+-- @return number Sequential length
 table_library.getn = table.getn
 
 --- Returns a key of the supplied table with the highest number value.
 -- @class function
--- @param tbl The table to search in
--- @return Winning key
+-- @param table tbl The table to search in
+-- @return any Winning key
 table_library.getWinningKey = table.GetWinningKey
 
 --- Checks if a table has a value. This function is very inefficient for large tables (O(n)).
 -- @class function
--- @param tbl Table to check
--- @param val Value to search for
--- @return Returns true if the table has that value, false otherwise
+-- @param table tbl Table to check
+-- @param any val Value to search for
+-- @return boolean Returns true if the table has that value, false otherwise
 table_library.hasValue = table.HasValue
 
 --- Copies any missing data from base to target, and sets the target's BaseClass member to the base table's pointer.
 -- @class function
--- @param target Table to copy data to
--- @param base Table to copy data from
--- @return The target table
+-- @param table target Table to copy data to
+-- @param table base Table to copy data from
+-- @return table The target table
 table_library.inherit = table.Inherit
 
 --- Inserts a value into a table at the end of the table or at the given position.
 -- @class function
--- @param tbl The table to insert the variable into
--- @param pos The position in the table to insert the variable. If the third argument is not provided, this argument becomes the value to insert at the end of given table
--- @param val The variable to insert into the table
+-- @param table tbl The table to insert the variable into
+-- @param any pos The position in the table to insert the variable. If the third argument is not provided, this argument becomes the value to insert at the end of given table
+-- @param any? val The variable to insert into the table
 table_library.insert = function(a,b,c) if c~=nil then b = math.Clamp(b, 1, 2^31-1) return table.insert(a,b,c) else return table.insert(a,b) end end
 
 --- Returns whether or not the table's keys are sequential.
 -- @class function
--- @param tbl Table to check
--- @return True if sequential
+-- @param table tbl Table to check
+-- @return boolean True if sequential
 table_library.isSequential = table.IsSequential
 
 --- Returns the first key found to be containing the supplied value.
 -- @class function
--- @param tbl Table to search
--- @param val Value to search for
--- @return Found key
+-- @param table tbl Table to search
+-- @param any val Value to search for
+-- @return any Found key
 table_library.keyFromValue = table.KeyFromValue
 
 --- Returns a table of keys containing the supplied value.
 -- @class function
--- @param tbl Table to search
--- @param val Value to search for
--- @return Table of keys
+-- @param table tbl Table to search
+-- @param any val Value to search for
+-- @return table Table of keys
 table_library.keysFromValue = table.KeysFromValue
 
 --- Returns a copy of the input table with all string keys converted to be lowercase recursively.
 -- @class function
--- @param tbl Table to convert
--- @return New converted table
+-- @param table tbl Table to convert
+-- @return table New converted table
 table_library.lowerKeyNames = table.LowerKeyNames
 
 --- Returns the highest numerical key.
 -- @class function
--- @param tbl The table to search
--- @return The highest numerical key
+-- @param table tbl The table to search
+-- @return number The highest numerical key
 table_library.maxn = table.maxn
 
 --- Returns a random value from the supplied table.
 -- @class function
--- @param tbl The table to choose from
--- @return A random value from the table
--- @return The key associated with the random value
+-- @param table tbl The table to choose from
+-- @return any A random value from the table
+-- @return any The key associated with the random value
 table_library.random = table.Random
 
 --- Removes a value from a table and shifts any other values down to fill the gap.
 -- @class function
--- @param tbl The table to remove the value from
--- @param index Optional index of the value to remove. Defaults to #tbl
--- @return The value that was removed
+-- @param table tbl The table to remove the value from
+-- @param number? index Optional index of the value to remove. Defaults to #tbl
+-- @return any The value that was removed
 table_library.remove = table.remove
 
 --- Removes the first instance of a given value from the specified table with table.remove, then returns the key that the value was found at
 -- @class function
--- @param tbl The table that will be searched
--- @param val The value to find within the table
--- @return The key at which the value was found, or false if the value was not found
+-- @param table tbl The table that will be searched
+-- @param any val The value to find within the table
+-- @return any The key at which the value was found, or false if the value was not found
 table_library.removeByValue = table.RemoveByValue
 
 --- Returns a reversed copy of a sequential table. Any non-sequential and non-numeric keyvalue pairs will not be copied
 -- @class function
--- @param tbl Table to reverse
--- @return A reversed copy of the table
+-- @param table tbl Table to reverse
+-- @return table A reversed copy of the table
 table_library.reverse = table.Reverse
 
 --- Sorts a table either ascending or by the given sort function
 -- @class function
--- @param tbl The table to sort
--- @param If specified, the function will be called with 2 parameters each. Return true in this function if you want the first parameter to come first in the sorted array
+-- @param table tbl The table to sort
+-- @param function? sorter If specified, the function will be called with 2 parameters each. Return true in this function if you want the first parameter to come first in the sorted array
 table_library.sort = table.sort
 
 --- Returns a list of keys sorted based on values of those keys.
 -- @class function
--- @param tbl Table to sort. All values of this table must be of same type
--- @param descending Optional, should the order be descending? Defaults to false
+-- @param table tbl Table to sort. All values of this table must be of same type
+-- @param boolean? descending Optional, should the order be descending? Defaults to false
 table_library.sortByKey = table.SortByKey
 
 --- Sorts a table by a named member.
 -- @class function
--- @param tbl Table to sort
--- @param member The key used to identify the member
--- @param ascending Optional, should be ascending? Defaults to false
+-- @param table tbl Table to sort
+-- @param any member The key used to identify the member
+-- @param boolean? ascending Optional, should be ascending? Defaults to false
 table_library.sortByMember = table.SortByMember
 
 --- Sorts a table in reverse order from table.sort
 -- @class function
--- @param tbl The table to sort in descending order
--- @return Sorted table
+-- @param table tbl The table to sort in descending order
+-- @return table Sorted table
 table_library.sortDesc = table.SortDesc
 
 --- Converts a table into a string
 -- @class function
--- @param tbl The table to iterate over
--- @param displayName Optional name for the table
--- @param niceFormatting Optional, adds new lines and tabs to the string. Defaults to false
+-- @param table tbl The table to iterate over
+-- @param string? displayName Optional name for the table
+-- @param boolean? niceFormatting Optional, adds new lines and tabs to the string. Defaults to false
 table_library.toString = table.ToString
 
 --- Creates a deep copy and returns that copy. This function does NOT copy userdata, such as Vectors and Angles!
 -- @class function
--- @param tbl The table to be copied
--- @return A deep copy of the original table
+-- @param table tbl The table to be copied
+-- @return table A deep copy of the original table
 function table_library.copy( tbl, lookup_table )
 	if ( tbl == nil ) then return nil end
 
@@ -279,9 +280,9 @@ end
 
 --- Merges the contents of the second table with the content in the first one.
 -- @class function
--- @param dest The table you want the source table to merge with
--- @param source The table you want to merge with the destination table
--- @return Destination table
+-- @param table dest The table you want the source table to merge with
+-- @param table source The table you want to merge with the destination table
+-- @return table Destination table
 function table_library.merge( dest, source )
 
 	for k, v in pairs( source ) do

--- a/lua/starfall/libs_sh/table.lua
+++ b/lua/starfall/libs_sh/table.lua
@@ -157,7 +157,7 @@ table_library.inherit = table.Inherit
 -- @class function
 -- @param table tbl The table to insert the variable into
 -- @param any pos The position in the table to insert the variable. If the third argument is not provided, this argument becomes the value to insert at the end of given table
--- @param any? val The variable to insert into the table
+-- @param any val The variable to insert into the table
 table_library.insert = function(a,b,c) if c~=nil then b = math.Clamp(b, 1, 2^31-1) return table.insert(a,b,c) else return table.insert(a,b) end end
 
 --- Returns whether or not the table's keys are sequential.

--- a/lua/starfall/libs_sh/table.lua
+++ b/lua/starfall/libs_sh/table.lua
@@ -42,8 +42,8 @@ table_library.concat = table.concat
 
 --- Empties the target table, and merges all values from the source table into it.
 -- @class function
--- @param target source The table to copy from
--- @param target target The table to write to
+-- @param table source The table to copy from
+-- @param table target The table to write to
 table_library.copyFromTo = table.CopyFromTo
 
 --- Counts the amount of keys in a table. This should only be used when a table is not numerically and sequentially indexed, for those table consider # operator

--- a/lua/starfall/libs_sh/team.lua
+++ b/lua/starfall/libs_sh/team.lua
@@ -13,21 +13,21 @@ local team_library = instance.Libraries.team
 local col_meta, cwrap, cunwrap = instance.Types.Color, instance.Types.Color.Wrap, instance.Types.Color.Unwrap
 
 --- Returns a table containing team information
--- @return table containing team information
+-- @return table Table containing team information
 function team_library.getAllTeams()
 	return instance.Sanitize(team.GetAllTeams())
 end
 
 --- Returns the color of a team
--- @param ind Index of the team
--- @return Color of the team
+-- @param number ind Index of the team
+-- @return color Color of the team
 function team_library.getColor(ind)
 	return cwrap(team.GetColor(ind))
 end
 
 --- Returns the table of players on a team
--- @param ind Index of the team
--- @return Table of players
+-- @param number ind Index of the team
+-- @return table Table of players
 function team_library.getPlayers(ind)
 	return instance.Sanitize(team.GetPlayers(ind))
 end
@@ -35,56 +35,56 @@ end
 --- Returns team with least players
 -- @name team_library.bestAutoJoinTeam
 -- @class function
--- @return index of the best team to join
+-- @return number Index of the best team to join
 team_library.bestAutoJoinTeam = team.BestAutoJoinTeam
 
 --- Returns the name of a team
 -- @name team_library.getName
 -- @class function
--- @param ind Index of the team
--- @return String name of the team
+-- @param number ind Index of the team
+-- @return string String name of the team
 team_library.getName = team.GetName
 
 --- Returns the score of a team
 -- @name team_library.getScore
 -- @class function
--- @param ind Index of the team
--- @return Number score of the team
+-- @param number ind Index of the team
+-- @return number Number score of the team
 team_library.getScore =  team.GetScore
 
 --- Returns whether or not a team can be joined
 -- @name team_library.getJoinable
 -- @class function
--- @param ind Index of the team
--- @return boolean
+-- @param number ind Index of the team
+-- @return boolean Whether the team is joinable
 team_library.getJoinable = team.Joinable
 
 --- Returns number of players on a team
 -- @name team_library.getNumPlayers
 -- @class function
--- @param ind Index of the team
--- @return number of players
+-- @param number ind Index of the team
+-- @return number Number of players on the team
 team_library.getNumPlayers = team.NumPlayers
 
 --- Returns number of deaths of all players on a team
 -- @name team_library.getNumDeaths
 -- @class function
--- @param ind Index of the team
--- @return number of deaths
+-- @param number ind Index of the team
+-- @return number Number of deaths
 team_library.getNumDeaths = team.TotalDeaths
 
 --- Returns number of frags of all players on a team
 -- @name team_library.getNumFrags
 -- @class function
--- @param ind Index of the team
--- @return number of frags
+-- @param number ind Index of the team
+-- @return number Number of frags
 team_library.getNumFrags = team.TotalFrags
 
 --- Returns whether or not the team exists
 -- @name team_library.exists
 -- @class function
--- @param ind Index of the team
--- @return boolean
+-- @param number ind Index of the team
+-- @return boolean Whether the team exists
 team_library.exists = team.Valid
 
 end

--- a/lua/starfall/libs_sh/team.lua
+++ b/lua/starfall/libs_sh/team.lua
@@ -20,7 +20,7 @@ end
 
 --- Returns the color of a team
 -- @param number ind Index of the team
--- @return color Color of the team
+-- @return Color Color of the team
 function team_library.getColor(ind)
 	return cwrap(team.GetColor(ind))
 end

--- a/lua/starfall/libs_sh/timer.lua
+++ b/lua/starfall/libs_sh/timer.lua
@@ -109,8 +109,8 @@ function timer_library.create(name, delay, reps, func)
 end
 
 --- Creates a simple timer, has no name, can't be stopped, paused, or destroyed.
--- @param number delay the time, in second, to set the timer to
--- @param function func the function to call when the timer is fired
+-- @param number delay The time, in second, to set the timer to
+-- @param function func The function to call when the timer is fired
 function timer_library.simple(delay, func)
 	checkluatype(delay, TYPE_NUMBER)
 	checkluatype(func, TYPE_FUNCTION)

--- a/lua/starfall/libs_sh/timer.lua
+++ b/lua/starfall/libs_sh/timer.lua
@@ -95,10 +95,10 @@ local function createTimer(name, delay, reps, func, simple)
 end
 
 --- Creates (and starts) a timer
--- @param name The timer name
--- @param delay The time, in seconds, to set the timer to.
--- @param reps The repititions of the timer. 0 = infinte
--- @param func The function to call when the timer is fired
+-- @param string name The timer name
+-- @param number delay The time, in seconds, to set the timer to.
+-- @param number reps The repititions of the timer. 0 = infinte
+-- @param function func The function to call when the timer is fired
 function timer_library.create(name, delay, reps, func)
 	checkluatype(name, TYPE_STRING)
 	checkluatype(delay, TYPE_NUMBER)
@@ -109,8 +109,8 @@ function timer_library.create(name, delay, reps, func)
 end
 
 --- Creates a simple timer, has no name, can't be stopped, paused, or destroyed.
--- @param delay the time, in second, to set the timer to
--- @param func the function to call when the timer is fired
+-- @param number delay the time, in second, to set the timer to
+-- @param function func the function to call when the timer is fired
 function timer_library.simple(delay, func)
 	checkluatype(delay, TYPE_NUMBER)
 	checkluatype(func, TYPE_FUNCTION)
@@ -118,7 +118,7 @@ function timer_library.simple(delay, func)
 end
 
 --- Stops and removes the timer.
--- @param name The timer name
+-- @param string name The timer name
 function timer_library.remove(name)
 	checkluatype(name, TYPE_STRING)
 
@@ -131,24 +131,24 @@ function timer_library.remove(name)
 end
 
 --- Checks if a timer exists
--- @param name The timer name
--- @return bool if the timer exists
+-- @param string name The timer name
+-- @return boolean if the timer exists
 function timer_library.exists(name)
 	checkluatype(name, TYPE_STRING)
 	return timer.Exists(mangle_timer_name(name))
 end
 
 --- Stops a timer
--- @param name The timer name
--- @return false if the timer didn't exist or was already stopped, true otherwise.
+-- @param string name The timer name
+-- @return boolean False if the timer didn't exist or was already stopped, true otherwise.
 function timer_library.stop(name)
 	checkluatype(name, TYPE_STRING)
 	return timer.Stop(mangle_timer_name(name))
 end
 
 --- Starts a timer
--- @param name The timer name
--- @return true if the timer exists, false if it doesn't.
+-- @param string name The timer name
+-- @return boolean True if the timer exists, false if it doesn't.
 function timer_library.start(name)
 	checkluatype(name, TYPE_STRING)
 
@@ -156,11 +156,11 @@ function timer_library.start(name)
 end
 
 --- Adjusts a timer
--- @param name The timer name
--- @param delay The time, in seconds, to set the timer to.
--- @param reps (Optional) The repititions of the timer. 0 = infinte, nil = 1
--- @param func (Optional) The function to call when the timer is fired
--- @return true if succeeded
+-- @param string name The timer name
+-- @param number delay The time, in seconds, to set the timer to.
+-- @param number? reps (Optional) The repetitions of the timer. 0 = infinite, nil = 1
+-- @param function? func (Optional) The function to call when the timer is fired
+-- @return boolean True if succeeded
 function timer_library.adjust(name, delay, reps, func)
 	checkluatype(name, TYPE_STRING)
 	checkluatype(delay, TYPE_NUMBER)
@@ -178,8 +178,8 @@ function timer_library.adjust(name, delay, reps, func)
 end
 
 --- Pauses a timer
--- @param name The timer name
--- @return false if the timer didn't exist or was already paused, true otherwise.
+-- @param string name The timer name
+-- @return boolean false if the timer didn't exist or was already paused, true otherwise.
 function timer_library.pause(name)
 	checkluatype(name, TYPE_STRING)
 
@@ -187,8 +187,8 @@ function timer_library.pause(name)
 end
 
 --- Unpauses a timer
--- @param name The timer name
--- @return false if the timer didn't exist or was already running, true otherwise.
+-- @param string name The timer name
+-- @return boolean false if the timer didn't exist or was already running, true otherwise.
 function timer_library.unpause(name)
 	checkluatype(name, TYPE_STRING)
 
@@ -196,8 +196,8 @@ function timer_library.unpause(name)
 end
 
 --- Runs either timer.pause or timer.unpause based on the timer's current status.
--- @param name The timer name
--- @return status of the timer.
+-- @param string name The timer name
+-- @return boolean Status of the timer.
 function timer_library.toggle(name)
 	checkluatype(name, TYPE_STRING)
 
@@ -205,8 +205,8 @@ function timer_library.toggle(name)
 end
 
 --- Returns amount of time left (in seconds) before the timer executes its function.
--- @param name The timer name
--- @return The amount of time left (in seconds). If the timer is paused, the amount will be negative. Nil if timer doesnt exist
+-- @param string name The timer name
+-- @return number The amount of time left (in seconds). If the timer is paused, the amount will be negative. Nil if timer doesnt exist
 function timer_library.timeleft(name)
 	checkluatype(name, TYPE_STRING)
 
@@ -214,8 +214,8 @@ function timer_library.timeleft(name)
 end
 
 --- Returns amount of repetitions/executions left before the timer destroys itself.
--- @param name The timer name
--- @return The amount of executions left. Nil if timer doesnt exist
+-- @param string name The timer name
+-- @return number The amount of executions left. Nil if timer doesnt exist
 function timer_library.repsleft(name)
 	checkluatype(name, TYPE_STRING)
 
@@ -223,7 +223,7 @@ function timer_library.repsleft(name)
 end
 
 --- Returns number of available timers
--- @return Number of available timers
+-- @return number Number of available timers
 function timer_library.getTimersLeft()
 	return max_timers:GetInt() - timer_count
 end

--- a/lua/starfall/libs_sh/trace.lua
+++ b/lua/starfall/libs_sh/trace.lua
@@ -53,13 +53,13 @@ local function convertFilter(filter)
 end
 
 --- Does a line trace
--- @param start Start position
--- @param endpos End position
--- @param filter Entity/array of entities to filter, or a function callback with an entity arguement that returns whether the trace should hit
--- @param mask Trace mask
--- @param colgroup The collision group of the trace
--- @param ignworld Whether the trace should ignore world
--- @return Result of the trace https://wiki.facepunch.com/gmod/Structures/TraceResult
+-- @param vector start Start position
+-- @param vector endpos End position
+-- @param any? filter Entity/array of entities to filter, or a function callback with an entity arguement that returns whether the trace should hit
+-- @param number? mask Trace mask
+-- @param number? colgroup The collision group of the trace
+-- @param boolean? ignworld Whether the trace should ignore world
+-- @return table Result of the trace https://wiki.facepunch.com/gmod/Structures/TraceResult
 function trace_library.trace(start, endpos, filter, mask, colgroup, ignworld)
 	checkpermission(instance, nil, "trace")
 	checkvector(start)
@@ -85,15 +85,15 @@ function trace_library.trace(start, endpos, filter, mask, colgroup, ignworld)
 end
 
 --- Does a swept-AABB trace
--- @param start Start position
--- @param endpos End position
--- @param minbox Lower box corner
--- @param maxbox Upper box corner
--- @param filter Entity/array of entities to filter, or a function callback with an entity arguement that returns whether the trace should hit
--- @param mask Trace mask
--- @param colgroup The collision group of the trace
--- @param ignworld Whether the trace should ignore world
--- @return Result of the trace https://wiki.facepunch.com/gmod/Structures/TraceResult
+-- @param vector start Start position
+-- @param vector endpos End position
+-- @param vector minbox Lower box corner
+-- @param vector maxbox Upper box corner
+-- @param any? filter Entity/array of entities to filter, or a function callback with an entity arguement that returns whether the trace should hit
+-- @param number? mask Trace mask
+-- @param number? colgroup The collision group of the trace
+-- @param boolean? ignworld Whether the trace should ignore world
+-- @return table Result of the trace https://wiki.facepunch.com/gmod/Structures/TraceResult
 function trace_library.traceHull(start, endpos, minbox, maxbox, filter, mask, colgroup, ignworld)
 	checkpermission(instance, nil, "trace")
 	checkvector(start)
@@ -123,36 +123,36 @@ function trace_library.traceHull(start, endpos, minbox, maxbox, filter, mask, co
 end
 
 --- Does a ray box intersection returning the position hit, normal, and trace fraction, or nil if not hit.
---@param rayStart The origin of the ray
---@param rayDelta The direction and length of the ray
---@param boxOrigin The origin of the box
---@param boxAngles The box's angles
---@param boxMins The box min bounding vector
---@param boxMaxs The box max bounding vector
---@return Hit position or nil if not hit
---@return Hit normal or nil if not hit
---@return Hit fraction or nil if not hit
+--@param vector rayStart The origin of the ray
+--@param vector rayDelta The direction and length of the ray
+--@param vector boxOrigin The origin of the box
+--@param angle boxAngles The box's angles
+--@param vector boxMins The box min bounding vector
+--@param vector boxMaxs The box max bounding vector
+--@return vector? Hit position or nil if not hit
+--@return vector? Hit normal or nil if not hit
+--@return number? Hit fraction or nil if not hit
 function trace_library.intersectRayWithOBB(rayStart, rayDelta, boxOrigin, boxAngles, boxMins, boxMaxs)
 	local pos, normal, fraction = util.IntersectRayWithOBB(vunwrap(rayStart), vunwrap(rayDelta), vunwrap(boxOrigin), aunwrap(boxAngles), vunwrap(boxMins), vunwrap(boxMaxs))
 	if pos then return vwrap(pos), vwrap(normal), fraction end
 end
 
 --- Does a ray plane intersection returning the position hit or nil if not hit
---@param rayStart The origin of the ray
---@param rayDelta The direction and length of the ray
---@param planeOrigin The origin of the plane
---@param planeNormal The normal of the plane
---@return Hit position or nil if not hit
+--@param vector rayStart The origin of the ray
+--@param vector rayDelta The direction and length of the ray
+--@param vector planeOrigin The origin of the plane
+--@param vector planeNormal The normal of the plane
+--@return vector? Hit position or nil if not hit
 function trace_library.intersectRayWithPlane(rayStart, rayDelta, planeOrigin, planeNormal)
 	local pos = util.IntersectRayWithPlane(vunwrap(rayStart), vunwrap(rayDelta), vunwrap(planeOrigin), vunwrap(planeNormal))
 	if pos then return vwrap(pos) end
 end
 
 --- Does a line trace and applies a decal to wherever is hit
--- @param name The decal name, see https://wiki.facepunch.com/gmod/util.Decal
--- @param start Start position
--- @param endpos End position
--- @param filter (Optional) Entity/array of entities to filter
+-- @param string name The decal name, see https://wiki.facepunch.com/gmod/util.Decal
+-- @param vector start Start position
+-- @param vector endpos End position
+-- @param any? filter (Optional) Entity/array of entities to filter
 function trace_library.decal(name, start, endpos, filter)
 	checkpermission(instance, nil, "trace.decal")
 	checkluatype(name, TYPE_STRING)
@@ -168,8 +168,8 @@ function trace_library.decal(name, start, endpos, filter)
 end
 
 --- Returns the contents of the position specified.
--- @param position The position to get the CONTENTS of
--- @return Contents bitflag, see the CONTENTS enums
+-- @param vector position The position to get the CONTENTS of
+-- @return number Contents bitflag, see the CONTENTS enums
 function trace_library.pointContents(position)
 	return util.PointContents(vunwrap(position))
 end

--- a/lua/starfall/libs_sh/trace.lua
+++ b/lua/starfall/libs_sh/trace.lua
@@ -53,8 +53,8 @@ local function convertFilter(filter)
 end
 
 --- Does a line trace
--- @param vector start Start position
--- @param vector endpos End position
+-- @param Vector start Start position
+-- @param Vector endpos End position
 -- @param any? filter Entity/array of entities to filter, or a function callback with an entity arguement that returns whether the trace should hit
 -- @param number? mask Trace mask
 -- @param number? colgroup The collision group of the trace
@@ -85,10 +85,10 @@ function trace_library.trace(start, endpos, filter, mask, colgroup, ignworld)
 end
 
 --- Does a swept-AABB trace
--- @param vector start Start position
--- @param vector endpos End position
--- @param vector minbox Lower box corner
--- @param vector maxbox Upper box corner
+-- @param Vector start Start position
+-- @param Vector endpos End position
+-- @param Vector minbox Lower box corner
+-- @param Vector maxbox Upper box corner
 -- @param any? filter Entity/array of entities to filter, or a function callback with an entity arguement that returns whether the trace should hit
 -- @param number? mask Trace mask
 -- @param number? colgroup The collision group of the trace
@@ -150,8 +150,8 @@ end
 
 --- Does a line trace and applies a decal to wherever is hit
 -- @param string name The decal name, see https://wiki.facepunch.com/gmod/util.Decal
--- @param vector start Start position
--- @param vector endpos End position
+-- @param Vector start Start position
+-- @param Vector endpos End position
 -- @param any? filter (Optional) Entity/array of entities to filter
 function trace_library.decal(name, start, endpos, filter)
 	checkpermission(instance, nil, "trace.decal")
@@ -168,7 +168,7 @@ function trace_library.decal(name, start, endpos, filter)
 end
 
 --- Returns the contents of the position specified.
--- @param vector position The position to get the CONTENTS of
+-- @param Vector position The position to get the CONTENTS of
 -- @return number Contents bitflag, see the CONTENTS enums
 function trace_library.pointContents(position)
 	return util.PointContents(vunwrap(position))

--- a/lua/starfall/libs_sh/trace.lua
+++ b/lua/starfall/libs_sh/trace.lua
@@ -55,7 +55,7 @@ end
 --- Does a line trace
 -- @param Vector start Start position
 -- @param Vector endpos End position
--- @param Entity?|table?|function? filter Entity/array of entities to filter, or a function callback with an entity arguement that returns whether the trace should hit
+-- @param Entity|table|function|nil filter Entity/array of entities to filter, or a function callback with an entity arguement that returns whether the trace should hit
 -- @param number? mask Trace mask
 -- @param number? colgroup The collision group of the trace
 -- @param boolean? ignworld Whether the trace should ignore world
@@ -89,7 +89,7 @@ end
 -- @param Vector endpos End position
 -- @param Vector minbox Lower box corner
 -- @param Vector maxbox Upper box corner
--- @param Entity?|table?|function? filter Entity/array of entities to filter, or a function callback with an entity arguement that returns whether the trace should hit
+-- @param Entity|table|function|nil filter Entity/array of entities to filter, or a function callback with an entity arguement that returns whether the trace should hit
 -- @param number? mask Trace mask
 -- @param number? colgroup The collision group of the trace
 -- @param boolean? ignworld Whether the trace should ignore world
@@ -152,7 +152,7 @@ end
 -- @param string name The decal name, see https://wiki.facepunch.com/gmod/util.Decal
 -- @param Vector start Start position
 -- @param Vector endpos End position
--- @param Entity?|table? filter (Optional) Entity/array of entities to filter
+-- @param Entity|table|nil filter (Optional) Entity/array of entities to filter
 function trace_library.decal(name, start, endpos, filter)
 	checkpermission(instance, nil, "trace.decal")
 	checkluatype(name, TYPE_STRING)

--- a/lua/starfall/libs_sh/trace.lua
+++ b/lua/starfall/libs_sh/trace.lua
@@ -55,7 +55,7 @@ end
 --- Does a line trace
 -- @param Vector start Start position
 -- @param Vector endpos End position
--- @param any? filter Entity/array of entities to filter, or a function callback with an entity arguement that returns whether the trace should hit
+-- @param entity?|table?|function? filter Entity/array of entities to filter, or a function callback with an entity arguement that returns whether the trace should hit
 -- @param number? mask Trace mask
 -- @param number? colgroup The collision group of the trace
 -- @param boolean? ignworld Whether the trace should ignore world
@@ -89,7 +89,7 @@ end
 -- @param Vector endpos End position
 -- @param Vector minbox Lower box corner
 -- @param Vector maxbox Upper box corner
--- @param any? filter Entity/array of entities to filter, or a function callback with an entity arguement that returns whether the trace should hit
+-- @param entity?|table?|function? filter Entity/array of entities to filter, or a function callback with an entity arguement that returns whether the trace should hit
 -- @param number? mask Trace mask
 -- @param number? colgroup The collision group of the trace
 -- @param boolean? ignworld Whether the trace should ignore world
@@ -152,7 +152,7 @@ end
 -- @param string name The decal name, see https://wiki.facepunch.com/gmod/util.Decal
 -- @param Vector start Start position
 -- @param Vector endpos End position
--- @param any? filter (Optional) Entity/array of entities to filter
+-- @param entity?|table? filter (Optional) Entity/array of entities to filter
 function trace_library.decal(name, start, endpos, filter)
 	checkpermission(instance, nil, "trace.decal")
 	checkluatype(name, TYPE_STRING)

--- a/lua/starfall/libs_sh/trace.lua
+++ b/lua/starfall/libs_sh/trace.lua
@@ -55,7 +55,7 @@ end
 --- Does a line trace
 -- @param Vector start Start position
 -- @param Vector endpos End position
--- @param entity?|table?|function? filter Entity/array of entities to filter, or a function callback with an entity arguement that returns whether the trace should hit
+-- @param Entity?|table?|function? filter Entity/array of entities to filter, or a function callback with an entity arguement that returns whether the trace should hit
 -- @param number? mask Trace mask
 -- @param number? colgroup The collision group of the trace
 -- @param boolean? ignworld Whether the trace should ignore world
@@ -89,7 +89,7 @@ end
 -- @param Vector endpos End position
 -- @param Vector minbox Lower box corner
 -- @param Vector maxbox Upper box corner
--- @param entity?|table?|function? filter Entity/array of entities to filter, or a function callback with an entity arguement that returns whether the trace should hit
+-- @param Entity?|table?|function? filter Entity/array of entities to filter, or a function callback with an entity arguement that returns whether the trace should hit
 -- @param number? mask Trace mask
 -- @param number? colgroup The collision group of the trace
 -- @param boolean? ignworld Whether the trace should ignore world
@@ -123,26 +123,26 @@ function trace_library.traceHull(start, endpos, minbox, maxbox, filter, mask, co
 end
 
 --- Does a ray box intersection returning the position hit, normal, and trace fraction, or nil if not hit.
---@param vector rayStart The origin of the ray
---@param vector rayDelta The direction and length of the ray
---@param vector boxOrigin The origin of the box
---@param angle boxAngles The box's angles
---@param vector boxMins The box min bounding vector
---@param vector boxMaxs The box max bounding vector
---@return vector? Hit position or nil if not hit
---@return vector? Hit normal or nil if not hit
---@return number? Hit fraction or nil if not hit
+-- @param Vector rayStart The origin of the ray
+-- @param Vector rayDelta The direction and length of the ray
+-- @param Vector boxOrigin The origin of the box
+-- @param Angle boxAngles The box's angles
+-- @param Vector boxMins The box min bounding vector
+-- @param Vector boxMaxs The box max bounding vector
+-- @return Vector? Hit position or nil if not hit
+-- @return Vector? Hit normal or nil if not hit
+-- @return number? Hit fraction or nil if not hit
 function trace_library.intersectRayWithOBB(rayStart, rayDelta, boxOrigin, boxAngles, boxMins, boxMaxs)
 	local pos, normal, fraction = util.IntersectRayWithOBB(vunwrap(rayStart), vunwrap(rayDelta), vunwrap(boxOrigin), aunwrap(boxAngles), vunwrap(boxMins), vunwrap(boxMaxs))
 	if pos then return vwrap(pos), vwrap(normal), fraction end
 end
 
 --- Does a ray plane intersection returning the position hit or nil if not hit
---@param vector rayStart The origin of the ray
---@param vector rayDelta The direction and length of the ray
---@param vector planeOrigin The origin of the plane
---@param vector planeNormal The normal of the plane
---@return vector? Hit position or nil if not hit
+-- @param Vector rayStart The origin of the ray
+-- @param Vector rayDelta The direction and length of the ray
+-- @param Vector planeOrigin The origin of the plane
+-- @param Vector planeNormal The normal of the plane
+-- @return Vector? Hit position or nil if not hit
 function trace_library.intersectRayWithPlane(rayStart, rayDelta, planeOrigin, planeNormal)
 	local pos = util.IntersectRayWithPlane(vunwrap(rayStart), vunwrap(rayDelta), vunwrap(planeOrigin), vunwrap(planeNormal))
 	if pos then return vwrap(pos) end
@@ -152,7 +152,7 @@ end
 -- @param string name The decal name, see https://wiki.facepunch.com/gmod/util.Decal
 -- @param Vector start Start position
 -- @param Vector endpos End position
--- @param entity?|table? filter (Optional) Entity/array of entities to filter
+-- @param Entity?|table? filter (Optional) Entity/array of entities to filter
 function trace_library.decal(name, start, endpos, filter)
 	checkpermission(instance, nil, "trace.decal")
 	checkluatype(name, TYPE_STRING)

--- a/lua/starfall/libs_sh/vectors.lua
+++ b/lua/starfall/libs_sh/vectors.lua
@@ -43,7 +43,7 @@ end)
 -- @param number x X value
 -- @param number y Y value
 -- @param number z Z value
--- @return vector Vector
+-- @return Vector Vector
 function instance.env.Vector(x, y, z)
 	if x~=nil then checkluatype(x, TYPE_NUMBER) else x = 0 end
 	if z~=nil then checkluatype(z, TYPE_NUMBER) else z = (y and 0 or x) end
@@ -58,7 +58,7 @@ end
 local xyz = { x = 1, y = 2, z = 3 }
 
 --- Sets a value at a key in the vector
--- @param vector Vec
+-- @param Vector Vec
 -- @param any Key
 -- @param number Value
 function vec_meta.__newindex(t, k, v)
@@ -86,14 +86,14 @@ local math_min = math.min
 --- Gets a value at a key in the vector
 -- Can be indexed with: 1, 2, 3, x, y, z, xx, xy, xz, xxx, xyz, zyx, etc.. 1,2,3 is most efficient.
 -- @param any Key to get the value at
--- @return any Value at the index
+-- @return any The value at the index
 function vec_meta.__index(t, k)
 	local method = vec_methods[k]
 	if method ~= nil then
 		return method
 	elseif xyz[k] then
 		return rawget(t, xyz[k])
-	else 
+	else
 		-- Swizzle support
 		local v = {0,0,0}
 		for i = 1, math_min(#k,3)do
@@ -119,7 +119,7 @@ end
 --- Multiplication metamethod
 -- @param any a Number or Vector multiplicand.
 -- @param any b Number or Vector multiplier.
--- @return vector Multiplied vector.
+-- @return Vector Multiplied vector.
 function vec_meta.__mul(a, b)
 	if isnumber(b) then
 		return wrap({ a[1] * b, a[2] * b, a[3] * b })
@@ -141,7 +141,7 @@ end
 --- Division metamethod
 -- @param any v1 Number or Vector dividend.
 -- @param any v2 Number or Vector divisor.
--- @return vector Scaled vector.
+-- @return Vector Scaled vector.
 function vec_meta.__div(a, b)
 	if isnumber(b) then
 		return wrap({ a[1] / b, a[2] / b, a[3] / b })
@@ -157,51 +157,51 @@ function vec_meta.__div(a, b)
 end
 
 --- Addition metamethod
--- @param vector v1 Initial vector.
--- @param vector v2 Vector to add to the first.
--- @return vector Resultant vector after addition operation.
+-- @param Vector v1 Initial vector.
+-- @param Vector v2 Vector to add to the first.
+-- @return Vector Resultant vector after addition operation.
 function vec_meta.__add(a, b)
 	return wrap({ a[1] + b[1], a[2] + b[2], a[3] + b[3] })
 end
 
 --- Subtraction metamethod
--- @param vector v1 Initial Vector
--- @param vector v2 Vector to subtract
--- @return vector Resultant vector after subtraction operation.
+-- @param Vector v1 Initial Vector
+-- @param Vector v2 Vector to subtract
+-- @return Vector Resultant vector after subtraction operation.
 function vec_meta.__sub(a, b)
 	return wrap({ a[1]-b[1], a[2]-b[2], a[3]-b[3] })
 end
 
 --- Unary Minus metamethod (Negative)
--- @return vector Negative vector.
+-- @return Vector Negative vector.
 function vec_meta.__unm(a)
 	return wrap({ -a[1], -a[2], -a[3] })
 end
 
 --- Equivalence metamethod
--- @param vector v1 Initial vector.
--- @param vector v2 Vector to check against.
+-- @param Vector v1 Initial vector.
+-- @param Vector v2 Vector to check against.
 -- @return bool Whether both sides are equal.
 function vec_meta.__eq(a, b)
 	return a[1]==b[1] and a[2]==b[2] and a[3]==b[3]
 end
 
 --- Get the vector's angle.
--- @return angle Angle representing the vector
+-- @return Angle Angle representing the vector
 function vec_methods:getAngle()
 	return awrap(unwrap(self):Angle())
 end
 
 --- Returns the vector's euler angle with respect to the other vector as if it were the new vertical axis.
--- @param vector v Second Vector
--- @return angle Angle
+-- @param Vector v Second Vector
+-- @return Angle Angle
 function vec_methods:getAngleEx(v)
 	return awrap(unwrap(self):AngleEx(unwrap(v)))
 end
 
 --- Calculates the cross product of the 2 vectors, creates a unique perpendicular vector to both input vectors.
--- @param vector v Second Vector
--- @return vector Vector from cross product
+-- @param Vector v Second Vector
+-- @return Vector Vector from cross product
 function vec_methods:cross(v)
 	return wrap({ self[2] * v[3] - self[3] * v[2], self[3] * v[1] - self[1] * v[3], self[1] * v[2] - self[2] * v[1] })
 end
@@ -209,28 +209,28 @@ end
 local math_sqrt = math.sqrt
 
 --- Returns the pythagorean distance between the vector and the other vector.
--- @param vector v Second Vector
+-- @param Vector v Second Vector
 -- @return number Vector distance from v
 function vec_methods:getDistance(v)
 	return math_sqrt((v[1]-self[1])^2 + (v[2]-self[2])^2 + (v[3]-self[3])^2)
 end
 
 --- Returns the squared distance of 2 vectors, this is faster Vector:getDistance as calculating the square root is an expensive process.
--- @param vector v Second Vector
+-- @param Vector v Second Vector
 -- @return number Vector distance from v
 function vec_methods:getDistanceSqr(v)
 	return ((v[1]-self[1])^2 + (v[2]-self[2])^2 + (v[3]-self[3])^2)
 end
 
 --- Dot product is the cosine of the angle between both vectors multiplied by their lengths. A.B = ||A||||B||cosA.
--- @param vector v Second Vector
+-- @param Vector v Second Vector
 -- @return number Dot product result between the two vectors
 function vec_methods:dot(v)
 	return (self[1] * v[1] + self[2] * v[2] + self[3] * v[3])
 end
 
 --- Returns a new vector with the same direction by length of 1.
--- @return vector Normalized vector
+-- @return Vector Normalized vector
 function vec_methods:getNormalized()
 	local len = math_sqrt(self[1]^2 + self[2]^2 + self[3]^2)
 
@@ -238,7 +238,7 @@ function vec_methods:getNormalized()
 end
 
 --- Is this vector and v equal within tolerance t.
--- @param vector v Second Vector
+-- @param Vector v Second Vector
 -- @param number t Tolerance number.
 -- @return boolean Whether the vector is equal to v within the tolerance.
 function vec_methods:isEqualTol(v, t)
@@ -279,7 +279,7 @@ end
 
 --- Add v to this vector
 -- Self-Modifies. Does not return anything
--- @param vector v Vector to add
+-- @param Vector v Vector to add
 function vec_methods:add(v)
 	self[1] = self[1] + v[1]
 	self[2] = self[2] + v[2]
@@ -288,7 +288,7 @@ end
 
 --- Subtract v from this Vector.
 -- Self-Modifies. Does not return anything
--- @param vector v Vector to subtract.
+-- @param Vector v Vector to subtract.
 function vec_methods:sub(v)
 	self[1] = self[1] - v[1]
 	self[2] = self[2] - v[2]
@@ -319,7 +319,7 @@ end
 
 --- Multiply self with a Vector.
 -- Self-Modifies. Does not return anything
--- @param vector v Vector to multiply with
+-- @param Vector v Vector to multiply with
 function vec_methods:vmul(v)
 	self[1] = self[1] * v[1]
 	self[2] = self[2] * v[2]
@@ -328,7 +328,7 @@ end
 
 --- Divide self by a Vector.
 -- Self-Modifies. Does not return anything
--- @param vector v Vector to divide by
+-- @param Vector v Vector to divide by
 function vec_methods:vdiv(v)
 	self[1] = self[1] / v[1]
 	self[2] = self[2] / v[2]
@@ -345,7 +345,7 @@ end
 
 --- Set's the vector's x coordinate and returns the vector after modifying.
 -- @param number x The x coordinate
--- @return vector Modified vector after setting X.
+-- @return Vector Modified vector after setting X.
 function vec_methods:setX(x)
 	self[1] = x
 	return self
@@ -353,7 +353,7 @@ end
 
 --- Set's the vector's y coordinate and returns the vector after modifying.
 -- @param number y The y coordinate
--- @return vector Modified vector after setting Y.
+-- @return Vector Modified vector after setting Y.
 function vec_methods:setY(y)
 	self[2] = y
 	return self
@@ -361,7 +361,7 @@ end
 
 --- Set's the vector's z coordinate and returns the vector after modifying.
 -- @param number z The z coordinate
--- @return vector Modified vector after setting Z.
+-- @return Vector Modified vector after setting Z.
 function vec_methods:setZ(z)
 	self[3] = z
 	return self
@@ -379,7 +379,7 @@ end
 
 --- Rotate the vector by Angle b.
 -- Self-Modifies. Does not return anything
--- @param angle b Angle to rotate by.
+-- @param Angle b Angle to rotate by.
 function vec_methods:rotate(b)
 	local vec = unwrap(self)
 	vec:Rotate(aunwrap(b))
@@ -390,8 +390,8 @@ function vec_methods:rotate(b)
 end
 
 --- Returns Rotated vector by Angle b
--- @param angle b Angle to rotate by.
--- @return vector Rotated Vector
+-- @param Angle b Angle to rotate by.
+-- @return Vector Rotated Vector
 function vec_methods:getRotated(b)
 	local vec = unwrap(self)
 	vec:Rotate(aunwrap(b))
@@ -413,10 +413,10 @@ function vec_methods:getBasis()
 end
 
 --- Return rotated vector by an axis
--- @param vector axis Axis the rotate around
+-- @param Vector axis Axis the rotate around
 -- @param number? degrees Angle to rotate by in degrees or nil if radians.
 -- @param number? radians Angle to rotate by in radians or nil if degrees.
--- @return vector Rotated vector
+-- @return Vector Rotated vector
 function vec_methods:rotateAroundAxis(axis, degrees, radians)
 	if degrees then
 		checkluatype(degrees, TYPE_NUMBER)
@@ -445,14 +445,14 @@ function vec_methods:round(idp)
 end
 
 --- Copies x,y,z from a vector and returns a new vector
--- @return vector The copy of the vector
+-- @return Vector The copy of the vector
 function vec_methods:clone()
 	return wrap({ self[1], self[2], self[3] })
 end
 
 --- Copies the values from the second vector to the first vector.
 -- Self-Modifies. Does not return anything
--- @param vector v Second Vector
+-- @param Vector v Second Vector
 function vec_methods:set(v)
 	self[1] = v[1]
 	self[2] = v[2]
@@ -466,14 +466,14 @@ function vec_methods:toScreen()
 end
 
 --- Converts vector to color
--- @return color New color object
+-- @return Color New color object
 function vec_methods:getColor()
 	return cwrap(unwrap(self):ToColor())
 end
 
 --- Returns whenever the given vector is in a box created by the 2 other vectors.
--- @param vector v1 Vector used to define AABox
--- @param vector v2 Second Vector to define AABox
+-- @param Vector v1 Vector used to define AABox
+-- @param Vector v2 Second Vector to define AABox
 -- @return bool True/False.
 function vec_methods:withinAABox(v1, v2)
 	if self[1] < math.min(v1[1], v2[1]) or self[1] > math.max(v1[1], v2[1]) then return false end

--- a/lua/starfall/libs_sh/vectors.lua
+++ b/lua/starfall/libs_sh/vectors.lua
@@ -59,7 +59,7 @@ local xyz = { x = 1, y = 2, z = 3 }
 
 --- Sets a value at a key in the vector
 -- @param Vector Vec
--- @param any Key
+-- @param number|string Key
 -- @param number Value
 function vec_meta.__newindex(t, k, v)
 	if xyz[k] then
@@ -85,8 +85,8 @@ local math_min = math.min
 
 --- Gets a value at a key in the vector
 -- Can be indexed with: 1, 2, 3, x, y, z, xx, xy, xz, xxx, xyz, zyx, etc.. 1,2,3 is most efficient.
--- @param any Key to get the value at
--- @return any The value at the index
+-- @param number|string Key to get the value at
+-- @return number The value at the index
 function vec_meta.__index(t, k)
 	local method = vec_methods[k]
 	if method ~= nil then
@@ -117,8 +117,8 @@ function vec_meta.__tostring(a)
 end
 
 --- Multiplication metamethod
--- @param any a Number or Vector multiplicand.
--- @param any b Number or Vector multiplier.
+-- @param number|Vector a Number or Vector multiplicand.
+-- @param number|Vector b Number or Vector multiplier.
 -- @return Vector Multiplied vector.
 function vec_meta.__mul(a, b)
 	if isnumber(b) then
@@ -139,8 +139,8 @@ function vec_meta.__mul(a, b)
 end
 
 --- Division metamethod
--- @param any v1 Number or Vector dividend.
--- @param any v2 Number or Vector divisor.
+-- @param number|Vector v1 Number or Vector dividend.
+-- @param number|Vector v2 Number or Vector divisor.
 -- @return Vector Scaled vector.
 function vec_meta.__div(a, b)
 	if isnumber(b) then

--- a/lua/starfall/libs_sh/vectors.lua
+++ b/lua/starfall/libs_sh/vectors.lua
@@ -40,10 +40,10 @@ end)
 --- Creates a Vector struct.
 -- @name builtins_library.Vector
 -- @class function
--- @param x - X
--- @param y - Y
--- @param z - Z
--- @return Vector
+-- @param number x X value
+-- @param number y Y value
+-- @param number z Z value
+-- @return vector Vector
 function instance.env.Vector(x, y, z)
 	if x~=nil then checkluatype(x, TYPE_NUMBER) else x = 0 end
 	if z~=nil then checkluatype(z, TYPE_NUMBER) else z = (y and 0 or x) end
@@ -57,7 +57,10 @@ end
 -- String based indexing returns string, just a pass through.
 local xyz = { x = 1, y = 2, z = 3 }
 
---- __newindex metamethod
+--- Sets a value at a key in the vector
+-- @param vector Vec
+-- @param any Key
+-- @param number Value
 function vec_meta.__newindex(t, k, v)
 	if xyz[k] then
 		rawset(t, xyz[k], v)
@@ -80,8 +83,10 @@ end
 
 local math_min = math.min
 
---- __index metamethod
+--- Gets a value at a key in the vector
 -- Can be indexed with: 1, 2, 3, x, y, z, xx, xy, xz, xxx, xyz, zyx, etc.. 1,2,3 is most efficient.
+-- @param any Key to get the value at
+-- @return any Value at the index
 function vec_meta.__index(t, k)
 	local method = vec_methods[k]
 	if method ~= nil then
@@ -105,16 +110,16 @@ end
 
 local table_concat = table.concat
 
---- tostring metamethod
--- @return string representing the vector.
+--- Turns a vector into a string.
+-- @return string String representation of the vector.
 function vec_meta.__tostring(a)
 	return table_concat(a, ' ', 1, 3)
 end
 
---- multiplication metamethod
--- @param lhs Left side of equation
--- @param rhs Right side of equation
--- @return Scaled vector.
+--- Multiplication metamethod
+-- @param any a Number or Vector multiplicand.
+-- @param any b Number or Vector multiplier.
+-- @return vector Multiplied vector.
 function vec_meta.__mul(a, b)
 	if isnumber(b) then
 		return wrap({ a[1] * b, a[2] * b, a[3] * b })
@@ -133,9 +138,10 @@ function vec_meta.__mul(a, b)
 	end
 end
 
---- division metamethod
--- @param b Scalar or vector to divide the scalar or vector by
--- @return Scaled vector.
+--- Division metamethod
+-- @param any v1 Number or Vector dividend.
+-- @param any v2 Number or Vector divisor.
+-- @return vector Scaled vector.
 function vec_meta.__div(a, b)
 	if isnumber(b) then
 		return wrap({ a[1] / b, a[2] / b, a[3] / b })
@@ -150,48 +156,52 @@ function vec_meta.__div(a, b)
 	end
 end
 
---- add metamethod
--- @param v Vector to add
--- @return Resultant vector after addition operation.
+--- Addition metamethod
+-- @param vector v1 Initial vector.
+-- @param vector v2 Vector to add to the first.
+-- @return vector Resultant vector after addition operation.
 function vec_meta.__add(a, b)
 	return wrap({ a[1] + b[1], a[2] + b[2], a[3] + b[3] })
 end
 
---- sub metamethod
--- @param v Vector to subtract
--- @return Resultant vector after subtraction operation.
+--- Subtraction metamethod
+-- @param vector v1 Initial Vector
+-- @param vector v2 Vector to subtract
+-- @return vector Resultant vector after subtraction operation.
 function vec_meta.__sub(a, b)
 	return wrap({ a[1]-b[1], a[2]-b[2], a[3]-b[3] })
 end
 
---- unary minus metamethod
--- @return negated vector.
+--- Unary Minus metamethod (Negative)
+-- @return vector Negative vector.
 function vec_meta.__unm(a)
 	return wrap({ -a[1], -a[2], -a[3] })
 end
 
---- equivalence metamethod
--- @return bool if both sides are equal.
+--- Equivalence metamethod
+-- @param vector v1 Initial vector.
+-- @param vector v2 Vector to check against.
+-- @return bool Whether both sides are equal.
 function vec_meta.__eq(a, b)
 	return a[1]==b[1] and a[2]==b[2] and a[3]==b[3]
 end
 
 --- Get the vector's angle.
--- @return Angle
+-- @return angle Angle representing the vector
 function vec_methods:getAngle()
 	return awrap(unwrap(self):Angle())
 end
 
 --- Returns the vector's euler angle with respect to the other vector as if it were the new vertical axis.
--- @param v Second Vector
--- @return Angle
+-- @param vector v Second Vector
+-- @return angle Angle
 function vec_methods:getAngleEx(v)
 	return awrap(unwrap(self):AngleEx(unwrap(v)))
 end
 
 --- Calculates the cross product of the 2 vectors, creates a unique perpendicular vector to both input vectors.
--- @param v Second Vector
--- @return Vector
+-- @param vector v Second Vector
+-- @return vector Vector from cross product
 function vec_methods:cross(v)
 	return wrap({ self[2] * v[3] - self[3] * v[2], self[3] * v[1] - self[1] * v[3], self[1] * v[2] - self[2] * v[1] })
 end
@@ -199,28 +209,28 @@ end
 local math_sqrt = math.sqrt
 
 --- Returns the pythagorean distance between the vector and the other vector.
--- @param v Second Vector
--- @return Number
+-- @param vector v Second Vector
+-- @return number Vector distance from v
 function vec_methods:getDistance(v)
 	return math_sqrt((v[1]-self[1])^2 + (v[2]-self[2])^2 + (v[3]-self[3])^2)
 end
 
 --- Returns the squared distance of 2 vectors, this is faster Vector:getDistance as calculating the square root is an expensive process.
--- @param v Second Vector
--- @return Number
+-- @param vector v Second Vector
+-- @return number Vector distance from v
 function vec_methods:getDistanceSqr(v)
 	return ((v[1]-self[1])^2 + (v[2]-self[2])^2 + (v[3]-self[3])^2)
 end
 
 --- Dot product is the cosine of the angle between both vectors multiplied by their lengths. A.B = ||A||||B||cosA.
--- @param v Second Vector
--- @return Number
+-- @param vector v Second Vector
+-- @return number Dot product result between the two vectors
 function vec_methods:dot(v)
 	return (self[1] * v[1] + self[2] * v[2] + self[3] * v[3])
 end
 
 --- Returns a new vector with the same direction by length of 1.
--- @return Vector Normalised
+-- @return vector Normalized vector
 function vec_methods:getNormalized()
 	local len = math_sqrt(self[1]^2 + self[2]^2 + self[3]^2)
 
@@ -228,23 +238,23 @@ function vec_methods:getNormalized()
 end
 
 --- Is this vector and v equal within tolerance t.
--- @param v Second Vector
--- @param t Tolerance number.
--- @return bool True/False.
+-- @param vector v Second Vector
+-- @param number t Tolerance number.
+-- @return boolean Whether the vector is equal to v within the tolerance.
 function vec_methods:isEqualTol(v, t)
 	checkluatype(t, TYPE_NUMBER)
 
 	return unwrap(self):IsEqualTol(unwrap(v), t)
 end
 
---- Are all fields zero.
--- @return bool True/False
+--- Returns whether all fields are zero
+-- @return boolean Whether all fields are zero
 function vec_methods:isZero()
 	return self[1]==0 and self[2]==0 and self[3]==0
 end
 
 --- Get the vector's Length.
--- @return number Length.
+-- @return number Length of the vector.
 function vec_methods:getLength()
 	return math_sqrt(self[1]^2 + self[2]^2 + self[3]^2)
 end
@@ -256,38 +266,38 @@ function vec_methods:getLengthSqr()
 end
 
 --- Returns the length of the vector in two dimensions, without the Z axis.
--- @return number length
+-- @return number Vector length
 function vec_methods:getLength2D()
 	return math_sqrt(self[1]^2 + self[2]^2)
 end
 
 --- Returns the length squared of the vector in two dimensions, without the Z axis. ( Saves computation by skipping the square root )
--- @return number length squared.
+-- @return number Length squared.
 function vec_methods:getLength2DSqr()
 	return (self[1]^2 + self[2]^2)
 end
 
---- Add vector - Modifies self.
--- @param v Vector to add
--- @return nil
+--- Add v to this vector
+-- Self-Modifies. Does not return anything
+-- @param vector v Vector to add
 function vec_methods:add(v)
 	self[1] = self[1] + v[1]
 	self[2] = self[2] + v[2]
 	self[3] = self[3] + v[3]
 end
 
---- Subtract v from this Vector. Self-Modifies.
--- @param v Second Vector.
--- @return nil
+--- Subtract v from this Vector.
+-- Self-Modifies. Does not return anything
+-- @param vector v Vector to subtract.
 function vec_methods:sub(v)
 	self[1] = self[1] - v[1]
 	self[2] = self[2] - v[2]
 	self[3] = self[3] - v[3]
 end
 
---- Scalar Multiplication of the vector. Self-Modifies.
--- @param n Scalar to multiply with.
--- @return nil
+--- Scalar Multiplication of the vector.
+-- Self-Modifies. Does not return anything
+-- @param number n Scalar to multiply with.
 function vec_methods:mul(n)
 	checkluatype(n, TYPE_NUMBER)
 
@@ -296,9 +306,9 @@ function vec_methods:mul(n)
 	self[3] = self[3] * n
 end
 
---- "Scalar Division" of the vector. Self-Modifies.
--- @param n Scalar to divide by.
--- @return nil
+--- "Scalar Division" of the vector.
+-- Self-Modifies. Does not return anything
+-- @param number n Scalar to divide by.
 function vec_methods:div(n)
 	checkluatype(n, TYPE_NUMBER)
 
@@ -307,16 +317,18 @@ function vec_methods:div(n)
 	self[3] = self[3] / n
 end
 
---- Multiply self with a Vector. Self-Modifies. ( convenience function )
--- @param v Vector to multiply with
+--- Multiply self with a Vector.
+-- Self-Modifies. Does not return anything
+-- @param vector v Vector to multiply with
 function vec_methods:vmul(v)
 	self[1] = self[1] * v[1]
 	self[2] = self[2] * v[2]
 	self[3] = self[3] * v[3]
 end
 
---- Divide self by a Vector. Self-Modifies. ( convenience function )
--- @param v Vector to divide by
+--- Divide self by a Vector.
+-- Self-Modifies. Does not return anything
+-- @param vector v Vector to divide by
 function vec_methods:vdiv(v)
 	self[1] = self[1] / v[1]
 	self[2] = self[2] / v[2]
@@ -324,39 +336,39 @@ function vec_methods:vdiv(v)
 end
 
 --- Set's all vector fields to 0.
--- @return nil
+-- Self-Modifies. Does not return anything
 function vec_methods:setZero()
 	self[1] = 0
 	self[2] = 0
 	self[3] = 0
 end
 
---- Set's the vector's x coordinate and returns it.
--- @param x The x coordinate
--- @return The modified vector
+--- Set's the vector's x coordinate and returns the vector after modifying.
+-- @param number x The x coordinate
+-- @return vector Modified vector after setting X.
 function vec_methods:setX(x)
 	self[1] = x
 	return self
 end
 
---- Set's the vector's y coordinate and returns it.
--- @param y The y coordinate
--- @return The modified vector
+--- Set's the vector's y coordinate and returns the vector after modifying.
+-- @param number y The y coordinate
+-- @return vector Modified vector after setting Y.
 function vec_methods:setY(y)
 	self[2] = y
 	return self
 end
 
---- Set's the vector's z coordinate and returns it.
--- @param z The z coordinate
--- @return The modified vector
+--- Set's the vector's z coordinate and returns the vector after modifying.
+-- @param number z The z coordinate
+-- @return vector Modified vector after setting Z.
 function vec_methods:setZ(z)
 	self[3] = z
 	return self
 end
 
---- Normalise the vector, same direction, length 1. Self-Modifies.
--- @return nil
+--- Normalise the vector, same direction, length 1.
+-- Self-Modifies. Does not return anything
 function vec_methods:normalize()
 	local len = math_sqrt(self[1]^2 + self[2]^2 + self[3]^2)
 
@@ -365,9 +377,9 @@ function vec_methods:normalize()
 	self[3] = self[3] / len
 end
 
---- Rotate the vector by Angle b. Self-Modifies.
--- @param b Angle to rotate by.
--- @return nil.
+--- Rotate the vector by Angle b.
+-- Self-Modifies. Does not return anything
+-- @param angle b Angle to rotate by.
 function vec_methods:rotate(b)
 	local vec = unwrap(self)
 	vec:Rotate(aunwrap(b))
@@ -378,8 +390,8 @@ function vec_methods:rotate(b)
 end
 
 --- Returns Rotated vector by Angle b
--- @param b Angle to rotate by.
--- @return Rotated Vector
+-- @param angle b Angle to rotate by.
+-- @return vector Rotated Vector
 function vec_methods:getRotated(b)
 	local vec = unwrap(self)
 	vec:Rotate(aunwrap(b))
@@ -388,8 +400,8 @@ function vec_methods:getRotated(b)
 end
 
 --- Returns an arbitrary orthogonal basis from the direction of the vector. Input must be a normalized vector
--- @return Basis 1
--- @return Basis 2
+-- @return number Basis 1
+-- @return number Basis 2
 function vec_methods:getBasis()
 	if self[3] < -0.9999999 then
 		return wrap({0.0, -1.0, 0.0}), wrap({-1.0, 0.0, 0.0})
@@ -401,10 +413,10 @@ function vec_methods:getBasis()
 end
 
 --- Return rotated vector by an axis
--- @param axis Axis the rotate around
--- @param degrees Angle to rotate by in degrees or nil if radians.
--- @param radians Angle to rotate by in radians or nil if degrees.
--- @return Rotated vector
+-- @param vector axis Axis the rotate around
+-- @param number? degrees Angle to rotate by in degrees or nil if radians.
+-- @param number? radians Angle to rotate by in radians or nil if degrees.
+-- @return vector Rotated vector
 function vec_methods:rotateAroundAxis(axis, degrees, radians)
 	if degrees then
 		checkluatype(degrees, TYPE_NUMBER)
@@ -423,9 +435,9 @@ function vec_methods:rotateAroundAxis(axis, degrees, radians)
 			(z * x * (1-ca) - y * sa) * x2 + (z * y * (1-ca) + x * sa) * y2 + (ca + (z^2) * (1-ca)) * z2 })
 end
 
---- Round the vector values. Self-Modifies.
--- @param idp (Default 0) The integer decimal place to round to. 
--- @return nil
+--- Round the vector values.
+-- Self-Modifies. Does not return anything
+-- @param number idp (Default 0) The integer decimal place to round to.
 function vec_methods:round(idp)
 	self[1] = math.Round(self[1], idp)
 	self[2] = math.Round(self[2], idp)
@@ -433,14 +445,14 @@ function vec_methods:round(idp)
 end
 
 --- Copies x,y,z from a vector and returns a new vector
--- @return The copy of the vector
+-- @return vector The copy of the vector
 function vec_methods:clone()
 	return wrap({ self[1], self[2], self[3] })
 end
 
---- Copies the values from the second vector to the first vector. Self-Modifies.
--- @param v Second Vector
--- @return nil
+--- Copies the values from the second vector to the first vector.
+-- Self-Modifies. Does not return anything
+-- @param vector v Second Vector
 function vec_methods:set(v)
 	self[1] = v[1]
 	self[2] = v[2]
@@ -448,20 +460,20 @@ function vec_methods:set(v)
 end
 
 --- Translates the vectors position into 2D user screen coordinates.
--- @return A table {x=screenx,y=screeny,visible=visible}
+-- @return table A table {x=screenx,y=screeny,visible=visible}
 function vec_methods:toScreen()
 	return unwrap(self):ToScreen()
 end
 
 --- Converts vector to color
--- @return New color object
+-- @return color New color object
 function vec_methods:getColor()
 	return cwrap(unwrap(self):ToColor())
 end
 
 --- Returns whenever the given vector is in a box created by the 2 other vectors.
--- @param v1 Vector used to define AABox
--- @param v2 Second Vector to define AABox
+-- @param vector v1 Vector used to define AABox
+-- @param vector v2 Second Vector to define AABox
 -- @return bool True/False.
 function vec_methods:withinAABox(v1, v2)
 	if self[1] < math.min(v1[1], v2[1]) or self[1] > math.max(v1[1], v2[1]) then return false end

--- a/lua/starfall/libs_sh/vehicles.lua
+++ b/lua/starfall/libs_sh/vehicles.lua
@@ -32,6 +32,8 @@ local function getveh(self)
 	end
 end
 
+--- tostring metamethod
+-- @return string String representation of the entity.
 function vehicle_meta:__tostring()
 	local ent = unwrap(self)
 	if not ent then return "(null entity)"
@@ -41,7 +43,7 @@ end
 if SERVER then
 	--- Returns the driver of the vehicle
 	-- @server
-	-- @return Driver of vehicle
+	-- @return player Driver of vehicle
 	function vehicle_methods:getDriver()
 		return pwrap(getveh(self):GetDriver())
 	end
@@ -57,8 +59,8 @@ if SERVER then
 
 	--- Returns a passenger of a vehicle
 	-- @server
-	-- @param n The index of the passenger to get
-	-- @return The passenger or NULL if empty
+	-- @param number n The index of the passenger to get
+	-- @return player The passenger or NULL if empty
 	function vehicle_methods:getPassenger(n)
 		checkluatype(n, TYPE_NUMBER)
 		return pwrap(getveh(self):GetPassenger(n))
@@ -76,7 +78,7 @@ if SERVER then
 	end
 
 	--- Strips weapons of the driver
-	-- @param class Optional weapon class to strip. Otherwise all are stripped.
+	-- @param string class Optional weapon class to strip. Otherwise all are stripped.
 	-- @server
 	function vehicle_methods:stripDriver(class)
 		if class ~= nil then checkluatype(class, TYPE_STRING) end

--- a/lua/starfall/libs_sh/vehicles.lua
+++ b/lua/starfall/libs_sh/vehicles.lua
@@ -79,7 +79,7 @@ if SERVER then
 	end
 
 	--- Strips weapons of the driver
-	-- @param string class Optional weapon class to strip. Otherwise all are stripped.
+	-- @param string? class Optional weapon class to strip. Otherwise all are stripped.
 	-- @server
 	function vehicle_methods:stripDriver(class)
 		if class ~= nil then checkluatype(class, TYPE_STRING) end

--- a/lua/starfall/libs_sh/vehicles.lua
+++ b/lua/starfall/libs_sh/vehicles.lua
@@ -15,6 +15,7 @@ end
 -- @name Vehicle
 -- @class type
 -- @libtbl vehicle_methods
+-- @libtbl vehicle_meta
 SF.RegisterType("Vehicle", false, true, debug.getregistry().Vehicle, "Entity")
 
 return function(instance)
@@ -32,8 +33,8 @@ local function getveh(self)
 	end
 end
 
---- tostring metamethod
--- @return string String representation of the entity.
+--- Turns a vehicle into a string.
+-- @return string String representing the vehicle.
 function vehicle_meta:__tostring()
 	local ent = unwrap(self)
 	if not ent then return "(null entity)"

--- a/lua/starfall/libs_sh/vehicles.lua
+++ b/lua/starfall/libs_sh/vehicles.lua
@@ -43,7 +43,7 @@ end
 if SERVER then
 	--- Returns the driver of the vehicle
 	-- @server
-	-- @return player Driver of vehicle
+	-- @return Player Driver of vehicle
 	function vehicle_methods:getDriver()
 		return pwrap(getveh(self):GetDriver())
 	end
@@ -60,7 +60,7 @@ if SERVER then
 	--- Returns a passenger of a vehicle
 	-- @server
 	-- @param number n The index of the passenger to get
-	-- @return player The passenger or NULL if empty
+	-- @return Player The passenger or NULL if empty
 	function vehicle_methods:getPassenger(n)
 		checkluatype(n, TYPE_NUMBER)
 		return pwrap(getveh(self):GetPassenger(n))

--- a/lua/starfall/libs_sh/vmatrix.lua
+++ b/lua/starfall/libs_sh/vmatrix.lua
@@ -25,217 +25,249 @@ end
 --- Returns a new VMatrix
 -- @name builtins_library.Matrix
 -- @class function
--- @return New VMatrix
+-- @param table Optional data to initialize the Matrix with.
+-- @return vmatrix New VMatrix
 function instance.env.Matrix(t)
 	return wrap(Matrix(t))
 end
 
 --- tostring metamethod
--- @return string representing the matrix.
+-- @return string String representing the matrix.
 function vmatrix_meta:__tostring()
 	return unwrap(self):__tostring()
 end
 
 --- Returns angles
--- @return Angles
+-- @return angle Angles
 function vmatrix_methods:getAngles()
 	return awrap(unwrap(self):GetAngles())
 end
 
 --- Returns scale
--- @return Scale
+-- @return vector Scale
 function vmatrix_methods:getScale()
 	return vwrap(unwrap(self):GetScale())
 end
 
 --- Returns translation
--- @return Translation
+-- @return vector Translation
 function vmatrix_methods:getTranslation()
 	return vwrap(unwrap(self):GetTranslation())
 end
 
 --- Returns a specific field in the matrix
--- @param row A number from 1 to 4
--- @param column A number from 1 to 4
--- @return Value of the specified field
+-- @param number row A number from 1 to 4
+-- @param number column A number from 1 to 4
+-- @return number Value of the specified field
 function vmatrix_methods:getField(row, column)
 	return unwrap(self):GetField(row, column)
 end
 
 --- Rotate the matrix
--- @param ang Angle to rotate by
+-- Self-Modifies. Does not return anything
+-- @param angle ang Angle to rotate by
 function vmatrix_methods:rotate(ang)
 	unwrap(self):Rotate(aunwrap(ang))
 end
 
 --- Returns an inverted matrix. Inverting the matrix will fail if its determinant is 0 or close to 0
--- @return Inverted matrix
+-- @return vmatrix Inverted matrix
 function vmatrix_methods:getInverse()
 	return wrap(unwrap(self):GetInverse())
 end
 
 --- Returns an inverted matrix. Efficiently for translations and rotations
--- @return Inverted matrix
+-- @return vmatrix Inverted matrix
 function vmatrix_methods:getInverseTR()
 	return wrap(unwrap(self):GetInverseTR())
 end
 
 --- Returns forward vector of matrix. First matrix column
--- @return Translation
+-- @return vector Translation
 function vmatrix_methods:getForward()
 	return vwrap(unwrap(self):GetForward())
 end
 
 --- Returns right vector of matrix. Negated second matrix column
--- @return Translation
+-- @return vector Translation
 function vmatrix_methods:getRight()
 	return vwrap(unwrap(self):GetRight())
 end
 
 --- Returns up vector of matrix. Third matrix column
--- @return Translation
+-- @return vector Translation
 function vmatrix_methods:getUp()
 	return vwrap(unwrap(self):GetUp())
 end
 
 --- Sets the scale
--- @param vec New scale
+-- Self-Modifies. Does not return anything
+-- @param vector vec New scale
 function vmatrix_methods:setScale(vec)
 	unwrap(self):SetScale(vunwrap(vec))
 end
 
 --- Scale the matrix
--- @param vec Vector to scale by
+-- Self-Modifies. Does not return anything
+-- @param vector vec Vector to scale by
 function vmatrix_methods:scale(vec)
 	unwrap(self):Scale(vunwrap(vec))
 end
 
 --- Scales the absolute translation
--- @param num Amount to scale by
+-- Self-Modifies. Does not return anything
+-- @param number num Amount to scale by
 function vmatrix_methods:scaleTranslation(num)
 	checkluatype (num, TYPE_NUMBER)
 	unwrap(self):ScaleTranslation(num)
 end
 
 --- Sets the angles
--- @param ang New angles
+-- Self-Modifies. Does not return anything
+-- @param angle ang New angles
 function vmatrix_methods:setAngles(ang)
 	unwrap(self):SetAngles(aunwrap(ang))
 end
 
 --- Sets the translation
--- @param vec New translation
+-- Self-Modifies. Does not return anything
+-- @param vector vec New translation
 function vmatrix_methods:setTranslation(vec)
 	unwrap(self):SetTranslation(vunwrap(vec))
 end
 
 --- Sets the forward direction of the matrix. First column
--- @param forward The forward vector
+-- Self-Modifies. Does not return anything
+-- @param vector forward The forward vector
 function vmatrix_methods:setForward(forward)
 	unwrap(self):SetForward(vunwrap(forward))
 end
 
 --- Sets the right direction of the matrix. Negated second column
--- @param right The right vector
+-- Self-Modifies. Does not return anything
+-- @param vector right The right vector
 function vmatrix_methods:setRight(right)
 	unwrap(self):SetRight(vunwrap(right))
 end
 
 --- Sets the up direction of the matrix. Third column
--- @param up The up vector
+-- Self-Modifies. Does not return anything
+-- @param vector up The up vector
 function vmatrix_methods:setUp(up)
 	unwrap(self):SetUp(vunwrap(up))
 end
 
 --- Sets a specific field in the matrix
--- @param row A number from 1 to 4
--- @param column A number from 1 to 4
--- @param value Value to set
+-- Self-Modifies. Does not return anything
+-- @param number row A number from 1 to 4
+-- @param number column A number from 1 to 4
+-- @param number value Value to set
 function vmatrix_methods:setField(row, column, value)
 	unwrap(self):SetField(row, column, value)
 end
 
 --- Copies The matrix and returns a new matrix
--- @return The copy of the matrix
+-- @return vmatrix The copy of the matrix
 function vmatrix_methods:clone()
 	return wrap(Matrix(unwrap(self)))
 end
 
 --- Returns all 16 fields of the matrix in row-major order
--- @return 16 numbers
+-- @return number [1, 1]
+-- @return number [1, 2]
+-- @return number [1, 3]
+-- @return number [1, 4]
+-- @return number [2, 1]
+-- @return number [2, 2]
+-- @return number [2, 3]
+-- @return number [2, 4]
+-- @return number [3, 1]
+-- @return number [3, 2]
+-- @return number [3, 3]
+-- @return number [3, 4]
+-- @return number [4, 1]
+-- @return number [4, 2]
+-- @return number [4, 3]
+-- @return number [4, 4]
 function vmatrix_methods:unpack()
 	return unwrap(self):Unpack()
 end
 
 --- Allows you to set all 16 fields in row-major order
--- @param ... The 16 fields
+-- Self-Modifies. Does not return anything
+-- @param ...number The 16 fields
 function vmatrix_methods:setUnpacked(...)
 	unwrap(self):SetUnpacked(...)
 end
 
---- Copies the values from the second matrix to the first matrix. Self-Modifies
--- @param src Second matrix
+--- Copies the values from the second matrix to the first matrix.
+-- Self-Modifies. Does not return anything
+-- @param vmatrix src Second matrix
 function vmatrix_methods:set(src)
 	unwrap(self):Set(unwrap(src))
 end
 
 --- Initializes the matrix as Identity matrix
+-- Self-Modifies. Does not return anything
 function vmatrix_methods:setIdentity()
 	unwrap(self):Identity()
 end
 
 --- Returns whether the matrix is equal to Identity matrix or not
--- @return bool True/False
+-- @return boolean True/False
 function vmatrix_methods:isIdentity()
 	return unwrap(self):IsIdentity()
 end
 
 --- Returns whether the matrix is a rotation matrix or not. Checks if the forward, right and up vectors are orthogonal and normalized.
--- @return bool True/False
+-- @return boolean True/False
 function vmatrix_methods:isRotationMatrix()
 	return unwrap(self):IsRotationMatrix()
 end
 
 --- Inverts the matrix. Inverting the matrix will fail if its determinant is 0 or close to 0
--- @return bool Whether the matrix was inverted or not
+-- Self-Modifies.
+-- @return boolean Whether the matrix was inverted or not
 function vmatrix_methods:invert()
 	return unwrap(self):Invert()
 end
 
 --- Inverts the matrix efficiently for translations and rotations
+-- Self-Modifies. Does not return anything
 function vmatrix_methods:invertTR()
 	unwrap(self):InvertTR()
 end
 
 --- Translate the matrix
--- @param vec Vector to translate by
+-- @param vector vec Vector to translate by
 function vmatrix_methods:translate(vec)
 	unwrap(self):Translate(vunwrap(vec))
 end
 
 --- Converts the matrix to a 4x4 table
--- @return The 4x4 table
+-- @return table The 4x4 table
 function vmatrix_methods:toTable()
 	return unwrap(self):ToTable()
 end
 
 --- Sets the rotation or the matrix to the rotation by an axis and angle
--- @param axis The normalized axis of rotation
--- @param angle The angle of rotation in radians
+-- Self-Modifies. Does not return anything
+-- @param vector axis The normalized axis of rotation
+-- @param number angle The angle of rotation in radians
 function vmatrix_methods:setAxisAngle(axis, ang)
 	local x, y, z = axis[1], axis[2], axis[3]
 	local c = math.cos(ang)
 	local s = math.sin(ang)
 	local cinv = 1 - c
-	
+
 	local xycinv = x*y*cinv
 	local xzcinv = x*z*cinv
 	local yzcinv = y*z*cinv
-	
+
 	local xs = x*s
 	local ys = y*s
 	local zs = z*s
-	
+
 	unwrap(self):SetUnpacked(
 		c + x^2*cinv, xycinv - zs, xzcinv + ys, 0,
 		xycinv + zs, c + y^2*cinv, yzcinv - xs, 0,
@@ -244,8 +276,8 @@ function vmatrix_methods:setAxisAngle(axis, ang)
 end
 
 --- Gets the rotation axis and angle of rotation of the rotation matrix
--- @return The axis of rotation
--- @return The angle of rotation
+-- @return vector The axis of rotation
+-- @return number The angle of rotation
 function vmatrix_methods:getAxisAngle()
 	local epsilon = 0.00001
 
@@ -299,19 +331,19 @@ function vmatrix_methods:getAxisAngle()
 end
 
 --- Adds two matrices (why would you do this?)
--- @return Added matrix
+-- @return vmatrix Added matrix
 function vmatrix_meta.__add(lhs, rhs)
 	return wrap(unwrap(lhs) + unwrap(rhs))
 end
 
 --- Subtracts two matrices (why would you do this?)
--- @return Subtracted matrix
+-- @return vmatrix Subtracted matrix
 function vmatrix_meta.__sub(lhs, rhs)
 	return wrap(unwrap(lhs) - unwrap(rhs))
 end
 
 --- Multiplies two matrices
--- @return Result matrix
+-- @return vmatrix Result matrix
 function vmatrix_meta.__mul(lhs, rhs)
 	local rhsmeta = dgetmeta(rhs)
 	if rhsmeta == vmatrix_meta then

--- a/lua/starfall/libs_sh/vmatrix.lua
+++ b/lua/starfall/libs_sh/vmatrix.lua
@@ -25,7 +25,7 @@ end
 --- Returns a new VMatrix
 -- @name builtins_library.Matrix
 -- @class function
--- @param table Optional data to initialize the Matrix with.
+-- @param table? Optional data to initialize the Matrix with.
 -- @return VMatrix New VMatrix
 function instance.env.Matrix(t)
 	return wrap(Matrix(t))
@@ -173,22 +173,7 @@ function vmatrix_methods:clone()
 end
 
 --- Returns all 16 fields of the matrix in row-major order
--- @return number [1, 1]
--- @return number [1, 2]
--- @return number [1, 3]
--- @return number [1, 4]
--- @return number [2, 1]
--- @return number [2, 2]
--- @return number [2, 3]
--- @return number [2, 4]
--- @return number [3, 1]
--- @return number [3, 2]
--- @return number [3, 3]
--- @return number [3, 4]
--- @return number [4, 1]
--- @return number [4, 2]
--- @return number [4, 3]
--- @return number [4, 4]
+-- @return ...number The 16 fields
 function vmatrix_methods:unpack()
 	return unwrap(self):Unpack()
 end
@@ -331,18 +316,24 @@ function vmatrix_methods:getAxisAngle()
 end
 
 --- Adds two matrices (why would you do this?)
+-- @param VMatrix lhs Initial Matrix
+-- @param VMatrix rhs Matrix to add to the first
 -- @return VMatrix Added matrix
 function vmatrix_meta.__add(lhs, rhs)
 	return wrap(unwrap(lhs) + unwrap(rhs))
 end
 
 --- Subtracts two matrices (why would you do this?)
+-- @param VMatrix lhs Initial Matrix
+-- @param VMatrix rhs Matrix to subtract from the first
 -- @return VMatrix Subtracted matrix
 function vmatrix_meta.__sub(lhs, rhs)
 	return wrap(unwrap(lhs) - unwrap(rhs))
 end
 
---- Multiplies two matrices
+--- Multiplies two matrices (Left must be a VMatrix)
+-- @param VMatrix lhs Matrix multiplicand
+-- @param VMatrix|Vector rhs Matrix or Vector multiplier
 -- @return VMatrix Result matrix
 function vmatrix_meta.__mul(lhs, rhs)
 	local rhsmeta = dgetmeta(rhs)

--- a/lua/starfall/libs_sh/vmatrix.lua
+++ b/lua/starfall/libs_sh/vmatrix.lua
@@ -180,7 +180,7 @@ end
 
 --- Allows you to set all 16 fields in row-major order
 -- Self-Modifies. Does not return anything
--- @param ...number The 16 fields
+-- @param ...number fields The 16 fields
 function vmatrix_methods:setUnpacked(...)
 	unwrap(self):SetUnpacked(...)
 end

--- a/lua/starfall/libs_sh/vmatrix.lua
+++ b/lua/starfall/libs_sh/vmatrix.lua
@@ -26,7 +26,7 @@ end
 -- @name builtins_library.Matrix
 -- @class function
 -- @param table Optional data to initialize the Matrix with.
--- @return vmatrix New VMatrix
+-- @return VMatrix New VMatrix
 function instance.env.Matrix(t)
 	return wrap(Matrix(t))
 end
@@ -38,19 +38,19 @@ function vmatrix_meta:__tostring()
 end
 
 --- Returns angles
--- @return angle Angles
+-- @return Angle Angles
 function vmatrix_methods:getAngles()
 	return awrap(unwrap(self):GetAngles())
 end
 
 --- Returns scale
--- @return vector Scale
+-- @return Vector Scale
 function vmatrix_methods:getScale()
 	return vwrap(unwrap(self):GetScale())
 end
 
 --- Returns translation
--- @return vector Translation
+-- @return Vector Translation
 function vmatrix_methods:getTranslation()
 	return vwrap(unwrap(self):GetTranslation())
 end
@@ -65,51 +65,51 @@ end
 
 --- Rotate the matrix
 -- Self-Modifies. Does not return anything
--- @param angle ang Angle to rotate by
+-- @param Angle ang Angle to rotate by
 function vmatrix_methods:rotate(ang)
 	unwrap(self):Rotate(aunwrap(ang))
 end
 
 --- Returns an inverted matrix. Inverting the matrix will fail if its determinant is 0 or close to 0
--- @return vmatrix Inverted matrix
+-- @return VMatrix Inverted matrix
 function vmatrix_methods:getInverse()
 	return wrap(unwrap(self):GetInverse())
 end
 
 --- Returns an inverted matrix. Efficiently for translations and rotations
--- @return vmatrix Inverted matrix
+-- @return VMatrix Inverted matrix
 function vmatrix_methods:getInverseTR()
 	return wrap(unwrap(self):GetInverseTR())
 end
 
 --- Returns forward vector of matrix. First matrix column
--- @return vector Translation
+-- @return Vector Translation
 function vmatrix_methods:getForward()
 	return vwrap(unwrap(self):GetForward())
 end
 
 --- Returns right vector of matrix. Negated second matrix column
--- @return vector Translation
+-- @return Vector Translation
 function vmatrix_methods:getRight()
 	return vwrap(unwrap(self):GetRight())
 end
 
 --- Returns up vector of matrix. Third matrix column
--- @return vector Translation
+-- @return Vector Translation
 function vmatrix_methods:getUp()
 	return vwrap(unwrap(self):GetUp())
 end
 
 --- Sets the scale
 -- Self-Modifies. Does not return anything
--- @param vector vec New scale
+-- @param Vector vec New scale
 function vmatrix_methods:setScale(vec)
 	unwrap(self):SetScale(vunwrap(vec))
 end
 
 --- Scale the matrix
 -- Self-Modifies. Does not return anything
--- @param vector vec Vector to scale by
+-- @param Vector vec Vector to scale by
 function vmatrix_methods:scale(vec)
 	unwrap(self):Scale(vunwrap(vec))
 end
@@ -124,35 +124,35 @@ end
 
 --- Sets the angles
 -- Self-Modifies. Does not return anything
--- @param angle ang New angles
+-- @param Angle ang New angles
 function vmatrix_methods:setAngles(ang)
 	unwrap(self):SetAngles(aunwrap(ang))
 end
 
 --- Sets the translation
 -- Self-Modifies. Does not return anything
--- @param vector vec New translation
+-- @param Vector vec New translation
 function vmatrix_methods:setTranslation(vec)
 	unwrap(self):SetTranslation(vunwrap(vec))
 end
 
 --- Sets the forward direction of the matrix. First column
 -- Self-Modifies. Does not return anything
--- @param vector forward The forward vector
+-- @param Vector forward The forward vector
 function vmatrix_methods:setForward(forward)
 	unwrap(self):SetForward(vunwrap(forward))
 end
 
 --- Sets the right direction of the matrix. Negated second column
 -- Self-Modifies. Does not return anything
--- @param vector right The right vector
+-- @param Vector right The right vector
 function vmatrix_methods:setRight(right)
 	unwrap(self):SetRight(vunwrap(right))
 end
 
 --- Sets the up direction of the matrix. Third column
 -- Self-Modifies. Does not return anything
--- @param vector up The up vector
+-- @param Vector up The up vector
 function vmatrix_methods:setUp(up)
 	unwrap(self):SetUp(vunwrap(up))
 end
@@ -167,7 +167,7 @@ function vmatrix_methods:setField(row, column, value)
 end
 
 --- Copies The matrix and returns a new matrix
--- @return vmatrix The copy of the matrix
+-- @return VMatrix The copy of the matrix
 function vmatrix_methods:clone()
 	return wrap(Matrix(unwrap(self)))
 end
@@ -202,7 +202,7 @@ end
 
 --- Copies the values from the second matrix to the first matrix.
 -- Self-Modifies. Does not return anything
--- @param vmatrix src Second matrix
+-- @param VMatrix src Second matrix
 function vmatrix_methods:set(src)
 	unwrap(self):Set(unwrap(src))
 end
@@ -239,7 +239,7 @@ function vmatrix_methods:invertTR()
 end
 
 --- Translate the matrix
--- @param vector vec Vector to translate by
+-- @param Vector vec Vector to translate by
 function vmatrix_methods:translate(vec)
 	unwrap(self):Translate(vunwrap(vec))
 end
@@ -252,7 +252,7 @@ end
 
 --- Sets the rotation or the matrix to the rotation by an axis and angle
 -- Self-Modifies. Does not return anything
--- @param vector axis The normalized axis of rotation
+-- @param Vector axis The normalized axis of rotation
 -- @param number angle The angle of rotation in radians
 function vmatrix_methods:setAxisAngle(axis, ang)
 	local x, y, z = axis[1], axis[2], axis[3]
@@ -276,7 +276,7 @@ function vmatrix_methods:setAxisAngle(axis, ang)
 end
 
 --- Gets the rotation axis and angle of rotation of the rotation matrix
--- @return vector The axis of rotation
+-- @return Vector The axis of rotation
 -- @return number The angle of rotation
 function vmatrix_methods:getAxisAngle()
 	local epsilon = 0.00001
@@ -331,19 +331,19 @@ function vmatrix_methods:getAxisAngle()
 end
 
 --- Adds two matrices (why would you do this?)
--- @return vmatrix Added matrix
+-- @return VMatrix Added matrix
 function vmatrix_meta.__add(lhs, rhs)
 	return wrap(unwrap(lhs) + unwrap(rhs))
 end
 
 --- Subtracts two matrices (why would you do this?)
--- @return vmatrix Subtracted matrix
+-- @return VMatrix Subtracted matrix
 function vmatrix_meta.__sub(lhs, rhs)
 	return wrap(unwrap(lhs) - unwrap(rhs))
 end
 
 --- Multiplies two matrices
--- @return vmatrix Result matrix
+-- @return VMatrix Result matrix
 function vmatrix_meta.__mul(lhs, rhs)
 	local rhsmeta = dgetmeta(rhs)
 	if rhsmeta == vmatrix_meta then

--- a/lua/starfall/libs_sh/von.lua
+++ b/lua/starfall/libs_sh/von.lua
@@ -810,16 +810,16 @@ return function(instance)
 local von_library = instance.Libraries.von
 
 --- Deserialize a string
--- @param str String to deserialize
--- @return Table
+-- @param string str String to deserialize
+-- @return table Table
 function von_library.deserialize(str)
 	g_instance = instance
 	return deserialize(str)
 end
 
 --- Serialize a table
--- @param tbl Table to serialize
--- @return String
+-- @param table tbl Table to serialize
+-- @return string String encoded from the table
 function von_library.serialize(tbl)
 	g_instance = instance
 	return serialize(tbl)

--- a/lua/starfall/libs_sh/vr.lua
+++ b/lua/starfall/libs_sh/vr.lua
@@ -2,7 +2,7 @@
 local checkluatype = SF.CheckLuaType
 local haspermission = SF.Permissions.hasAccess
 
---- VRMod Library 
+--- VRMod Library
 -- Addon and module: https://steamcommunity.com/sharedfiles/filedetails/?id=1678408548
 -- Follow install instructions on the addon's page.
 -- @name vr
@@ -65,40 +65,40 @@ instance:AddHook("initialize", function()
 	getply = instance.Types.Player.GetPlayer
 end)
 
---- Checks wether the player is in VR
--- @param target player to check
--- @return boolean true if player is in VR
+--- Checks whether the player is in VR
+-- @param player target Player to check
+-- @return boolean True if player is in VR
 function vr_library.isPlayerInVR(ply)
 	return vrmod.IsPlayerInVR(getply(ply))
 end
 
 --- Checks wether the player is using empty hands
--- @param target player to check
--- @return boolean true if player is using empty hands
+-- @param player target Player to check
+-- @return boolean True if player is using empty hands
 function vr_library.usingEmptyHands(ply)
 	return vrmod.UsingEmptyHands(getply(ply))
 end
 
 --HMD
 
---- returns the HMD position
--- @param target player to get the HMD position from
--- @return vector position
+--- Returns the Head Mounted Device position
+-- @param player target Player to get the HMD position from
+-- @return vector HMD Position
 function vr_library.getHMDPos(ply)
 	return vwrap(vrmod.GetHMDPos(getply(ply)))
 end
 
---- returns the HMD angles
--- @param target player to get the HMD angles from
--- @return angle angles
+--- Returns the Head Mounted Device angles
+-- @param player target Player to get the HMD angles from
+-- @return angle HMD Angles
 function vr_library.getHMDAng(ply)
 	return awrap(vrmod.GetHMDAng(getply(ply)))
 end
 
---- returns the HMD pose
--- @param target player to get the HMD pose from
--- @return vector position 
--- @return angle angles
+--- Returns the HMD pose
+-- @param player target Player to get the HMD pose from
+-- @return vector HMD Position
+-- @return angle HMD Angles
 function vr_library.getHMDPose(ply)
 	local pos, ang = vrmod.GetHMDPose(getply(ply))
 	return vwrap(pos), awrap(ang)
@@ -106,24 +106,24 @@ end
 
 --Left Hand
 
---- returns the left hand position
--- @param target player to get the left hand position from
--- @return vector position
+--- Returns the left hand position
+-- @param player target Player to get the left hand position from
+-- @return vector Position
 function vr_library.getLeftHandPos(ply)
 	return vwrap(vrmod.GetLeftHandPos(getply(ply)))
 end
 
---- returns the left hand angles
--- @param target player to get the left hand angles from
--- @return angle angles
+--- Returns the left hand angles
+-- @param player target Player to get the left hand angles from
+-- @return angle Angles
 function vr_library.getLeftHandAng(ply)
 	return awrap(vrmod.GetLeftHandAng(getply(ply)))
 end
 
---- returns the left hand pose
--- @param target player to get the left hand pose from
--- @return vector position 
--- @return angle angles
+--- Returns the left hand pose
+-- @param player target Player to get the left hand pose from
+-- @return vector Position
+-- @return angle Angles
 function vr_library.getLeftHandPose(ply)
 	local pos, ang = vrmod.GetLeftHandPose(getply(ply))
 	return vwrap(pos), awrap(ang)
@@ -131,24 +131,24 @@ end
 
 --Right Hand
 
---- returns the right hand position
--- @param target player to get the right hand position from
--- @return vector position
+--- Returns the right hand position
+-- @param player target Player to get the right hand position from
+-- @return vector Position
 function vr_library.getRightHandPos(ply)
 	return vwrap(vrmod.GetRightHandPos(getply(ply)))
 end
 
---- returns the left hand angles
--- @param target player to get the right hand angles from
--- @return angle angles
+--- Returns the left hand angles
+-- @param player target Player to get the right hand angles from
+-- @return angle Angles
 function vr_library.getRightHandAng(ply)
 	return awrap(vrmod.GetRightHandAng(getply(ply)))
 end
 
---- returns the left hand pose
--- @param target player to get the right hand pose from
--- @return vector position 
--- @return angle angles
+--- Returns the left hand pose
+-- @param player target Player to get the right hand pose from
+-- @return vector Position
+-- @return angle Angles
 function vr_library.getRightHandPose(ply)
 	local pos, ang = vrmod.GetRightHandPose(getply(ply))
 	return vwrap(pos), awrap(ang)
@@ -156,12 +156,12 @@ end
 
 if CLIENT then
 
-	--- returns the a controller's input state, may return boolean, number or vector.
-	-- @param actionname to check control of, check VR enums
-	-- @return boolean, vector or number of input
+	--- Returns the a controller's input state, may return boolean, number or vector.
+	-- @param string actionname ActionName to check control of, see the VR enums
+	-- @return any Boolean, Vector or Number of input
 	-- @client
 	function vr_library.getInput(actionname)
-		checkluatype(actionname, TYPE_STRING) 
+		checkluatype(actionname, TYPE_STRING)
 		local var = vrmod.GetInput(actionname)
 		local typeid = TypeID(var)
 		if typeid == TYPE_BOOL or typeid == TYPE_NUMBER then
@@ -175,23 +175,23 @@ if CLIENT then
 
 	-- HMD
 
-	--- returns the HMD velocity
-	-- @return vector velocity
+	--- Returns the HMD velocity
+	-- @return vector HMD Velocity
 	-- @client
 	function vr_library.getHMDVelocity()
 		return vwrap(vrmod.GetHMDVelocity())
 	end
 
-	--- returns the HMD angular velocity
-	-- @return vector angular velocity
+	--- Returns the HMD angular velocity
+	-- @return vector Angular velocity
 	-- @client
 	function vr_library.getHMDAngularVelocity()
 		return vwrap(vrmod.GetHMDVelocity())
 	end
 
-	--- returns the HMD velocities, position and angular
-	-- @return vector velocity
-	-- @return vector angular velocity
+	--- Returns the HMD velocities, position and angular
+	-- @return vector Velocity
+	-- @return vector Angular velocity
 	-- @client
 	function vr_library.getHMDVelocities()
 		local v1, v2 = vrmod.GetHMDVelocities()
@@ -200,23 +200,23 @@ if CLIENT then
 
 	--Left hand
 
-	--- returns the left hand velocity
-	-- @return vector velocity
+	--- Returns the left hand velocity
+	-- @return vector Velocity
 	-- @client
 	function vr_library.getLeftHandVelocity()
 		return vwrap(vrmod.GetLeftHandVelocity())
 	end
 
-	--- returns the left hand angular velocity
-	-- @return vector angular velocity
+	--- Returns the left hand angular velocity
+	-- @return vector Angular velocity
 	-- @client
 	function vr_library.getLeftHandAngularVelocity()
 		return vwrap(vrmod.GetLeftHandAngularVelocity())
 	end
 
-	--- returns the left hand velocities, position and angular
-	-- @return vector velocity
-	-- @return vector angular velocity
+	--- Returns the left hand velocities, position and angular
+	-- @return vector Velocity
+	-- @return vector Angular velocity
 	-- @client
 	function vr_library.getLeftHandVelocities()
 		local v1, v2 = vrmod.GetLeftHandVelocities()
@@ -225,23 +225,23 @@ if CLIENT then
 
 	--Right hand
 
-	--- returns the right hand velocity
-	-- @return vector velocity
+	--- Returns the right hand velocity
+	-- @return vector Velocity
 	-- @client
 	function vr_library.getRightHandVelocity()
 		return vwrap(vrmod.GetRightHandVelocity())
 	end
 
-	--- returns the right hand angular velocity
-	-- @return vector angular velocity
+	--- Returns the right hand angular velocity
+	-- @return vector Angular velocity
 	-- @client
 	function vr_library.getRightHandAngularVelocity()
 		return vwrap(vrmod.GetRightHandAngularVelocity())
 	end
 
-	--- returns the right hand velocities, position and angular
-	-- @return vector velocity
-	-- @return vector angular velocity
+	--- Returns the right hand velocities, position and angular
+	-- @return vector Velocity
+	-- @return vector Angular velocity
 	-- @client
 	function vr_library.getRightHandVelocities()
 		local v1, v2 = vrmod.GetRightHandVelocities()
@@ -257,23 +257,23 @@ if CLIENT then
 
 	--Playspace
 
-	--- returns the playspace position
-	-- @return vector position
+	--- Returns the playspace position
+	-- @return vector Position
 	-- @client
 	function vr_library.getOriginPos()
 		return vwrap(vrmod.GetOriginPos())
 	end
 
-	--- returns the playspace angles
-	-- @return angle angles
+	--- Returns the playspace angles
+	-- @return angle Angles
 	-- @client
 	function vr_library.getOriginAng()
 		return awrap(vrmod.GetOriginAng())
 	end
 
-	--- returns the playspace position and angles
-	-- @return vector position
-	-- @return angle angles
+	--- Returns the playspace position and angles
+	-- @return vector Position
+	-- @return angle Angles
 	-- @client
 	function vr_library.getOrigin()
 		local pos, ang = vrmod.GetOrigin()
@@ -282,22 +282,22 @@ if CLIENT then
 
 	--eyes GetEyePos
 
-	--- returns position of the eye that is currently being used for rendering.
-	-- @return vector position
+	--- Returns position of the eye that is currently being used for rendering.
+	-- @return vector Position
 	-- @client
 	function vr_library.getEyePos()
 		return vwrap(vrmod.GetEyePos())
 	end
 
-	--- returns position of the left eye
-	-- @return vector position
+	--- Returns position of the left eye
+	-- @return vector Position
 	-- @client
 	function vr_library.getLeftEyePos()
 		return vwrap(vrmod.GetLeftEyePos())
 	end
 
-	--- returns position of the right eye
-	-- @return vector position
+	--- Returns position of the right eye
+	-- @return vector Position
 	-- @client
 	function vr_library.getRightEyePos()
 		return vwrap(vrmod.GetRightEyePos())

--- a/lua/starfall/libs_sh/vr.lua
+++ b/lua/starfall/libs_sh/vr.lua
@@ -13,20 +13,20 @@ SF.RegisterLibrary("vr")
 --- Called when a player enters VR
 -- @name VRStart
 -- @class hook
--- @param ply Player entering VR
+-- @param Player ply Player entering VR
 SF.hookAdd("VRMod_Start", "vrstart")
 
 --- Called when a player exits VR
 -- @name VRExit
 -- @class hook
--- @param ply Player exiting VR
+-- @param Player ply Player exiting VR
 SF.hookAdd("VRMod_Exit", "vrexit")
 
 if CLIENT then
 	--- This gets called every time a boolean controller input action changes state
 	-- @name VRInput
 	-- @class hook
-	-- @param actionname Name of the input
+	-- @param string actionname Name of the input
 	-- @param boolean State of the input
 	-- @client
 	SF.hookAdd("VRMod_Input", "vrinput")

--- a/lua/starfall/libs_sh/vr.lua
+++ b/lua/starfall/libs_sh/vr.lua
@@ -66,14 +66,14 @@ instance:AddHook("initialize", function()
 end)
 
 --- Checks whether the player is in VR
--- @param player target Player to check
+-- @param Player target Player to check
 -- @return boolean True if player is in VR
 function vr_library.isPlayerInVR(ply)
 	return vrmod.IsPlayerInVR(getply(ply))
 end
 
 --- Checks wether the player is using empty hands
--- @param player target Player to check
+-- @param Player target Player to check
 -- @return boolean True if player is using empty hands
 function vr_library.usingEmptyHands(ply)
 	return vrmod.UsingEmptyHands(getply(ply))
@@ -82,23 +82,23 @@ end
 --HMD
 
 --- Returns the Head Mounted Device position
--- @param player target Player to get the HMD position from
--- @return vector HMD Position
+-- @param Player target Player to get the HMD position from
+-- @return Vector HMD Position
 function vr_library.getHMDPos(ply)
 	return vwrap(vrmod.GetHMDPos(getply(ply)))
 end
 
 --- Returns the Head Mounted Device angles
--- @param player target Player to get the HMD angles from
--- @return angle HMD Angles
+-- @param Player target Player to get the HMD angles from
+-- @return Angle HMD Angles
 function vr_library.getHMDAng(ply)
 	return awrap(vrmod.GetHMDAng(getply(ply)))
 end
 
 --- Returns the HMD pose
--- @param player target Player to get the HMD pose from
--- @return vector HMD Position
--- @return angle HMD Angles
+-- @param Player target Player to get the HMD pose from
+-- @return Vector HMD Position
+-- @return Angle HMD Angles
 function vr_library.getHMDPose(ply)
 	local pos, ang = vrmod.GetHMDPose(getply(ply))
 	return vwrap(pos), awrap(ang)
@@ -107,23 +107,23 @@ end
 --Left Hand
 
 --- Returns the left hand position
--- @param player target Player to get the left hand position from
--- @return vector Position
+-- @param Player target Player to get the left hand position from
+-- @return Vector Position
 function vr_library.getLeftHandPos(ply)
 	return vwrap(vrmod.GetLeftHandPos(getply(ply)))
 end
 
 --- Returns the left hand angles
--- @param player target Player to get the left hand angles from
--- @return angle Angles
+-- @param Player target Player to get the left hand angles from
+-- @return Angle Angles
 function vr_library.getLeftHandAng(ply)
 	return awrap(vrmod.GetLeftHandAng(getply(ply)))
 end
 
 --- Returns the left hand pose
--- @param player target Player to get the left hand pose from
--- @return vector Position
--- @return angle Angles
+-- @param Player target Player to get the left hand pose from
+-- @return Vector Position
+-- @return Angle Angles
 function vr_library.getLeftHandPose(ply)
 	local pos, ang = vrmod.GetLeftHandPose(getply(ply))
 	return vwrap(pos), awrap(ang)
@@ -132,23 +132,23 @@ end
 --Right Hand
 
 --- Returns the right hand position
--- @param player target Player to get the right hand position from
--- @return vector Position
+-- @param Player target Player to get the right hand position from
+-- @return Vector Position
 function vr_library.getRightHandPos(ply)
 	return vwrap(vrmod.GetRightHandPos(getply(ply)))
 end
 
 --- Returns the left hand angles
--- @param player target Player to get the right hand angles from
--- @return angle Angles
+-- @param Player target Player to get the right hand angles from
+-- @return Angle Angles
 function vr_library.getRightHandAng(ply)
 	return awrap(vrmod.GetRightHandAng(getply(ply)))
 end
 
 --- Returns the left hand pose
--- @param player target Player to get the right hand pose from
--- @return vector Position
--- @return angle Angles
+-- @param Player target Player to get the right hand pose from
+-- @return Vector Position
+-- @return Angle Angles
 function vr_library.getRightHandPose(ply)
 	local pos, ang = vrmod.GetRightHandPose(getply(ply))
 	return vwrap(pos), awrap(ang)
@@ -176,22 +176,22 @@ if CLIENT then
 	-- HMD
 
 	--- Returns the HMD velocity
-	-- @return vector HMD Velocity
+	-- @return Vector HMD Velocity
 	-- @client
 	function vr_library.getHMDVelocity()
 		return vwrap(vrmod.GetHMDVelocity())
 	end
 
 	--- Returns the HMD angular velocity
-	-- @return vector Angular velocity
+	-- @return Vector Angular velocity
 	-- @client
 	function vr_library.getHMDAngularVelocity()
 		return vwrap(vrmod.GetHMDVelocity())
 	end
 
 	--- Returns the HMD velocities, position and angular
-	-- @return vector Velocity
-	-- @return vector Angular velocity
+	-- @return Vector Velocity
+	-- @return Vector Angular velocity
 	-- @client
 	function vr_library.getHMDVelocities()
 		local v1, v2 = vrmod.GetHMDVelocities()
@@ -201,22 +201,22 @@ if CLIENT then
 	--Left hand
 
 	--- Returns the left hand velocity
-	-- @return vector Velocity
+	-- @return Vector Velocity
 	-- @client
 	function vr_library.getLeftHandVelocity()
 		return vwrap(vrmod.GetLeftHandVelocity())
 	end
 
 	--- Returns the left hand angular velocity
-	-- @return vector Angular velocity
+	-- @return Vector Angular velocity
 	-- @client
 	function vr_library.getLeftHandAngularVelocity()
 		return vwrap(vrmod.GetLeftHandAngularVelocity())
 	end
 
 	--- Returns the left hand velocities, position and angular
-	-- @return vector Velocity
-	-- @return vector Angular velocity
+	-- @return Vector Velocity
+	-- @return Vector Angular velocity
 	-- @client
 	function vr_library.getLeftHandVelocities()
 		local v1, v2 = vrmod.GetLeftHandVelocities()
@@ -226,22 +226,22 @@ if CLIENT then
 	--Right hand
 
 	--- Returns the right hand velocity
-	-- @return vector Velocity
+	-- @return Vector Velocity
 	-- @client
 	function vr_library.getRightHandVelocity()
 		return vwrap(vrmod.GetRightHandVelocity())
 	end
 
 	--- Returns the right hand angular velocity
-	-- @return vector Angular velocity
+	-- @return Vector Angular velocity
 	-- @client
 	function vr_library.getRightHandAngularVelocity()
 		return vwrap(vrmod.GetRightHandAngularVelocity())
 	end
 
 	--- Returns the right hand velocities, position and angular
-	-- @return vector Velocity
-	-- @return vector Angular velocity
+	-- @return Vector Velocity
+	-- @return Vector Angular velocity
 	-- @client
 	function vr_library.getRightHandVelocities()
 		local v1, v2 = vrmod.GetRightHandVelocities()
@@ -258,22 +258,22 @@ if CLIENT then
 	--Playspace
 
 	--- Returns the playspace position
-	-- @return vector Position
+	-- @return Vector Position
 	-- @client
 	function vr_library.getOriginPos()
 		return vwrap(vrmod.GetOriginPos())
 	end
 
 	--- Returns the playspace angles
-	-- @return angle Angles
+	-- @return Angle Angles
 	-- @client
 	function vr_library.getOriginAng()
 		return awrap(vrmod.GetOriginAng())
 	end
 
 	--- Returns the playspace position and angles
-	-- @return vector Position
-	-- @return angle Angles
+	-- @return Vector Position
+	-- @return Angle Angles
 	-- @client
 	function vr_library.getOrigin()
 		local pos, ang = vrmod.GetOrigin()
@@ -283,21 +283,21 @@ if CLIENT then
 	--eyes GetEyePos
 
 	--- Returns position of the eye that is currently being used for rendering.
-	-- @return vector Position
+	-- @return Vector Position
 	-- @client
 	function vr_library.getEyePos()
 		return vwrap(vrmod.GetEyePos())
 	end
 
 	--- Returns position of the left eye
-	-- @return vector Position
+	-- @return Vector Position
 	-- @client
 	function vr_library.getLeftEyePos()
 		return vwrap(vrmod.GetLeftEyePos())
 	end
 
 	--- Returns position of the right eye
-	-- @return vector Position
+	-- @return Vector Position
 	-- @client
 	function vr_library.getRightEyePos()
 		return vwrap(vrmod.GetRightEyePos())

--- a/lua/starfall/libs_sh/vr.lua
+++ b/lua/starfall/libs_sh/vr.lua
@@ -158,7 +158,7 @@ if CLIENT then
 
 	--- Returns the a controller's input state, may return boolean, number or vector.
 	-- @param string actionname ActionName to check control of, see the VR enums
-	-- @return any Boolean, Vector or Number of input
+	-- @return boolean|Vector|number Boolean, Vector or Number of input
 	-- @client
 	function vr_library.getInput(actionname)
 		checkluatype(actionname, TYPE_STRING)

--- a/lua/starfall/libs_sh/weapons.lua
+++ b/lua/starfall/libs_sh/weapons.lua
@@ -15,6 +15,8 @@ local checkpermission = instance.player ~= SF.Superuser and SF.Permissions.check
 local weapon_methods, weapon_meta, wrap, unwrap = instance.Types.Weapon.Methods, instance.Types.Weapon, instance.Types.Weapon.Wrap, instance.Types.Weapon.Unwrap
 
 
+--- Tostring metamethod
+-- @return string String representation of the weapon
 function weapon_meta:__tostring()
 	local ent = unwrap(self)
 	if not ent then return "(null entity)"
@@ -25,28 +27,28 @@ end
 -- ------------------------------------------------------------------------- --
 --- Returns Ammo in primary clip
 -- @shared
--- @return amount of ammo
+-- @return number Amount of ammo
 function weapon_methods:clip1()
 	return unwrap(self):Clip1()
 end
 
 --- Returns Maximum ammo in primary clip
 -- @shared
--- @return amount of ammo
+-- @return number Amount of ammo
 function weapon_methods:maxClip1()
 	return unwrap(self):GetMaxClip1()
 end
 
 --- Returns Ammo in secondary clip
 -- @shared
--- @return amount of ammo
+-- @return number Amount of ammo
 function weapon_methods:clip2()
 	return unwrap(self):Clip2()
 end
 
 --- Returns Maximum ammo in secondary clip
 -- @shared
--- @return amount of ammo
+-- @return number Amount of ammo
 function weapon_methods:maxClip2()
 	return unwrap(self):GetMaxClip2()
 end
@@ -67,49 +69,49 @@ end
 
 --- Gets the next time the weapon can primary fire.
 -- @shared
--- @return The time, relative to CurTime
+-- @return number The time, relative to CurTime
 function weapon_methods:getNextPrimaryFire()
 	return unwrap(self):GetNextPrimaryFire()
 end
 
 --- Gets the next time the weapon can secondary fire.
 -- @shared
--- @return The time, relative to CurTime
+-- @return number The time, relative to CurTime
 function weapon_methods:getNextSecondaryFire()
 	return unwrap(self):GetNextSecondaryFire()
 end
 
 --- Gets the primary ammo type of the given weapon.
 -- @shared
--- @return Ammo number type
+-- @return number Ammo number type
 function weapon_methods:getPrimaryAmmoType()
 	return unwrap(self):GetPrimaryAmmoType()
 end
 
 --- Gets the secondary ammo type of the given weapon.
 -- @shared
--- @return Ammo number type
+-- @return number Ammo number type
 function weapon_methods:getSecondaryAmmoType()
 	return unwrap(self):GetSecondaryAmmoType()
 end
 
 --- Returns whether the weapon is visible
 -- @shared
--- @return Whether the weapon is visble or not
+-- @return boolean Whether the weapon is visble or not
 function weapon_methods:isWeaponVisible()
 	return unwrap(self):IsWeaponVisible()
 end
 
 --- Returns the time since a weapon was last fired at a float variable
 -- @shared
--- @return Time the weapon was last shot
+-- @return number Time the weapon was last shot
 function weapon_methods:lastShootTime()
 	return unwrap(self):LastShootTime()
 end
 
 --- Returns the tool mode of the toolgun
 -- @shared
--- @return The tool mode of the toolgun
+-- @return string The tool mode of the toolgun
 function weapon_methods:getToolMode()
 	local ent = unwrap(self)
 	return ent:GetClass()=="gmod_tool" and ent.Mode or ""
@@ -125,7 +127,7 @@ if CLIENT then
 
 	--- Returns if the weapon is carried by the local player.
 	-- @client
-	-- @return whether or not the weapon is carried by the local player
+	-- @return boolean Whether or not the weapon is carried by the local player
 	function weapon_methods:isCarriedByLocalPlayer()
 		return unwrap(self):IsCarriedByLocalPlayer()
 	end

--- a/lua/starfall/libs_sh/weapons.lua
+++ b/lua/starfall/libs_sh/weapons.lua
@@ -6,6 +6,7 @@ local checkluatype = SF.CheckLuaType
 -- @name Weapon
 -- @class type
 -- @libtbl weapon_methods
+-- @libtbl weapon_meta
 SF.RegisterType("Weapon", false, true, debug.getregistry().Weapon, "Entity")
 
 
@@ -15,8 +16,8 @@ local checkpermission = instance.player ~= SF.Superuser and SF.Permissions.check
 local weapon_methods, weapon_meta, wrap, unwrap = instance.Types.Weapon.Methods, instance.Types.Weapon, instance.Types.Weapon.Wrap, instance.Types.Weapon.Unwrap
 
 
---- Tostring metamethod
--- @return string String representation of the weapon
+--- Turns a weapon into a string.
+-- @return string String representing the weapon.
 function weapon_meta:__tostring()
 	local ent = unwrap(self)
 	if not ent then return "(null entity)"

--- a/lua/starfall/libs_sv/constraint.lua
+++ b/lua/starfall/libs_sv/constraint.lua
@@ -242,18 +242,18 @@ function constraint_library.ballsocketadv(e1, e2, bone1, bone2, v1, v2, force_li
 end
 
 --- Elastic constraint between two entities
--- @param index Index of the elastic constraint
--- @param e1 The first entity
--- @param e2 The second entity
--- @param bone1 Number bone of the first entity
--- @param bone2 Number bone of the second entity
--- @param v1 Position on the first entity, in its local space coordinates
--- @param v2 Position on the second entity, in its local space coordinates
--- @param const Constant of the constraint. Default = 1000
--- @param damp Damping of the constraint. Default = 100
--- @param rdamp Rotational damping of the constraint. Default = 0
--- @param width Width of the created constraint
--- @param strech True to mark as strech-only
+-- @param number index Index of the elastic constraint
+-- @param Entity e1 The first entity
+-- @param Entity e2 The second entity
+-- @param number? bone1 Number bone of the first entity. Default 0
+-- @param number? bone2 Number bone of the second entity. Default 0
+-- @param Vector v1 Position on the first entity, in its local space coordinates
+-- @param Vector v2 Position on the second entity, in its local space coordinates
+-- @param number? const Constant of the constraint. Default 1000
+-- @param number? damp Damping of the constraint. Default 100
+-- @param number? rdamp Rotational damping of the constraint. Default 0
+-- @param number? width Width of the created constraint. Default 0
+-- @param boolean? strech True to mark as strech-only. Default false
 -- @server
 function constraint_library.elastic(index, e1, e2, bone1, bone2, v1, v2, const, damp, rdamp, width, strech)
 	plyCount:checkuse(instance.player, 1)

--- a/lua/starfall/libs_sv/constraint.lua
+++ b/lua/starfall/libs_sv/constraint.lua
@@ -82,8 +82,8 @@ local function register(ent, instance)
 end
 
 --- Welds two entities
--- @param entity e1 The first entity
--- @param entity e2 The second entity
+-- @param Entity e1 The first entity
+-- @param Entity e2 The second entity
 -- @param number? bone1 Number bone of the first entity. Default 0
 -- @param number? bone2 Number bone of the second entity. Default 0
 -- @param number? force_lim Max force the weld can take before breaking. Default 0
@@ -114,17 +114,17 @@ function constraint_library.weld(e1, e2, bone1, bone2, force_lim, nocollide)
 end
 
 --- Axis two entities. v1 in e1's coordinates and v2 in e2's coodinates (or laxis in e1's coordinates again) define the axis
--- @param entity e1 The first entity
--- @param entity e2 The second entity
+-- @param Entity e1 The first entity
+-- @param Entity e2 The second entity
 -- @param number? bone1 Number bone of the first entity. Default 0
 -- @param number? bone2 Number bone of the second entity. Default 0
--- @param vector v1 Position to center the axis, local to e1's space coordinates
--- @param vector v2 The second position defining the axis, local to e2's space coordinates. The laxis may be specified instead which is local to e1's space coordinates
+-- @param Vector v1 Position to center the axis, local to e1's space coordinates
+-- @param Vector v2 The second position defining the axis, local to e2's space coordinates. The laxis may be specified instead which is local to e1's space coordinates
 -- @param number? force_lim Amount of force until it breaks, 0 = Unbreakable. Default 0
 -- @param number? torque_lim Amount of torque until it breaks, 0 = Unbreakable. Default 0
 -- @param number? friction Friction of the constraint. Default 0
 -- @param boolean? nocollide Bool whether or not to nocollide the two entities. Default false
--- @param vector? laxis Optional second position of the constraint, same as v2 but local to e1
+-- @param Vector? laxis Optional second position of the constraint, same as v2 but local to e1
 -- @server
 function constraint_library.axis(e1, e2, bone1, bone2, v1, v2, force_lim, torque_lim, friction, nocollide, laxis)
 	plyCount:checkuse(instance.player, 1)
@@ -158,11 +158,11 @@ function constraint_library.axis(e1, e2, bone1, bone2, v1, v2, force_lim, torque
 end
 
 --- Ballsocket two entities together. For more options, see constraint.ballsocketadv
--- @param entity e1 The first entity
--- @param entity e2 The second entity
+-- @param Entity e1 The first entity
+-- @param Entity e2 The second entity
 -- @param number? bone1 Number bone of the first entity. Default 0
 -- @param number? bone2 Number bone of the second entity. Default 0
--- @param vector pos Position of the joint, relative to the second entity
+-- @param Vector pos Position of the joint, relative to the second entity
 -- @param number? force_lim Amount of force until it breaks, 0 = Unbreakable. Default 0
 -- @param number? torque_lim Amount of torque until it breaks, 0 = Unbreakable. Default 0
 -- @param boolean? nocollide Bool whether or not to nocollide the two entities. Default false
@@ -195,17 +195,17 @@ function constraint_library.ballsocket(e1, e2, bone1, bone2, pos, force_lim, tor
 end
 
 --- Ballsocket two entities together with more options
--- @param entity e1 The first entity
--- @param entity e2 The second entity
+-- @param Entity e1 The first entity
+-- @param Entity e2 The second entity
 -- @param number? bone1 Number bone of the first entity. Default 0
 -- @param number? bone2 Number bone of the second entity. Default 0
--- @param vector v1 Position on the first entity, in its local space coordinates
--- @param vector v2 Position on the second entity, in its local space coordinates
+-- @param Vector v1 Position on the first entity, in its local space coordinates
+-- @param Vector v2 Position on the second entity, in its local space coordinates
 -- @param number? force_lim Amount of force until it breaks, 0 = Unbreakable. Default 0
 -- @param number? torque_lim Amount of torque until it breaks, 0 = Unbreakable. Default 0
--- @param vector? minv Vector defining minimum rotation angle based on world axes. Default Vec(0)
--- @param vector? maxv Vector defining maximum rotation angle based on world axes. Default Vec(0)
--- @param vector? frictionv Vector defining rotational friction, local to the constraint. Default Vec(0)
+-- @param Vector? minv Vector defining minimum rotation angle based on world axes. Default Vec(0)
+-- @param Vector? maxv Vector defining maximum rotation angle based on world axes. Default Vec(0)
+-- @param Vector? frictionv Vector defining rotational friction, local to the constraint. Default Vec(0)
 -- @param boolean? rotateonly If True, ballsocket will only affect the rotation allowing for free movement, otherwise it will limit both - rotation and movement. Default false
 -- @param boolean? nocollide Bool whether or not to nocollide the two entities. Default false
 -- @server
@@ -295,12 +295,12 @@ end
 
 --- Creates a rope between two entities
 -- @param number index Index of the rope constraint
--- @param entity e1 The first entity
--- @param entity e2 The second entity
+-- @param Entity e1 The first entity
+-- @param Entity e2 The second entity
 -- @param number? bone1 Number bone of the first entity. Default 0
 -- @param number? bone2 Number bone of the second entity. Default 0
--- @param vector v1 Position on the first entity, in its local space coordinates
--- @param vector v2 Position on the second entity, in its local space coordinates
+-- @param Vector v1 Position on the first entity, in its local space coordinates
+-- @param Vector v2 Position on the second entity, in its local space coordinates
 -- @param number? length Length of the created rope. Default 0
 -- @param number? addlength Amount to add to the base length of the rope. Default 0
 -- @param number? force_lim Amount of force until it breaks, 0 = Unbreakable. Default 0
@@ -348,12 +348,12 @@ function constraint_library.rope(index, e1, e2, bone1, bone2, v1, v2, length, ad
 end
 
 --- Sliders two entities
--- @param entity e1 The first entity
--- @param entity e2 The second entity
+-- @param Entity e1 The first entity
+-- @param Entity e2 The second entity
 -- @param number? bone1 Number bone of the first entity. Default 0
 -- @param number? bone2 Number bone of the second entity. Default 0
--- @param vector v1 Position on the first entity, in its local space coordinates
--- @param vector v2 Position on the second entity, in its local space coordinates
+-- @param Vector v1 Position on the first entity, in its local space coordinates
+-- @param Vector v2 Position on the second entity, in its local space coordinates
 -- @param number? width Width of the slider. Default 0
 -- @server
 function constraint_library.slider(e1, e2, bone1, bone2, v1, v2, width)
@@ -383,8 +383,8 @@ function constraint_library.slider(e1, e2, bone1, bone2, v1, v2, width)
 end
 
 --- Nocollides two entities
--- @param entity e1 The first entity
--- @param entity e2 The second entity
+-- @param Entity e1 The first entity
+-- @param Entity e2 The second entity
 -- @param number? bone1 Number bone of the first entity. Default 0
 -- @param number? bone2 Number bone of the second entity. Default 0
 -- @server
@@ -411,8 +411,8 @@ function constraint_library.nocollide(e1, e2, bone1, bone2)
 end
 
 --- Applies a keepupright constraint on an entity
--- @param entity e The entity
--- @param angle ang The upright angle
+-- @param Entity e The entity
+-- @param Angle ang The upright angle
 -- @param number bone Number bone of the entity. Default 0
 -- @param number lim The strength of the constraint. Default 5000
 -- @server
@@ -438,7 +438,7 @@ end
 
 --- Sets the length of a rope attached to the entity
 -- @param number index Index of the rope constraint
--- @param entity e Entity that has the constraint
+-- @param Entity e Entity that has the constraint
 -- @param number length New length of the constraint
 -- @server
 function constraint_library.setRopeLength(index, e, length)
@@ -460,7 +460,7 @@ end
 
 --- Sets the length of an elastic attached to the entity
 -- @param number index Index of the elastic constraint
--- @param entity e Entity that has the constraint
+-- @param Entity e Entity that has the constraint
 -- @param number length New length of the constraint
 -- @server
 function constraint_library.setElasticLength(index, e, length)
@@ -480,7 +480,7 @@ function constraint_library.setElasticLength(index, e, length)
 end
 
 --- Breaks all constraints on an entity
--- @param entity e Entity to remove the constraints from
+-- @param Entity e Entity to remove the constraints from
 -- @server
 function constraint_library.breakAll(e)
 	local ent1 = getent(e)
@@ -490,7 +490,7 @@ function constraint_library.breakAll(e)
 end
 
 --- Breaks all constraints of a certain type on an entity
--- @param entity e Entity to be affected
+-- @param Entity e Entity to be affected
 -- @param string typename Name of the constraint type, ie. Weld, Elastic, NoCollide, etc.
 -- @server
 function constraint_library.breakType(e, typename)
@@ -505,7 +505,7 @@ end
 
 
 --- Returns the table of constraints on an entity
--- @param entity ent The entity
+-- @param Entity ent The entity
 -- @return table Table of entity constraints
 function constraint_library.getTable(ent)
 	return instance.Sanitize(constraint.GetTable(getent(ent)))

--- a/lua/starfall/libs_sv/constraint.lua
+++ b/lua/starfall/libs_sv/constraint.lua
@@ -82,12 +82,12 @@ local function register(ent, instance)
 end
 
 --- Welds two entities
--- @param e1 The first entity
--- @param e2 The second entity
--- @param bone1 Number bone of the first entity
--- @param bone2 Number bone of the second entity
--- @param force_lim Max force the weld can take before breaking
--- @param nocollide Bool whether or not to nocollide the two entities
+-- @param entity e1 The first entity
+-- @param entity e2 The second entity
+-- @param number? bone1 Number bone of the first entity. Default 0
+-- @param number? bone2 Number bone of the second entity. Default 0
+-- @param number? force_lim Max force the weld can take before breaking. Default 0
+-- @param boolean? nocollide Bool whether or not to nocollide the two entities. Default false
 -- @server
 function constraint_library.weld(e1, e2, bone1, bone2, force_lim, nocollide)
 	plyCount:checkuse(instance.player, 1)
@@ -114,17 +114,17 @@ function constraint_library.weld(e1, e2, bone1, bone2, force_lim, nocollide)
 end
 
 --- Axis two entities. v1 in e1's coordinates and v2 in e2's coodinates (or laxis in e1's coordinates again) define the axis
--- @param e1 The first entity
--- @param e2 The second entity
--- @param bone1 Number bone of the first entity
--- @param bone2 Number bone of the second entity
--- @param v1 Position to center the axis, local to e1's space coordinates
--- @param v2 The second position defining the axis, local to e2's space coordinates. The laxis may be specified instead which is local to e1's space coordinates
--- @param force_lim Amount of force until it breaks, 0 = Unbreakable
--- @param torque_lim Amount of torque until it breaks, 0 = Unbreakable
--- @param friction Friction of the constraint
--- @param nocollide Bool whether or not to nocollide the two entities
--- @param laxis Optional second position of the constraint, same as v2 but local to e1
+-- @param entity e1 The first entity
+-- @param entity e2 The second entity
+-- @param number? bone1 Number bone of the first entity. Default 0
+-- @param number? bone2 Number bone of the second entity. Default 0
+-- @param vector v1 Position to center the axis, local to e1's space coordinates
+-- @param vector v2 The second position defining the axis, local to e2's space coordinates. The laxis may be specified instead which is local to e1's space coordinates
+-- @param number? force_lim Amount of force until it breaks, 0 = Unbreakable. Default 0
+-- @param number? torque_lim Amount of torque until it breaks, 0 = Unbreakable. Default 0
+-- @param number? friction Friction of the constraint. Default 0
+-- @param boolean? nocollide Bool whether or not to nocollide the two entities. Default false
+-- @param vector? laxis Optional second position of the constraint, same as v2 but local to e1
 -- @server
 function constraint_library.axis(e1, e2, bone1, bone2, v1, v2, force_lim, torque_lim, friction, nocollide, laxis)
 	plyCount:checkuse(instance.player, 1)
@@ -158,14 +158,14 @@ function constraint_library.axis(e1, e2, bone1, bone2, v1, v2, force_lim, torque
 end
 
 --- Ballsocket two entities together. For more options, see constraint.ballsocketadv
--- @param e1 The first entity
--- @param e2 The second entity
--- @param bone1 Number bone of the first entity
--- @param bone2 Number bone of the second entity
--- @param pos Position of the joint, relative to the second entity
--- @param force_lim Amount of force until it breaks, 0 = Unbreakable
--- @param torque_lim Amount of torque until it breaks, 0 = Unbreakable
--- @param nocollide Bool whether or not to nocollide the two entities
+-- @param entity e1 The first entity
+-- @param entity e2 The second entity
+-- @param number? bone1 Number bone of the first entity. Default 0
+-- @param number? bone2 Number bone of the second entity. Default 0
+-- @param vector pos Position of the joint, relative to the second entity
+-- @param number? force_lim Amount of force until it breaks, 0 = Unbreakable. Default 0
+-- @param number? torque_lim Amount of torque until it breaks, 0 = Unbreakable. Default 0
+-- @param boolean? nocollide Bool whether or not to nocollide the two entities. Default false
 -- @server
 function constraint_library.ballsocket(e1, e2, bone1, bone2, pos, force_lim, torque_lim, nocollide)
 	plyCount:checkuse(instance.player, 1)
@@ -195,19 +195,19 @@ function constraint_library.ballsocket(e1, e2, bone1, bone2, pos, force_lim, tor
 end
 
 --- Ballsocket two entities together with more options
--- @param e1 The first entity
--- @param e2 The second entity
--- @param bone1 Number bone of the first entity
--- @param bone2 Number bone of the second entity
--- @param v1 Position on the first entity, in its local space coordinates
--- @param v2 Position on the second entity, in its local space coordinates
--- @param force_lim Amount of force until it breaks, 0 = Unbreakable
--- @param torque_lim Amount of torque until it breaks, 0 = Unbreakable
--- @param minv Vector defining minimum rotation angle based on world axes
--- @param maxv Vector defining maximum rotation angle based on world axes
--- @param frictionv Vector defining rotational friction, local to the constraint
--- @param rotateonly If True, ballsocket will only affect the rotation allowing for free movement, otherwise it will limit both - rotation and movement
--- @param nocollide Bool whether or not to nocollide the two entities
+-- @param entity e1 The first entity
+-- @param entity e2 The second entity
+-- @param number? bone1 Number bone of the first entity. Default 0
+-- @param number? bone2 Number bone of the second entity. Default 0
+-- @param vector v1 Position on the first entity, in its local space coordinates
+-- @param vector v2 Position on the second entity, in its local space coordinates
+-- @param number? force_lim Amount of force until it breaks, 0 = Unbreakable. Default 0
+-- @param number? torque_lim Amount of torque until it breaks, 0 = Unbreakable. Default 0
+-- @param vector? minv Vector defining minimum rotation angle based on world axes. Default Vec(0)
+-- @param vector? maxv Vector defining maximum rotation angle based on world axes. Default Vec(0)
+-- @param vector? frictionv Vector defining rotational friction, local to the constraint. Default Vec(0)
+-- @param boolean? rotateonly If True, ballsocket will only affect the rotation allowing for free movement, otherwise it will limit both - rotation and movement. Default false
+-- @param boolean? nocollide Bool whether or not to nocollide the two entities. Default false
 -- @server
 function constraint_library.ballsocketadv(e1, e2, bone1, bone2, v1, v2, force_lim, torque_lim, minv, maxv, frictionv, rotateonly, nocollide)
 	plyCount:checkuse(instance.player, 1)
@@ -294,19 +294,19 @@ function constraint_library.elastic(index, e1, e2, bone1, bone2, v1, v2, const, 
 end
 
 --- Creates a rope between two entities
--- @param index Index of the rope constraint
--- @param e1 The first entity
--- @param e2 The second entity
--- @param bone1 Number bone of the first entity
--- @param bone2 Number bone of the second entity
--- @param v1 Position on the first entity, in its local space coordinates
--- @param v2 Position on the second entity, in its local space coordinates
--- @param length Length of the created rope
--- @param addlength Amount to add to the base length of the rope. Default = 0
--- @param force_lim Amount of force until it breaks, 0 = Unbreakable
--- @param width Width of the rope
--- @param material Material of the rope
--- @param rigid Whether the rope is rigid
+-- @param number index Index of the rope constraint
+-- @param entity e1 The first entity
+-- @param entity e2 The second entity
+-- @param number? bone1 Number bone of the first entity. Default 0
+-- @param number? bone2 Number bone of the second entity. Default 0
+-- @param vector v1 Position on the first entity, in its local space coordinates
+-- @param vector v2 Position on the second entity, in its local space coordinates
+-- @param number? length Length of the created rope. Default 0
+-- @param number? addlength Amount to add to the base length of the rope. Default 0
+-- @param number? force_lim Amount of force until it breaks, 0 = Unbreakable. Default 0
+-- @param number? width Width of the rope. Default 0
+-- @param string? materialName Material of the rope
+-- @param boolean? rigid Whether the rope is rigid. Default false
 -- @server
 function constraint_library.rope(index, e1, e2, bone1, bone2, v1, v2, length, addlength, force_lim, width, material, rigid)
 	plyCount:checkuse(instance.player, 1)
@@ -348,13 +348,13 @@ function constraint_library.rope(index, e1, e2, bone1, bone2, v1, v2, length, ad
 end
 
 --- Sliders two entities
--- @param e1 The first entity
--- @param e2 The second entity
--- @param bone1 Number bone of the first entity
--- @param bone2 Number bone of the second entity
--- @param v1 Position on the first entity, in its local space coordinates
--- @param v2 Position on the second entity, in its local space coordinates
--- @param width Width of the slider 
+-- @param entity e1 The first entity
+-- @param entity e2 The second entity
+-- @param number? bone1 Number bone of the first entity. Default 0
+-- @param number? bone2 Number bone of the second entity. Default 0
+-- @param vector v1 Position on the first entity, in its local space coordinates
+-- @param vector v2 Position on the second entity, in its local space coordinates
+-- @param number? width Width of the slider. Default 0
 -- @server
 function constraint_library.slider(e1, e2, bone1, bone2, v1, v2, width)
 
@@ -383,10 +383,10 @@ function constraint_library.slider(e1, e2, bone1, bone2, v1, v2, width)
 end
 
 --- Nocollides two entities
--- @param e1 The first entity
--- @param e2 The second entity
--- @param bone1 Number bone of the first entity (default 0)
--- @param bone2 Number bone of the second entity (default 0)
+-- @param entity e1 The first entity
+-- @param entity e2 The second entity
+-- @param number? bone1 Number bone of the first entity. Default 0
+-- @param number? bone2 Number bone of the second entity. Default 0
 -- @server
 function constraint_library.nocollide(e1, e2, bone1, bone2)
 
@@ -411,10 +411,10 @@ function constraint_library.nocollide(e1, e2, bone1, bone2)
 end
 
 --- Applies a keepupright constraint on an entity
--- @param e The entity
--- @param ang The upright angle
--- @param bone Number bone of the entity (default 0)
--- @param lim The strength of the constraint (default 5000)
+-- @param entity e The entity
+-- @param angle ang The upright angle
+-- @param number bone Number bone of the entity. Default 0
+-- @param number lim The strength of the constraint. Default 5000
 -- @server
 function constraint_library.keepupright(e, ang, bone, lim)
 	plyCount:checkuse(instance.player, 1)
@@ -437,9 +437,9 @@ function constraint_library.keepupright(e, ang, bone, lim)
 end
 
 --- Sets the length of a rope attached to the entity
--- @param index Index of the rope constraint
--- @param e Entity that has the constraint
--- @param length New length of the constraint
+-- @param number index Index of the rope constraint
+-- @param entity e Entity that has the constraint
+-- @param number length New length of the constraint
 -- @server
 function constraint_library.setRopeLength(index, e, length)
 	local ent1 = getent(e)
@@ -459,9 +459,9 @@ function constraint_library.setRopeLength(index, e, length)
 end
 
 --- Sets the length of an elastic attached to the entity
--- @param index Index of the elastic constraint
--- @param e Entity that has the constraint
--- @param length New length of the constraint
+-- @param number index Index of the elastic constraint
+-- @param entity e Entity that has the constraint
+-- @param number length New length of the constraint
 -- @server
 function constraint_library.setElasticLength(index, e, length)
 	local ent1 = getent(e)
@@ -480,7 +480,7 @@ function constraint_library.setElasticLength(index, e, length)
 end
 
 --- Breaks all constraints on an entity
--- @param e Entity to remove the constraints from
+-- @param entity e Entity to remove the constraints from
 -- @server
 function constraint_library.breakAll(e)
 	local ent1 = getent(e)
@@ -490,8 +490,8 @@ function constraint_library.breakAll(e)
 end
 
 --- Breaks all constraints of a certain type on an entity
--- @param e Entity to be affected
--- @param typename Name of the constraint type, ie. Weld, Elastic, NoCollide, etc.
+-- @param entity e Entity to be affected
+-- @param string typename Name of the constraint type, ie. Weld, Elastic, NoCollide, etc.
 -- @server
 function constraint_library.breakType(e, typename)
 	checkluatype(typename, TYPE_STRING)
@@ -505,21 +505,21 @@ end
 
 
 --- Returns the table of constraints on an entity
--- @param ent The entity
--- @return Table of entity constraints
+-- @param entity ent The entity
+-- @return table Table of entity constraints
 function constraint_library.getTable(ent)
 	return instance.Sanitize(constraint.GetTable(getent(ent)))
 end
 
 --- Sets whether the chip should remove created constraints when the chip is removed
--- @param on Boolean whether the constraints should be cleaned or not
+-- @param boolean on Whether the constraints should be cleaned or not
 function constraint_library.setConstraintClean(on)
 	constraintsClean = on
 end
 
 --- Checks how many constraints can be spawned
 -- @server
--- @return number of constraints able to be spawned
+-- @return number Number of constraints able to be spawned
 function constraint_library.constraintsLeft()
 	return plyCount:check(instance.player)
 end

--- a/lua/starfall/libs_sv/constraint.lua
+++ b/lua/starfall/libs_sv/constraint.lua
@@ -253,9 +253,9 @@ end
 -- @param number? damp Damping of the constraint. Default 100
 -- @param number? rdamp Rotational damping of the constraint. Default 0
 -- @param number? width Width of the created constraint. Default 0
--- @param boolean? strech True to mark as strech-only. Default false
+-- @param boolean? stretch True to mark as stretch-only. Default false
 -- @server
-function constraint_library.elastic(index, e1, e2, bone1, bone2, v1, v2, const, damp, rdamp, width, strech)
+function constraint_library.elastic(index, e1, e2, bone1, bone2, v1, v2, const, damp, rdamp, width, stretch)
 	plyCount:checkuse(instance.player, 1)
 
 	local ent1 = eunwrap(e1)
@@ -284,7 +284,7 @@ function constraint_library.elastic(index, e1, e2, bone1, bone2, v1, v2, const, 
 	e1.Elastics = e1.Elastics or {}
 	e2.Elastics = e2.Elastics or {}
 
-	local ent = constraint.Elastic(ent1, ent2, bone1, bone2, vec1, vec2, const, damp, rdamp, "cable/cable2", math.Clamp(width, 0, 50), strech)
+	local ent = constraint.Elastic(ent1, ent2, bone1, bone2, vec1, vec2, const, damp, rdamp, "cable/cable2", math.Clamp(width, 0, 50), stretch)
 	if ent then
 		register(ent, instance)
 

--- a/lua/starfall/libs_sv/entities.lua
+++ b/lua/starfall/libs_sv/entities.lua
@@ -826,7 +826,7 @@ function ents_methods:setUnbreakable(on)
 end
 
 --- Check if the given Entity or Vector is within this entity's PVS (Potentially Visible Set). See: https://developer.valvesoftware.com/wiki/PVS
--- @param entity|Vector other Entity or Vector to test
+-- @param Entity|Vector other Entity or Vector to test
 -- @return boolean If the Entity/Vector is within the PVS
 function ents_methods:testPVS(other)
 	local ent = getent(self)

--- a/lua/starfall/libs_sv/entities.lua
+++ b/lua/starfall/libs_sv/entities.lua
@@ -67,8 +67,8 @@ end)
 -- ------------------------- Methods ------------------------- --
 
 --- Parents the entity to another entity
--- @param parent Entity to parent to. nil to unparent
--- @param attachment Optional string attachment name to parent to
+-- @param entity? parent Entity to parent to. nil to unparent
+-- @param string? attachment Optional string attachment name to parent to
 function ents_methods:setParent(parent, attachment)
 	local ent = getent(self)
 	if ent:IsPlayer() then SF.Throw("Target is a player!", 2) end
@@ -103,7 +103,7 @@ function ents_methods:unparent()
 end
 
 --- Links starfall components to a starfall processor or vehicle. Screen can only connect to processor. HUD can connect to processor and vehicle.
--- @param e Entity to link the component to, a vehicle or starfall for huds, or a starfall for screens. nil to clear links.
+-- @param entity? e Entity to link the component to, a vehicle or starfall for huds, or a starfall for screens. nil to clear links.
 function ents_methods:linkComponent(e)
 	local ent = getent(self)
 	checkpermission(instance, ent, "entities.canTool")
@@ -132,7 +132,7 @@ function ents_methods:linkComponent(e)
 end
 
 --- Sets a component's ability to lock a player's controls
--- @param enable Whether the component will lock the player's controls when used
+-- @param boolean enable Whether the component will lock the player's controls when used
 function ents_methods:setComponentLocksControls(enable)
 	local ent = getent(self)
 	checkluatype(enable, TYPE_BOOL)
@@ -145,9 +145,9 @@ function ents_methods:setComponentLocksControls(enable)
 end
 
 --- Applies damage to an entity
--- @param amt damage amount
--- @param attacker damage attacker
--- @param inflictor damage inflictor
+-- @param number amt Damage amount
+-- @param entity attacker Damage attacker
+-- @param entity inflictor Damage inflictor
 function ents_methods:applyDamage(amt, attacker, inflictor)
 	local ent = getent(self)
 	checkluatype(amt, TYPE_NUMBER)
@@ -165,9 +165,9 @@ function ents_methods:applyDamage(amt, attacker, inflictor)
 end
 
 --- Sets a custom prop's physics simulation forces. Thrusters and balloons use this.
--- @param ang Angular Force (Torque)
--- @param lin Linear Force
--- @param mode The physics mode to use. 0 = Off, 1 = Local acceleration, 2 = Local force, 3 = Global Acceleration, 4 = Global force
+-- @param vector ang Angular Force (Torque)
+-- @param vector lin Linear Force
+-- @param number mode The physics mode to use. 0 = Off, 1 = Local acceleration, 2 = Local force, 3 = Global Acceleration, 4 = Global force
 function ents_methods:setCustomPropForces(ang, lin, mode)
 	local ent = getent(self)
 	if ent:GetClass()~="starfall_prop" then SF.Throw("The entity isn't a custom prop", 2) end
@@ -189,7 +189,7 @@ function ents_methods:setCustomPropForces(ang, lin, mode)
 end
 
 --- Set the angular velocity of an object
--- @param angvel The local angvel vector to set
+-- @param vector angvel The local angvel vector to set
 function ents_methods:setAngleVelocity(angvel)
 	local ent = getent(self)
 	angvel = vunwrap(angvel)
@@ -204,7 +204,7 @@ function ents_methods:setAngleVelocity(angvel)
 end
 
 --- Applys a angular velocity to an object
--- @param angvel The local angvel vector to apply
+-- @param vector angvel The local angvel vector to apply
 function ents_methods:addAngleVelocity(angvel)
 	local ent = getent(self)
 	angvel = vunwrap(angvel)
@@ -239,9 +239,9 @@ function ents_methods:setElasticity(elasticity)
 	checkpermission(instance, ent, "entities.canTool")
 	ent:SetElasticity(elasticity)
 end
-	
+
 --- Applies linear force to the entity
--- @param vec The force vector
+-- @param vector vec The force vector
 function ents_methods:applyForceCenter(vec)
 	local ent = getent(self)
 	local vec = vunwrap(vec)
@@ -256,8 +256,8 @@ function ents_methods:applyForceCenter(vec)
 end
 
 --- Applies linear force to the entity with an offset
--- @param force The force vector in world coordinates
--- @param position The force position in world coordinates
+-- @param vector force The force vector in world coordinates
+-- @param vector position The force position in world coordinates
 function ents_methods:applyForceOffset(force, position)
 	local ent = getent(self)
 
@@ -276,7 +276,7 @@ function ents_methods:applyForceOffset(force, position)
 end
 
 --- Applies angular force to the entity (This function is garbage, use applyTorque instead)
--- @param ang The force angle
+-- @param angle ang The force angle
 function ents_methods:applyAngForce(ang)
 	local ent = getent(self)
 
@@ -316,7 +316,7 @@ function ents_methods:applyAngForce(ang)
 end
 
 --- Applies torque
--- @param torque The torque vector
+-- @param vector torque The torque vector
 function ents_methods:applyTorque(torque)
 	local ent = getent(self)
 
@@ -346,12 +346,12 @@ local function addCollisions(func)
 	end
 end
 --- Allows detecting collisions on an entity. You can only do this once for the entity's entire lifespan so use it wisely.
--- @param func The callback function with argument, table collsiondata, http://wiki.facepunch.com/gmod/Structures/CollisionData
+-- @param function func The callback function with argument, table collsiondata, http://wiki.facepunch.com/gmod/Structures/CollisionData
 function ents_methods:addCollisionListener(func)
 	local ent = getent(self)
 	checkluatype(func, TYPE_FUNCTION)
 	checkpermission(instance, ent, "entities.canTool")
-	
+
 	local callback = addCollisions(func)
 	if ent:GetClass() ~= "starfall_prop" then
 		if ent.SF_CollisionCallback then SF.Throw("The entity is already listening to collisions!", 2) end
@@ -379,7 +379,8 @@ function ents_methods:removeCollisionListener()
 end
 
 --- Sets whether an entity's shadow should be drawn
--- @param ply Optional player argument to set only for that player. Can also be table of players.
+-- @param boolean draw Whether the shadow should draw
+-- @param player? ply Optional player argument to set only for that player. Can also be table of players.
 function ents_methods:setDrawShadow(draw, ply)
 	local ent = getent(self)
 	checkpermission(instance, ent, "entities.setRenderProperty")
@@ -392,7 +393,7 @@ function ents_methods:setDrawShadow(draw, ply)
 end
 
 --- Sets the entitiy's position. No interpolation will occur clientside, use physobj.setPos to have interpolation.
--- @param vec New position
+-- @param vector vec New position
 function ents_methods:setPos(vec)
 	local ent = getent(self)
 
@@ -403,7 +404,7 @@ function ents_methods:setPos(vec)
 end
 
 --- Sets the entity's angles
--- @param ang New angles
+-- @param angle ang New angles
 function ents_methods:setAngles(ang)
 	local ent = getent(self)
 
@@ -414,7 +415,7 @@ function ents_methods:setAngles(ang)
 end
 
 --- Sets the entity's linear velocity
--- @param vel New velocity
+-- @param vector vel New velocity
 function ents_methods:setVelocity(vel)
 	local ent = getent(self)
 
@@ -446,8 +447,8 @@ function ents_methods:breakEnt()
 end
 
 --- Ignites an entity
--- @param length How long the fire lasts
--- @param radius (optional) How large the fire hitbox is (entity obb is the max)
+-- @param number length How long the fire lasts
+-- @param number? radius (optional) How large the fire hitbox is (entity obb is the max)
 function ents_methods:ignite(length, radius)
 	local ent = getent(self)
 	checkluatype(length, TYPE_NUMBER)
@@ -472,8 +473,8 @@ function ents_methods:extinguish()
 end
 
 --- Simulate a Use action on the entity by the chip owner
--- @param usetype The USE_ enum use type. (Default: USE_ON)
--- @param value The use value (Default: 0)
+-- @param number? usetype The USE_ enum use type. (Default: USE_ON)
+-- @param number? value The use value (Default: 0)
 function ents_methods:use(usetype, value)
     local ent = getent(self)
     checkpermission(instance, ent, "entities.use")
@@ -483,7 +484,7 @@ function ents_methods:use(usetype, value)
 end
 
 --- Sets the entity frozen state
--- @param freeze Should the entity be frozen?
+-- @param boolean freeze Should the entity be frozen?
 function ents_methods:setFrozen(freeze)
 	local ent = getent(self)
 	local phys = ent:GetPhysicsObject()
@@ -496,16 +497,16 @@ function ents_methods:setFrozen(freeze)
 end
 
 --- Checks the entities frozen state
--- @return True if entity is frozen
+-- @return boolean True if entity is frozen
 function ents_methods:isFrozen()
 	local ent = getent(self)
 	local phys = ent:GetPhysicsObject()
 	if not phys:IsValid() then SF.Throw("Physics object is invalid", 2) end
-	if phys:IsMoveable() then return false else return true end
+	return not phys:IsMoveable()
 end
 
 --- Sets the entity to be Solid or not.
--- @param solid Boolean, Should the entity be solid?
+-- @param boolean solid Should the entity be solid?
 function ents_methods:setSolid(solid)
 	local ent = getent(self)
 	if ent:IsPlayer() then SF.Throw("Target is a player!", 2) end
@@ -515,7 +516,7 @@ function ents_methods:setSolid(solid)
 end
 
 --- Sets the entity's collision group
--- @param group The COLLISION_GROUP value to set it to
+-- @param number group The COLLISION_GROUP value to set it to
 function ents_methods:setCollisionGroup(group)
 	checkluatype(group, TYPE_NUMBER)
 	if group < 0 or group >= LAST_SHARED_COLLISION_GROUP then SF.Throw("Invalid collision group value", 2) end
@@ -527,7 +528,7 @@ function ents_methods:setCollisionGroup(group)
 end
 
 --- Set's the entity to collide with nothing but the world. Alias to entity:setCollisionGroup(COLLISION_GROUP_WORLD)
--- @param nocollide Whether to collide with nothing except world or not.
+-- @param boolean nocollide Whether to collide with nothing except world or not.
 function ents_methods:setNocollideAll(nocollide)
 	local ent = getent(self)
 	if ent:IsPlayer() then SF.Throw("Target is a player!", 2) end
@@ -537,7 +538,7 @@ function ents_methods:setNocollideAll(nocollide)
 end
 
 --- Sets the entity's mass
--- @param mass number mass
+-- @param number mass Mass to set to
 function ents_methods:setMass(mass)
 	local ent = getent(self)
 	if ent:IsPlayer() then SF.Throw("Target is a player!", 2) end
@@ -553,7 +554,7 @@ function ents_methods:setMass(mass)
 end
 
 --- Sets the entity's inertia
--- @param vec Inertia tensor
+-- @param vector vec Inertia tensor
 function ents_methods:setInertia(vec)
 	local ent = getent(self)
 	if ent:IsPlayer() then SF.Throw("Target is a player!", 2) end
@@ -571,7 +572,7 @@ function ents_methods:setInertia(vec)
 end
 
 --- Sets the physical material of the entity
--- @param mat Material to use
+-- @param string materialName Material to use
 function ents_methods:setPhysMaterial(mat)
 	local ent = getent(self)
 	if ent:IsPlayer() then SF.Throw("Target is a player!", 2) end
@@ -585,7 +586,7 @@ function ents_methods:setPhysMaterial(mat)
 end
 
 --- Get the physical material of the entity
--- @return the physical material
+-- @return string The physical material
 function ents_methods:getPhysMaterial()
 	local ent = getent(self)
 	local phys = ent:GetPhysicsObject()
@@ -595,7 +596,7 @@ function ents_methods:getPhysMaterial()
 end
 
 --- Checks whether entity has physics
--- @return True if entity has physics
+-- @return boolean If entity has physics
 function ents_methods:isValidPhys()
 	local ent = getent(self)
 	local phys = ent:GetPhysicsObject()
@@ -604,7 +605,7 @@ end
 
 --- Returns true if the entity is being held by a player. Either by Physics gun, Gravity gun or Use-key.
 -- @server
--- @return Boolean if the entity is being held or not
+-- @return boolean If the entity is being held or not
 function ents_methods:isPlayerHolding()
 	local ent = getent(self)
 	return ent:IsPlayerHolding()
@@ -612,13 +613,13 @@ end
 
 ---Returns if the entity is a constraint.
 -- @server
--- @return Boolean if the entity is a constraint
+-- @return boolean If the entity is a constraint
 function ents_methods:isConstraint()
 	return getent(self):IsConstraint()
 end
 
 --- Sets entity gravity
--- @param grav Bool should the entity respect gravity?
+-- @param boolean grav Should the entity respect gravity?
 function ents_methods:enableGravity(grav)
 	local ent = getent(self)
 	if ent:IsPlayer() then SF.Throw("Target is a player!", 2) end
@@ -632,7 +633,7 @@ function ents_methods:enableGravity(grav)
 end
 
 --- Sets the entity drag state
--- @param drag Bool should the entity have air resistence?
+-- @param boolean drag Should the entity have air resistence?
 function ents_methods:enableDrag(drag)
 	local ent = getent(self)
 	if ent:IsPlayer() then SF.Throw("Target is a player!", 2) end
@@ -645,7 +646,7 @@ function ents_methods:enableDrag(drag)
 end
 
 --- Sets the entity movement state
--- @param move Bool should the entity move?
+-- @param boolean move Should the entity move?
 function ents_methods:enableMotion(move)
 	local ent = getent(self)
 	if ent:IsPlayer() then SF.Throw("Target is a player!", 2) end
@@ -660,7 +661,7 @@ end
 
 
 --- Sets the physics of an entity to be a sphere
--- @param enabled Bool should the entity be spherical?
+-- @param boolean enabled Should the entity be spherical?
 function ents_methods:enableSphere(enabled)
 	local ent = getent(self)
 	if ent:GetClass() ~= "prop_physics" then SF.Throw("This function only works for prop_physics", 2) end
@@ -694,7 +695,7 @@ function ents_methods:enableSphere(enabled)
 end
 
 --- Gets what the entity is welded to. If the entity is parented, returns the parent.
---@return The first welded/parent entity
+-- @return entity The first welded/parent entity
 function ents_methods:isWeldedTo()
 	local ent = getent(self)
 	local constr = constraint.FindConstraint(ent, "Weld")
@@ -710,7 +711,7 @@ function ents_methods:isWeldedTo()
 end
 
 --- Gets a table of all constrained entities to each other
---@param filter Optional constraint type filter table where keys are the type name and values are 'true'. "Wire" and "Parent" are used for wires and parents.
+-- @param table? filter Optional constraint type filter table where keys are the type name and values are 'true'. "Wire" and "Parent" are used for wires and parents.
 function ents_methods:getAllConstrained(filter)
 	local ent = getent(self)
 	if filter ~= nil then checkluatype(filter, TYPE_TABLE) end
@@ -764,13 +765,13 @@ function ents_methods:getAllConstrained(filter)
 end
 
 --- Adds a trail to the entity with the specified attributes.
--- @param startSize The start size of the trail
--- @param endSize The end size of the trail
--- @param length The length size of the trail
--- @param material The material of the trail
--- @param color The color of the trail
--- @param attachmentID Optional attachmentid the trail should attach to
--- @param additive If the trail's rendering is additive
+-- @param number startSize The start size of the trail (0-128)
+-- @param number endSize The end size of the trail (0-128)
+-- @param number length The length size of the trail
+-- @param string material The material of the trail
+-- @param color color The color of the trail
+-- @param number? attachmentID Optional attachmentid the trail should attach to
+-- @param boolean? additive If the trail's rendering is additive
 function ents_methods:setTrails(startSize, endSize, length, material, color, attachmentID, additive)
 	local ent = getent(self)
 	checkluatype(material, TYPE_STRING)
@@ -803,7 +804,7 @@ function ents_methods:removeTrails()
 end
 
 --- Sets a prop_physics to be unbreakable
--- @param on Whether to make the prop unbreakable
+-- @param boolean on Whether to make the prop unbreakable
 function ents_methods:setUnbreakable(on)
 	local ent = getent(self)
 	checkluatype(on, TYPE_BOOL)
@@ -825,8 +826,8 @@ function ents_methods:setUnbreakable(on)
 end
 
 --- Check if the given Entity or Vector is within this entity's PVS (Potentially Visible Set). See: https://developer.valvesoftware.com/wiki/PVS
--- @param other Entity or Vector to test
--- @return bool True/False
+-- @param any other Entity or Vector to test
+-- @return boolean If the Entity/Vector is within the PVS
 function ents_methods:testPVS(other)
 	local ent = getent(self)
 
@@ -843,7 +844,7 @@ function ents_methods:testPVS(other)
 end
 
 --- Returns entity's creation ID (similar to entIndex, but increments monotonically)
--- @return The creation ID
+-- @return number The creation ID
 function ents_methods:getCreationID()
 	local ent = getent(self)
 	return ent:GetCreationID()

--- a/lua/starfall/libs_sv/entities.lua
+++ b/lua/starfall/libs_sv/entities.lua
@@ -67,7 +67,7 @@ end)
 -- ------------------------- Methods ------------------------- --
 
 --- Parents the entity to another entity
--- @param entity? parent Entity to parent to. nil to unparent
+-- @param Entity? parent Entity to parent to. nil to unparent
 -- @param string? attachment Optional string attachment name to parent to
 function ents_methods:setParent(parent, attachment)
 	local ent = getent(self)
@@ -103,7 +103,7 @@ function ents_methods:unparent()
 end
 
 --- Links starfall components to a starfall processor or vehicle. Screen can only connect to processor. HUD can connect to processor and vehicle.
--- @param entity? e Entity to link the component to, a vehicle or starfall for huds, or a starfall for screens. nil to clear links.
+-- @param Entity? e Entity to link the component to, a vehicle or starfall for huds, or a starfall for screens. nil to clear links.
 function ents_methods:linkComponent(e)
 	local ent = getent(self)
 	checkpermission(instance, ent, "entities.canTool")
@@ -146,8 +146,8 @@ end
 
 --- Applies damage to an entity
 -- @param number amt Damage amount
--- @param entity attacker Damage attacker
--- @param entity inflictor Damage inflictor
+-- @param Entity attacker Damage attacker
+-- @param Entity inflictor Damage inflictor
 function ents_methods:applyDamage(amt, attacker, inflictor)
 	local ent = getent(self)
 	checkluatype(amt, TYPE_NUMBER)
@@ -165,8 +165,8 @@ function ents_methods:applyDamage(amt, attacker, inflictor)
 end
 
 --- Sets a custom prop's physics simulation forces. Thrusters and balloons use this.
--- @param vector ang Angular Force (Torque)
--- @param vector lin Linear Force
+-- @param Vector ang Angular Force (Torque)
+-- @param Vector lin Linear Force
 -- @param number mode The physics mode to use. 0 = Off, 1 = Local acceleration, 2 = Local force, 3 = Global Acceleration, 4 = Global force
 function ents_methods:setCustomPropForces(ang, lin, mode)
 	local ent = getent(self)
@@ -189,7 +189,7 @@ function ents_methods:setCustomPropForces(ang, lin, mode)
 end
 
 --- Set the angular velocity of an object
--- @param vector angvel The local angvel vector to set
+-- @param Vector angvel The local angvel vector to set
 function ents_methods:setAngleVelocity(angvel)
 	local ent = getent(self)
 	angvel = vunwrap(angvel)
@@ -204,7 +204,7 @@ function ents_methods:setAngleVelocity(angvel)
 end
 
 --- Applys a angular velocity to an object
--- @param vector angvel The local angvel vector to apply
+-- @param Vector angvel The local angvel vector to apply
 function ents_methods:addAngleVelocity(angvel)
 	local ent = getent(self)
 	angvel = vunwrap(angvel)
@@ -241,7 +241,7 @@ function ents_methods:setElasticity(elasticity)
 end
 
 --- Applies linear force to the entity
--- @param vector vec The force vector
+-- @param Vector vec The force vector
 function ents_methods:applyForceCenter(vec)
 	local ent = getent(self)
 	local vec = vunwrap(vec)
@@ -256,8 +256,8 @@ function ents_methods:applyForceCenter(vec)
 end
 
 --- Applies linear force to the entity with an offset
--- @param vector force The force vector in world coordinates
--- @param vector position The force position in world coordinates
+-- @param Vector force The force vector in world coordinates
+-- @param Vector position The force position in world coordinates
 function ents_methods:applyForceOffset(force, position)
 	local ent = getent(self)
 
@@ -276,7 +276,7 @@ function ents_methods:applyForceOffset(force, position)
 end
 
 --- Applies angular force to the entity (This function is garbage, use applyTorque instead)
--- @param angle ang The force angle
+-- @param Angle ang The force angle
 function ents_methods:applyAngForce(ang)
 	local ent = getent(self)
 
@@ -316,7 +316,7 @@ function ents_methods:applyAngForce(ang)
 end
 
 --- Applies torque
--- @param vector torque The torque vector
+-- @param Vector torque The torque vector
 function ents_methods:applyTorque(torque)
 	local ent = getent(self)
 
@@ -380,7 +380,7 @@ end
 
 --- Sets whether an entity's shadow should be drawn
 -- @param boolean draw Whether the shadow should draw
--- @param player? ply Optional player argument to set only for that player. Can also be table of players.
+-- @param Player? ply Optional player argument to set only for that player. Can also be table of players.
 function ents_methods:setDrawShadow(draw, ply)
 	local ent = getent(self)
 	checkpermission(instance, ent, "entities.setRenderProperty")
@@ -393,7 +393,7 @@ function ents_methods:setDrawShadow(draw, ply)
 end
 
 --- Sets the entitiy's position. No interpolation will occur clientside, use physobj.setPos to have interpolation.
--- @param vector vec New position
+-- @param Vector vec New position
 function ents_methods:setPos(vec)
 	local ent = getent(self)
 
@@ -404,7 +404,7 @@ function ents_methods:setPos(vec)
 end
 
 --- Sets the entity's angles
--- @param angle ang New angles
+-- @param Angle ang New angles
 function ents_methods:setAngles(ang)
 	local ent = getent(self)
 
@@ -415,7 +415,7 @@ function ents_methods:setAngles(ang)
 end
 
 --- Sets the entity's linear velocity
--- @param vector vel New velocity
+-- @param Vector vel New velocity
 function ents_methods:setVelocity(vel)
 	local ent = getent(self)
 
@@ -554,7 +554,7 @@ function ents_methods:setMass(mass)
 end
 
 --- Sets the entity's inertia
--- @param vector vec Inertia tensor
+-- @param Vector vec Inertia tensor
 function ents_methods:setInertia(vec)
 	local ent = getent(self)
 	if ent:IsPlayer() then SF.Throw("Target is a player!", 2) end
@@ -695,7 +695,7 @@ function ents_methods:enableSphere(enabled)
 end
 
 --- Gets what the entity is welded to. If the entity is parented, returns the parent.
--- @return entity The first welded/parent entity
+-- @return Entity The first welded/parent entity
 function ents_methods:isWeldedTo()
 	local ent = getent(self)
 	local constr = constraint.FindConstraint(ent, "Weld")
@@ -769,7 +769,7 @@ end
 -- @param number endSize The end size of the trail (0-128)
 -- @param number length The length size of the trail
 -- @param string material The material of the trail
--- @param color color The color of the trail
+-- @param Color color The color of the trail
 -- @param number? attachmentID Optional attachmentid the trail should attach to
 -- @param boolean? additive If the trail's rendering is additive
 function ents_methods:setTrails(startSize, endSize, length, material, color, attachmentID, additive)

--- a/lua/starfall/libs_sv/entities.lua
+++ b/lua/starfall/libs_sv/entities.lua
@@ -826,7 +826,7 @@ function ents_methods:setUnbreakable(on)
 end
 
 --- Check if the given Entity or Vector is within this entity's PVS (Potentially Visible Set). See: https://developer.valvesoftware.com/wiki/PVS
--- @param any other Entity or Vector to test
+-- @param entity|Vector other Entity or Vector to test
 -- @return boolean If the Entity/Vector is within the PVS
 function ents_methods:testPVS(other)
 	local ent = getent(self)

--- a/lua/starfall/libs_sv/prop.lua
+++ b/lua/starfall/libs_sv/prop.lua
@@ -61,11 +61,11 @@ end
 
 --- Creates a prop
 -- @server
--- @param vector pos Initial entity position
--- @param angle ang Initial entity angles
+-- @param Vector pos Initial entity position
+-- @param Angle ang Initial entity angles
 -- @param string model Model path
 -- @param boolean? frozen True to spawn the entity in a frozen state. Default = False
--- @return entity The prop object
+-- @return Entity The prop object
 function props_library.create(pos, ang, model, frozen)
 
 	checkpermission(instance, nil, "prop.create")
@@ -119,7 +119,7 @@ end
 -- @server
 -- @param string model Model path
 -- @param boolean? frozen True to spawn the entity in a frozen state. Default = False
--- @return entity The ragdoll entity
+-- @return Entity The ragdoll entity
 function props_library.createRagdoll(model, frozen)
     checkpermission(instance, nil, "prop.createRagdoll")
     checkluatype(model, TYPE_STRING)
@@ -166,11 +166,11 @@ end
 
 --- Creates a custom prop.
 -- @server
--- @param vector pos The position to spawn the prop
--- @param angle ang The angles to spawn the prop
+-- @param Vector pos The position to spawn the prop
+-- @param Angle ang The angles to spawn the prop
 -- @param table vertices The table of tables of vectices that make up the physics mesh {{v1,v2,...},{v1,v2,...},...}
 -- @param boolean frozen Whether the prop starts frozen
--- @return entity The prop object
+-- @return Entity The prop object
 function props_library.createCustom(pos, ang, vertices, frozen)
 	local pos = SF.clampPos(vunwrap(pos))
 	local ang = aunwrap(ang)
@@ -265,13 +265,13 @@ local allowed_components = {
 -- Allowed components:
 -- starfall_hud
 -- starfall_screen
--- @param vector pos Position of created component
--- @param angle ang Angle of created component
+-- @param Vector pos Position of created component
+-- @param Angle ang Angle of created component
 -- @param string class Class of created component
 -- @param string model Model of created component
 -- @param boolean frozen True to spawn frozen
 -- @server
--- @return entity Component entity
+-- @return Entity Component entity
 function props_library.createComponent(pos, ang, class, model, frozen)
 	checkpermission(instance,  nil, "prop.create")
 	checkluatype(class, TYPE_STRING)
@@ -359,13 +359,13 @@ function props_library.getSpawnableSents(categorized)
 end
 
 --- Creates a sent.
--- @param vector pos Position of created sent
--- @param angle ang Angle of created sent
+-- @param Vector pos Position of created sent
+-- @param Angle ang Angle of created sent
 -- @param string class Class of created sent
 -- @param boolean frozen True to spawn frozen
 -- @param table? data Optional table, additional entity data to be supplied to certain SENTs. See prop.SENT_Data_Structures table in Docs for list of SENTs
 -- @server
--- @return entity The sent object
+-- @return Entity The sent object
 function props_library.createSent(pos, ang, class, frozen, data)
 	checkpermission(instance,  nil, "prop.create")
 

--- a/lua/starfall/libs_sv/prop.lua
+++ b/lua/starfall/libs_sv/prop.lua
@@ -61,11 +61,11 @@ end
 
 --- Creates a prop
 -- @server
--- @param pos Initial entity position
--- @param ang Initial entity angles
--- @param model Model path
--- @param frozen True to spawn the entity in a frozen state. Default = False
--- @return The prop object
+-- @param vector pos Initial entity position
+-- @param angle ang Initial entity angles
+-- @param string model Model path
+-- @param boolean? frozen True to spawn the entity in a frozen state. Default = False
+-- @return entity The prop object
 function props_library.create(pos, ang, model, frozen)
 
 	checkpermission(instance, nil, "prop.create")
@@ -117,9 +117,9 @@ end
 
 --- Creates a ragdoll
 -- @server
--- @param model Model path
--- @param frozen True to spawn the entity in a frozen state. Default = False
--- @return The ragdoll entity
+-- @param string model Model path
+-- @param boolean? frozen True to spawn the entity in a frozen state. Default = False
+-- @return entity The ragdoll entity
 function props_library.createRagdoll(model, frozen)
     checkpermission(instance, nil, "prop.createRagdoll")
     checkluatype(model, TYPE_STRING)
@@ -166,11 +166,11 @@ end
 
 --- Creates a custom prop.
 -- @server
--- @param pos The position to spawn the prop
--- @param ang The angles to spawn the prop
--- @param vertices The table of tables of vectices that make up the physics mesh {{v1,v2,...},{v1,v2,...},...}
--- @param frozen Whether the prop starts frozen
--- @return The prop object
+-- @param vector pos The position to spawn the prop
+-- @param angle ang The angles to spawn the prop
+-- @param table vertices The table of tables of vectices that make up the physics mesh {{v1,v2,...},{v1,v2,...},...}
+-- @param boolean frozen Whether the prop starts frozen
+-- @return entity The prop object
 function props_library.createCustom(pos, ang, vertices, frozen)
 	local pos = SF.clampPos(vunwrap(pos))
 	local ang = aunwrap(ang)
@@ -265,13 +265,13 @@ local allowed_components = {
 -- Allowed components:
 -- starfall_hud
 -- starfall_screen
--- @param pos Position of created component
--- @param ang Angle of created component
--- @param class Class of created component
--- @param model Model of created component
--- @param frozen True to spawn frozen
+-- @param vector pos Position of created component
+-- @param angle ang Angle of created component
+-- @param string class Class of created component
+-- @param string model Model of created component
+-- @param boolean frozen True to spawn frozen
 -- @server
--- @return Component entity
+-- @return entity Component entity
 function props_library.createComponent(pos, ang, class, model, frozen)
 	checkpermission(instance,  nil, "prop.create")
 	checkluatype(class, TYPE_STRING)
@@ -328,8 +328,8 @@ function props_library.createComponent(pos, ang, class, model, frozen)
 end
 
 --- Get a list of all spawnable sents.
--- @param categorized True to get an categorized list
--- @return The table
+-- @param boolean? categorized True to get an categorized list
+-- @return table The table
 function props_library.getSpawnableSents(categorized)
 	local tbl = {}
 
@@ -359,13 +359,13 @@ function props_library.getSpawnableSents(categorized)
 end
 
 --- Creates a sent.
--- @param pos Position of created sent
--- @param ang Angle of created sent
--- @param class Class of created sent
--- @param frozen True to spawn frozen
--- @param data Optional table, additional entity data to be supplied to certain SENTs. See prop.SENT_Data_Structures table in Docs for list of SENTs
+-- @param vector pos Position of created sent
+-- @param angle ang Angle of created sent
+-- @param string class Class of created sent
+-- @param boolean frozen True to spawn frozen
+-- @param table? data Optional table, additional entity data to be supplied to certain SENTs. See prop.SENT_Data_Structures table in Docs for list of SENTs
 -- @server
--- @return The sent object
+-- @return entity The sent object
 function props_library.createSent(pos, ang, class, frozen, data)
 	checkpermission(instance,  nil, "prop.create")
 
@@ -601,7 +601,7 @@ end
 
 --- Checks if a user can spawn anymore props.
 -- @server
--- @return True if user can spawn props, False if not.
+-- @return boolean True if user can spawn props, False if not.
 function props_library.canSpawn()
 	if not SF.Permissions.hasAccess(instance, nil, "prop.create") then return false end
 	return plyCount:check(instance.player) > 0 and plyPropBurst:check(instance.player) >= 1
@@ -609,7 +609,7 @@ end
 
 --- Checks how many props can be spawned
 -- @server
--- @return number of props able to be spawned
+-- @return number Number of props able to be spawned
 function props_library.propsLeft()
 	if not SF.Permissions.hasAccess(instance,  nil, "prop.create") then return 0 end
 	return math.min(plyCount:check(instance.player), plyPropBurst:check(instance.player))
@@ -617,21 +617,19 @@ end
 
 --- Returns how many props per second the user can spawn
 -- @server
--- @return Number of props per second the user can spawn
+-- @return number Number of props per second the user can spawn
 function props_library.spawnRate()
-
 	return plyPropBurst.rate
-
 end
 
 --- Sets whether the chip should remove created props when the chip is removed
--- @param on Boolean whether the props should be cleaned or not
+-- @param boolean on Whether the props should be cleaned or not
 function props_library.setPropClean(on)
 	propClean = on
 end
 
 --- Sets whether the props should be undo-able
--- @param on Boolean whether the props should be undo-able
+-- @param boolean on Whether the props should be undo-able
 function props_library.setPropUndo(on)
 	propUndo = on
 end

--- a/lua/starfall/libs_sv/wire.lua
+++ b/lua/starfall/libs_sv/wire.lua
@@ -499,7 +499,7 @@ ents_methods.getWirelink = wire_library.getWirelink
 
 --- Retrieves an output. Returns nil if the output doesn't exist.
 -- @param any Key to get the value at
--- @return any? Value at the index
+-- @return any Value at the index
 wirelink_meta.__index = function(self, k)
 	checkpermission(instance, nil, "wire.wirelink.read")
 	if wirelink_methods[k] then

--- a/lua/starfall/libs_sv/wire.lua
+++ b/lua/starfall/libs_sv/wire.lua
@@ -243,8 +243,8 @@ local sfTypeToWireTypeTable = {
 
 --- Creates/Modifies wire inputs. All wire ports must begin with an uppercase
 -- letter and contain only alphabetical characters or numbers but may not begin with a number.
--- @param names An array of input names. May be modified by the function.
--- @param types An array of input types. Can be shortcuts. May be modified by the function.
+-- @param table names An array of input names. May be modified by the function.
+-- @param table types An array of input types. Can be shortcuts. May be modified by the function.
 function wire_library.adjustInputs(names, types)
 	checkpermission(instance, nil, "wire.setInputs")
 	checkluatype(names, TYPE_TABLE)
@@ -271,8 +271,8 @@ end
 
 --- Creates/Modifies wire outputs. All wire ports must begin with an uppercase
 -- letter and contain only alphabetical characters or numbers but may not begin with a number.
--- @param names An array of output names. May be modified by the function.
--- @param types An array of output types. Can be shortcuts. May be modified by the function.
+-- @param table names An array of output names. May be modified by the function.
+-- @param table types An array of output types. Can be shortcuts. May be modified by the function.
 function wire_library.adjustOutputs(names, types)
 	checkpermission(instance, nil, "wire.setOutputs")
 	checkluatype(names, TYPE_TABLE)
@@ -310,8 +310,8 @@ end
 
 --- Creates/Modifies wire inputs/outputs. All wire ports must begin with an uppercase
 -- letter and contain only alphabetical characters or numbers but may not begin with a number.
--- @param inputs (Optional) A key-value table with input port names as keys and types as values. e.g. {MyInput="number"} or {MyInput={type="number"}}. If nil, input ports won't be changed.
--- @param outputs (Optional) A key-value table with output port names as keys and types as values. e.g. {MyOutput="number"} or {MyOutput={type="number"}}. If nil, output ports won't be changed.
+-- @param table? inputs (Optional) A key-value table with input port names as keys and types as values. e.g. {MyInput="number"} or {MyInput={type="number"}}. If nil, input ports won't be changed.
+-- @param table? outputs (Optional) A key-value table with output port names as keys and types as values. e.g. {MyOutput="number"} or {MyOutput={type="number"}}. If nil, output ports won't be changed.
 function wire_library.adjustPorts(inputs, outputs)
 	if inputs ~= nil then
 		checkluatype(inputs, TYPE_TABLE)
@@ -355,6 +355,7 @@ function wire_library.adjustPorts(inputs, outputs)
 end
 
 --- Returns the wirelink representing this entity.
+-- @return wirelink Wirelink representing this entity
 function wire_library.self()
 	local ent = instance.entity
 	if not ent then SF.Throw("No entity", 2) end
@@ -362,20 +363,20 @@ function wire_library.self()
 end
 
 --- Returns the server's UUID.
--- @return UUID as string
+-- @return string Server UUID
 function wire_library.serverUUID()
 	return WireLib.GetServerUUID()
 end
 
 local ValidWireMat = { 	["cable/rope"] = true, ["cable/cable2"] = true, ["cable/xbeam"] = true, ["cable/redlaser"] = true, ["cable/blue_elec"] = true, ["cable/physbeam"] = true, ["cable/hydra"] = true, ["arrowire/arrowire"] = true, ["arrowire/arrowire2"] = true }
 --- Wires two entities together
--- @param entI Entity with input
--- @param entO Entity with output
--- @param inputname Input to be wired
--- @param outputname Output to be wired
--- @param width Width of the wire(optional)
--- @param color Color of the wire(optional)
--- @param material Material of the wire(optional), Valid materials are cable/rope, cable/cable2, cable/xbeam, cable/redlaser, cable/blue_elec, cable/physbeam, cable/hydra, arrowire/arrowire, arrowire/arrowire2
+-- @param entity entI Entity with input
+-- @param entity entO Entity with output
+-- @param string inputname Input to be wired
+-- @param string outputname Output to be wired
+-- @param number? width Width of the wire(optional)
+-- @param color? color Color of the wire(optional)
+-- @param string? materialName Material of the wire(optional), Valid materials are cable/rope, cable/cable2, cable/xbeam, cable/redlaser, cable/blue_elec, cable/physbeam, cable/hydra, arrowire/arrowire, arrowire/arrowire2
 function wire_library.create(entI, entO, inputname, outputname, width, color, material)
 	checkluatype(inputname, TYPE_STRING)
 	checkluatype(outputname, TYPE_STRING)
@@ -421,8 +422,8 @@ function wire_library.create(entI, entO, inputname, outputname, width, color, ma
 end
 
 --- Unwires an entity's input
--- @param entI Entity with input
--- @param inputname Input to be un-wired
+-- @param entity entI Entity with input
+-- @param string inputname Input to be un-wired
 function wire_library.delete(entI, inputname)
 	checkluatype(inputname, TYPE_STRING)
 
@@ -459,24 +460,24 @@ local function parseEntity(ent, io)
 end
 
 --- Returns a table of entity's inputs
--- @param entI Entity with input(s)
--- @return Table of entity's input names
--- @return Table of entity's input types
+-- @param entity entI Entity with input(s)
+-- @return table Table of entity's input names
+-- @return table Table of entity's input types
 function wire_library.getInputs(entI)
 	return parseEntity(entI, "Inputs")
 end
 
 --- Returns a table of entity's outputs
--- @param entO Entity with output(s)
--- @return Table of entity's output names
--- @return Table of entity's output types
+-- @param entity entO Entity with output(s)
+-- @return table Table of entity's output names
+-- @return table Table of entity's output types
 function wire_library.getOutputs(entO)
 	return parseEntity(entO, "Outputs")
 end
 
 --- Returns a wirelink to a wire entity
--- @param ent Wire entity
--- @return Wirelink of the entity
+-- @param entity ent Wire entity
+-- @return wirelink Wirelink of the entity
 function wire_library.getWirelink(ent)
 	ent = eunwrap(ent)
 	if not ent:IsValid() then return end
@@ -491,12 +492,14 @@ end
 
 --- Returns an entities wirelink
 -- @class function
--- @return Wirelink of the entity
+-- @return wirelink Wirelink of the entity
 ents_methods.getWirelink = wire_library.getWirelink
 
 -- ------------------------- Wirelink ------------------------- --
 
 --- Retrieves an output. Returns nil if the output doesn't exist.
+-- @param any Key to get the value at
+-- @return any? Value at the index
 wirelink_meta.__index = function(self, k)
 	checkpermission(instance, nil, "wire.wirelink.read")
 	if wirelink_methods[k] then
@@ -516,6 +519,8 @@ wirelink_meta.__index = function(self, k)
 end
 
 --- Writes to an input.
+-- @param any key Key to set the value at
+-- @param any val Value to set at the index
 wirelink_meta.__newindex = function(self, k, v)
 	checkpermission(instance, nil, "wire.wirelink.write")
 	local wl = wlunwrap(self)
@@ -532,11 +537,14 @@ wirelink_meta.__newindex = function(self, k, v)
 end
 
 --- Checks if a wirelink is valid. (ie. doesn't point to an invalid entity)
+-- @return boolean Whether the wirelink is valid
 function wirelink_methods:isValid()
 	return wlunwrap(self) and true or false
 end
 
 --- Returns the type of input name, or nil if it doesn't exist
+-- @param string name Input name to search for
+-- @return string Type of input
 function wirelink_methods:inputType(name)
 	local wl = wlunwrap(self)
 	if not wl then return end
@@ -545,6 +553,8 @@ function wirelink_methods:inputType(name)
 end
 
 --- Returns the type of output name, or nil if it doesn't exist
+-- @param string name Output name to search for
+-- @return string Type of output
 function wirelink_methods:outputType(name)
 	local wl = wlunwrap(self)
 	if not wl then return end
@@ -553,11 +563,13 @@ function wirelink_methods:outputType(name)
 end
 
 --- Returns the entity that the wirelink represents
+-- @return entity Entity the wirelink represents
 function wirelink_methods:entity()
 	return owrap(wlunwrap(self))
 end
 
 --- Returns a table of all of the wirelink's inputs
+-- @return table All of the wirelink's inputs
 function wirelink_methods:inputs()
 	local wl = wlunwrap(self)
 	if not wl then return nil end
@@ -578,6 +590,7 @@ function wirelink_methods:inputs()
 end
 
 --- Returns a table of all of the wirelink's outputs
+-- @return table All of the wirelink's outputs
 function wirelink_methods:outputs()
 	local wl = wlunwrap(self)
 	if not wl then return nil end
@@ -598,7 +611,8 @@ function wirelink_methods:outputs()
 end
 
 --- Checks if an input is wired.
--- @param name Name of the input to check
+-- @param string name Name of the input to check
+-- @return boolean Whether it is wired
 function wirelink_methods:isWired(name)
 	checkluatype(name, TYPE_STRING)
 	local wl = wlunwrap(self)
@@ -609,8 +623,8 @@ function wirelink_methods:isWired(name)
 end
 
 --- Returns what an input of the wirelink is wired to.
--- @param name Name of the input
--- @return The entity the wirelink is wired to
+-- @param string name Name of the input
+-- @return entity The entity the wirelink is wired to
 function wirelink_methods:getWiredTo(name)
 	checkluatype(name, TYPE_STRING)
 	local wl = wlunwrap(self)
@@ -622,8 +636,8 @@ function wirelink_methods:getWiredTo(name)
 end
 
 --- Returns the name of the output an input of the wirelink is wired to.
--- @param name Name of the input of the wirelink.
--- @return String name of the output that the input is wired to.
+-- @param string name Name of the input of the wirelink.
+-- @return string String name of the output that the input is wired to.
 function wirelink_methods:getWiredToName(name)
 	checkluatype(name, TYPE_STRING)
 	local wl = wlunwrap(self)
@@ -666,20 +680,20 @@ wire_library.ports = setmetatable({}, {
 --- Called when an input on a wired SF chip is written to
 -- @name input
 -- @class hook
--- @param input The input name
--- @param value The value of the input
+-- @param string input The input name
+-- @param any value The value of the input
 
 --- Called when a high speed device reads from a wired SF chip
 -- @name readcell
 -- @class hook
 -- @server
--- @param address The address requested
--- @return The value read
+-- @param any address The address requested
+-- @return any The value read
 
 --- Called when a high speed device writes to a wired SF chip
 -- @name writecell
 -- @class hook
--- @param address The address written to
--- @param data The data being written
+-- @param any address The address written to
+-- @param table data The data being written
 
 end

--- a/lua/starfall/libs_sv/wire.lua
+++ b/lua/starfall/libs_sv/wire.lua
@@ -355,7 +355,7 @@ function wire_library.adjustPorts(inputs, outputs)
 end
 
 --- Returns the wirelink representing this entity.
--- @return wirelink Wirelink representing this entity
+-- @return Wirelink Wirelink representing this entity
 function wire_library.self()
 	local ent = instance.entity
 	if not ent then SF.Throw("No entity", 2) end
@@ -370,12 +370,12 @@ end
 
 local ValidWireMat = { 	["cable/rope"] = true, ["cable/cable2"] = true, ["cable/xbeam"] = true, ["cable/redlaser"] = true, ["cable/blue_elec"] = true, ["cable/physbeam"] = true, ["cable/hydra"] = true, ["arrowire/arrowire"] = true, ["arrowire/arrowire2"] = true }
 --- Wires two entities together
--- @param entity entI Entity with input
--- @param entity entO Entity with output
+-- @param Entity entI Entity with input
+-- @param Entity entO Entity with output
 -- @param string inputname Input to be wired
 -- @param string outputname Output to be wired
 -- @param number? width Width of the wire(optional)
--- @param color? color Color of the wire(optional)
+-- @param Color? color Color of the wire(optional)
 -- @param string? materialName Material of the wire(optional), Valid materials are cable/rope, cable/cable2, cable/xbeam, cable/redlaser, cable/blue_elec, cable/physbeam, cable/hydra, arrowire/arrowire, arrowire/arrowire2
 function wire_library.create(entI, entO, inputname, outputname, width, color, material)
 	checkluatype(inputname, TYPE_STRING)
@@ -422,7 +422,7 @@ function wire_library.create(entI, entO, inputname, outputname, width, color, ma
 end
 
 --- Unwires an entity's input
--- @param entity entI Entity with input
+-- @param Entity entI Entity with input
 -- @param string inputname Input to be un-wired
 function wire_library.delete(entI, inputname)
 	checkluatype(inputname, TYPE_STRING)
@@ -460,7 +460,7 @@ local function parseEntity(ent, io)
 end
 
 --- Returns a table of entity's inputs
--- @param entity entI Entity with input(s)
+-- @param Entity entI Entity with input(s)
 -- @return table Table of entity's input names
 -- @return table Table of entity's input types
 function wire_library.getInputs(entI)
@@ -468,7 +468,7 @@ function wire_library.getInputs(entI)
 end
 
 --- Returns a table of entity's outputs
--- @param entity entO Entity with output(s)
+-- @param Entity entO Entity with output(s)
 -- @return table Table of entity's output names
 -- @return table Table of entity's output types
 function wire_library.getOutputs(entO)
@@ -476,8 +476,8 @@ function wire_library.getOutputs(entO)
 end
 
 --- Returns a wirelink to a wire entity
--- @param entity ent Wire entity
--- @return wirelink Wirelink of the entity
+-- @param Entity ent Wire entity
+-- @return Wirelink Wirelink of the entity
 function wire_library.getWirelink(ent)
 	ent = eunwrap(ent)
 	if not ent:IsValid() then return end
@@ -492,7 +492,7 @@ end
 
 --- Returns an entities wirelink
 -- @class function
--- @return wirelink Wirelink of the entity
+-- @return Wirelink Wirelink of the entity
 ents_methods.getWirelink = wire_library.getWirelink
 
 -- ------------------------- Wirelink ------------------------- --
@@ -563,7 +563,7 @@ function wirelink_methods:outputType(name)
 end
 
 --- Returns the entity that the wirelink represents
--- @return entity Entity the wirelink represents
+-- @return Entity Entity the wirelink represents
 function wirelink_methods:entity()
 	return owrap(wlunwrap(self))
 end
@@ -624,7 +624,7 @@ end
 
 --- Returns what an input of the wirelink is wired to.
 -- @param string name Name of the input
--- @return entity The entity the wirelink is wired to
+-- @return Entity The entity the wirelink is wired to
 function wirelink_methods:getWiredTo(name)
 	checkluatype(name, TYPE_STRING)
 	local wl = wlunwrap(self)

--- a/lua/starfall/sflib.lua
+++ b/lua/starfall/sflib.lua
@@ -964,7 +964,7 @@ local materialBlacklist = {
 	["effects/ar2_altfire1"] = true,
 }
 --- Checks that the material isn't malicious
--- @param material The path to the material
+-- @param Material The path to the material
 -- @return The material object or false if it's invalid
 function SF.CheckMaterial(material)
 	if material == "" then return end


### PR DESCRIPTION
This PR normalizes documentation for all hooks and functions to use a format of
``-- @param <type> <param_name> <description>``
or
``-- @return <type> <description>``
Types are case-sensitive right now, in order to avoid looping through every value in the Types table for each bit of documentation. All future docs should be created in this way if/when this is pulled (I spent way too long on this pls...)

This breaks the website documentation so a parity PR on ``dochtml`` will be needed since the structure of the docs made in editor/docs.lua will change.
For external addons, if it is detected that the docs are in the old format, it *should* fallback to create docs with a filler type.

Changelist:
* Most documentation has been changed from slightly to completely different.
* Added documentation for the ``bit`` and ``socket`` libraries, as well as added a lot of missing docs (Some were missing parameters and return values entirely).
* "param" and "return" will both return tables now, both have keys named "type" inside that is something like "number", "...vector" or "angle?".

WIP!! I still am not sure if I've even missed a file to make docs for. You get tired after pretty much rewriting most of the docs..



