### PR TITLE
fixed table inputs not updating

### DIFF
--- a/lua/starfall/libs_sv/wire.lua
+++ b/lua/starfall/libs_sv/wire.lua
@@ -656,10 +656,18 @@ wire_library.ports = setmetatable({}, {
 	__index = function(self, name)
 		local input = instance.entity.Inputs[name]
 		if input then
-			if wirecache[name]==input.Value then return wirecachevals[name] end
-			local ret = inputConverters[input.Type](input.Value)
-			wirecache[name] = input.Value
-			wirecachevals[name] = ret
+			local ret
+			if type(input.Value) == "table" then
+				ret = inputConverters[input.Type](input.Value)
+			else
+				if wirecache[name]==input.Value then 
+					ret = wirecachevals[name]
+				else
+					ret = inputConverters[input.Type](input.Value)
+					wirecache[name] = input.Value
+					wirecachevals[name] = ret
+				end
+			end
 			return ret
 		end
 	end,

--- a/lua/starfall/libs_sv/wire.lua
+++ b/lua/starfall/libs_sv/wire.lua
@@ -660,7 +660,7 @@ wire_library.ports = setmetatable({}, {
 			if type(input.Value) == "table" then
 				ret = inputConverters[input.Type](input.Value)
 			else
-				if wirecache[name]==input.Value then 
+				if wirecache[name]==input.Value then
 					ret = wirecachevals[name]
 				else
 					ret = inputConverters[input.Type](input.Value)


### PR DESCRIPTION
When trying to read an input table/array from `wire.ports` the value isnt updated.
If you wire this E2
```
@name Starfall Array
@outputs MyArray:array

interval(1000)
MyArray[1, number] = time()
```
and this starfall script
```lua
--@name
--@server
wire.adjustInputs({"MyArray"}, {"Array"})
timer.create("tick", 1, 0, function()
    printTable(wire.ports["MyArray"])
end)
```
The starfall script will always print the same value.
I dont know if not caching tables is the best way to fix this but it seems to work.