### PR TITLE
Add --@includedata directive

### DIFF
--- a/lua/starfall/editor/editor.lua
+++ b/lua/starfall/editor/editor.lua
@@ -288,7 +288,6 @@ if CLIENT then
 					assert(tbl.includes[codepath] == inc)
 				end
 
-				local includesdata = ppdata.includesdata or {}
 				for i = 1, #inc do
 					recursiveLoad(inc[i], codedir)
 				end

--- a/lua/starfall/editor/editor.lua
+++ b/lua/starfall/editor/editor.lua
@@ -268,6 +268,12 @@ if CLIENT then
 
 			codedir = string.GetPathFromFilename(codepath)
 			tbl.files[codepath] = code
+
+			local includesdata = ppdata.includesdata
+			if includesdata and includesdata[codepath] then
+				return
+			end
+
 			SF.Preprocessor.ParseDirectives(codepath, code, ppdata)
 
 			local clientmain = ppdata.clientmain and ppdata.clientmain[codepath]
@@ -282,6 +288,7 @@ if CLIENT then
 					assert(tbl.includes[codepath] == inc)
 				end
 
+				local includesdata = ppdata.includesdata or {}
 				for i = 1, #inc do
 					recursiveLoad(inc[i], codedir)
 				end

--- a/lua/starfall/instance.lua
+++ b/lua/starfall/instance.lua
@@ -111,13 +111,16 @@ function SF.Instance.Compile(code, mainfile, player, entity)
 	if not ok then
 		return false, { message = "", traceback = err }
 	end
+	local includesdata = instance.ppdata.includesdata or {}
 	for filename, source in pairs(code) do
 		local serverorclient
 		if instance.ppdata.serverorclient then
 			serverorclient = instance.ppdata.serverorclient[filename]
 		end
 
-		if string.match(source, "^[%s\n]*$") or (serverorclient == "server" and CLIENT) or (serverorclient == "client" and SERVER) then
+		if includesdata[filename] then
+			-- Don't do anything.
+		elseif string.match(source, "^[%s\n]*$") or (serverorclient == "server" and CLIENT) or (serverorclient == "client" and SERVER) then
 			-- Lua doesn't have empty statements, so an empty file gives a syntax error
 			instance.scripts[filename] = function() end
 		else

--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -1063,6 +1063,13 @@ end
 -- @class directive
 -- @param path Path to the directory
 
+--- Mark a file to be included in the upload.
+-- Different from include in that the file does not have to have valid syntax.
+-- Cannot be used with require() or dofile(), can only be used with getScripts().
+-- @name includedata
+-- @class directive
+-- @param path Path to the file
+
 --- Set the name of the script.
 -- This will become the name of the tab and will show on the overlay of the processor. --@name Awesome script
 -- @name name

--- a/lua/starfall/preprocessor.lua
+++ b/lua/starfall/preprocessor.lua
@@ -88,6 +88,10 @@ end
 -- @param source The source code to parse.
 -- @param data The data table passed to the directives.
 function SF.Preprocessor.ParseDirectives(filename, source, data)
+	local includesdata = data.includesdata
+	if includesdata and includesdata[filename] then
+		return
+	end
 	local ending = nil
 	local endingLevel = nil
 	local lines = string.Explode("\r?\n", source, true)
@@ -141,6 +145,13 @@ local function directive_includedir(args, filename, data)
 	incl[#incl + 1] = string.Trim(args)
 end
 SF.Preprocessor.SetGlobalDirective("includedir", directive_includedir)
+
+SF.Preprocessor.SetGlobalDirective("includedata", function(args, filename, data)
+	if not data.includesdata then data.includesdata = {} end
+	data.includesdata[string.Trim(args)] = true
+
+	directive_include(args, filename, data)
+end)
 
 local function directive_name(args, filename, data)
 	if not data.scriptnames then data.scriptnames = {} end


### PR DESCRIPTION
I hope I'm not being a nuisance with these PRs. Adds an `--@includedata` directive to allow including files, but without attempting to compile or process directives for those files. Useful for including non-script files, and will allow for some chips to avoid the whole roundabout process of uploading the assets online and downloading them again at runtime.

Tests:
`includedata.txt`:
```lua
--@shared
--@includedata invalidsyntax.txt
local a = getScripts()['invalidsyntax.txt']
--print(a)
assert(a, "not working :(")
assert(not getScripts()['invalidsyntax2.txt'], "almost working :|")
print("it works :)")
```
`invalidsyntax.txt`:
```lua
--@include invalidsyntax2.txt
--@invalid
lolol invalid syntax
```
`invalidsyntax2.txt`:
```lua
LOLOL INVALID SYNTAX AGAIN!!!!
```

Practical example:
```lua
--@client
--@includedata chopsrampage/chopper.obj
--@includedata chopsrampage/palette.png
-- Load a model of a helicopter and display it.
local data = getScripts()
local obj = data['chopsrampage/chopper.obj']
local matpath = file.writeTemp('palette.png', data['chopsrampage/palette.png'])
local mat = material.createFromImage('../'..matpath, '')
local threshold = quotaMax()*0.5
local thread = coroutine.create(function()
    return mesh.createFromObj(obj, true, true)
end)
hook.add('think', 'init', function()
    while quotaUsed() < threshold do
        local tbl = coroutine.resume(thread)
        if tbl then
            hook.remove('think', 'init')
            local vmtx = {
                w = 1024,
                h = 1024,
                type = '3D',
                origin = Vector(0, -10, 0),
                angles = Angle(0, 90, 0),
                fov = 70,
                aspect = 1
            }
            render.createRenderTarget('out')
            hook.add('render', '', function()
                render.selectRenderTarget('out')
                    render.pushViewMatrix(vmtx)
                        render.setFilterMag(TEXFILTER.POINT)
                        render.setMaterial(mat)
                        tbl.chopper:draw()
                    render.popViewMatrix()
                render.selectRenderTarget()
                render.setRenderTargetTexture('out')
                render.drawTexturedRect(0, 0, 512, 512)
            end)
            return
        end
    end
end)
```
![Screenshot](https://user-images.githubusercontent.com/70858634/113641158-0a08e200-964b-11eb-9746-3c703e8cef07.png)
(Ignore the rendering bugs)