### PR TITLE
Don't run PostDrawHUD while a permission prompt is open

### DIFF
--- a/lua/entities/starfall_processor/cl_init.lua
+++ b/lua/entities/starfall_processor/cl_init.lua
@@ -140,7 +140,7 @@ net.Receive("starfall_processor_used", function(len)
 
 	instance:runScriptHook("starfallused", instance.WrapObject( activator ), instance.WrapObject( used ))
 
-	if activator == LocalPlayer() and instance.player ~= SF.Superuser and instance.permissionRequest and instance.permissionRequest.showOnUse and not SF.Permissions.permissionRequestSatisfied( instance ) and not IsValid(chip.permPanel) then
+	if activator == LocalPlayer() and instance.player ~= SF.Superuser and instance.permissionRequest and instance.permissionRequest.showOnUse and not SF.Permissions.permissionRequestSatisfied( instance ) and not IsValid(chip.permPanel) and not SF.showingPermissionPrompt then
 		local pnl = vgui.Create("SFChipPermissions")
 		if pnl then
 			pnl:OpenForChip( chip )

--- a/lua/entities/starfall_processor/cl_init.lua
+++ b/lua/entities/starfall_processor/cl_init.lua
@@ -140,11 +140,11 @@ net.Receive("starfall_processor_used", function(len)
 
 	instance:runScriptHook("starfallused", instance.WrapObject( activator ), instance.WrapObject( used ))
 
-	if activator == LocalPlayer() and instance.player ~= SF.Superuser and instance.permissionRequest and instance.permissionRequest.showOnUse and not SF.Permissions.permissionRequestSatisfied( instance ) and not IsValid(chip.permPanel) and not SF.showingPermissionPrompt then
+	if activator == LocalPlayer() and instance.player ~= SF.Superuser and instance.permissionRequest and instance.permissionRequest.showOnUse and not SF.Permissions.permissionRequestSatisfied( instance ) and not IsValid(SF.permPanel) then
 		local pnl = vgui.Create("SFChipPermissions")
 		if pnl then
 			pnl:OpenForChip( chip )
-			chip.permPanel = pnl
+			SF.permPanel = pnl
 		end
 	end
 end)

--- a/lua/starfall/editor/sfderma.lua
+++ b/lua/starfall/editor/sfderma.lua
@@ -619,13 +619,7 @@ function PANEL:OpenForChip( chip, showOverrides )
 	end
 end
 
-function PANEL:OnClose()
-	SF.showingPermissionPrompt = false
-end
-
 function PANEL:Init()
-	SF.showingPermissionPrompt = true
-
 	self:ShowCloseButton( false )
 	self:DockPadding( 5, 5, 5, 5 )
 	self:SetSize( 640, 400 )

--- a/lua/starfall/editor/sfderma.lua
+++ b/lua/starfall/editor/sfderma.lua
@@ -617,10 +617,15 @@ function PANEL:OpenForChip( chip, showOverrides )
 			chip.instance:runScriptHook( 'permissionrequest' )
 		end
 	end
+end
 
+function PANEL:OnClose()
+	SF.showingPermissionPrompt = false
 end
 
 function PANEL:Init()
+	SF.showingPermissionPrompt = true
+
 	self:ShowCloseButton( false )
 	self:DockPadding( 5, 5, 5, 5 )
 	self:SetSize( 640, 400 )

--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -181,11 +181,11 @@ SF.hookAdd("PreDrawOpaqueRenderables", "hologrammatrix", function(instance, draw
 	return not drawskybox, {}
 end)
 
-local function canRenderHud(instance, ...)
+local function canRenderHudSafeArgs(instance, ...)
 	return SF.IsHUDActive(instance.entity) and (instance.player == SF.Superuser or haspermission(instance, nil, "render.hud")), {...}
 end
 
-local function canRenderHudSecurely(instance, ...)
+local function canRenderHudSafeArgsParanoid(instance, ...)
 	return SF.IsHUDActive(instance.entity) and (instance.player == SF.Superuser or haspermission(instance, nil, "render.hud")) and not SF.showingPermissionPrompt, {...}
 end
 
@@ -208,19 +208,19 @@ local function returnCalcview(instance, tbl)
 	end
 end
 
-SF.hookAdd("HUDPaint", "drawhud", canRenderHud)
-SF.hookAdd("HUDShouldDraw", nil, canRenderHud, function(instance, args)
+SF.hookAdd("HUDPaint", "drawhud", canRenderHudSafeArgs)
+SF.hookAdd("HUDShouldDraw", nil, canRenderHudSafeArgs, function(instance, args)
 	if args[2]==false then return false end
 end)
-SF.hookAdd("PreDrawOpaqueRenderables", nil, canRenderHud)
-SF.hookAdd("PostDrawOpaqueRenderables", nil, canRenderHud)
-SF.hookAdd("PreDrawTranslucentRenderables", nil, canRenderHud)
-SF.hookAdd("PostDrawTranslucentRenderables", nil, canRenderHud)
-SF.hookAdd("PreDrawHUD", nil, canRenderHud)
-SF.hookAdd("PostDrawHUD", nil, canRenderHudSecurely)
+SF.hookAdd("PreDrawOpaqueRenderables", nil, canRenderHudSafeArgs)
+SF.hookAdd("PostDrawOpaqueRenderables", nil, canRenderHudSafeArgs)
+SF.hookAdd("PreDrawTranslucentRenderables", nil, canRenderHudSafeArgs)
+SF.hookAdd("PostDrawTranslucentRenderables", nil, canRenderHudSafeArgs)
+SF.hookAdd("PreDrawHUD", nil, canRenderHudSafeArgs)
+SF.hookAdd("PostDrawHUD", nil, canRenderHudSafeArgsParanoid)
 SF.hookAdd("CalcView", nil, canCalcview, returnCalcview)
-SF.hookAdd("SetupWorldFog", nil, canRenderHud, function() return true end)
-SF.hookAdd("SetupSkyboxFog", nil, canRenderHud, function() return true end)
+SF.hookAdd("SetupWorldFog", nil, canRenderHudSafeArgs, function() return true end)
+SF.hookAdd("SetupSkyboxFog", nil, canRenderHudSafeArgs, function() return true end)
 
 hook.Add("ShouldDrawLocalPlayer", "SF_DrawLocalPlayerInRenderView", function()
 	if renderingView and drawViewerInView then

--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -181,8 +181,12 @@ SF.hookAdd("PreDrawOpaqueRenderables", "hologrammatrix", function(instance, draw
 	return not drawskybox, {}
 end)
 
-local function canRenderHudSafeArgs(instance, ...)
+local function canRenderHud(instance, ...)
 	return SF.IsHUDActive(instance.entity) and (instance.player == SF.Superuser or haspermission(instance, nil, "render.hud")), {...}
+end
+
+local function canRenderHudSecurely(instance, ...)
+	return SF.IsHUDActive(instance.entity) and (instance.player == SF.Superuser or haspermission(instance, nil, "render.hud")) and not SF.showingPermissionPrompt, {...}
 end
 
 local function canCalcview(instance, ply, pos, ang, fov, znear, zfar)
@@ -204,19 +208,19 @@ local function returnCalcview(instance, tbl)
 	end
 end
 
-SF.hookAdd("HUDPaint", "drawhud", canRenderHudSafeArgs)
-SF.hookAdd("HUDShouldDraw", nil, canRenderHudSafeArgs, function(instance, args)
+SF.hookAdd("HUDPaint", "drawhud", canRenderHud)
+SF.hookAdd("HUDShouldDraw", nil, canRenderHud, function(instance, args)
 	if args[2]==false then return false end
 end)
-SF.hookAdd("PreDrawOpaqueRenderables", nil, canRenderHudSafeArgs)
-SF.hookAdd("PostDrawOpaqueRenderables", nil, canRenderHudSafeArgs)
-SF.hookAdd("PreDrawTranslucentRenderables", nil, canRenderHudSafeArgs)
-SF.hookAdd("PostDrawTranslucentRenderables", nil, canRenderHudSafeArgs)
-SF.hookAdd("PreDrawHUD", nil, canRenderHudSafeArgs)
-SF.hookAdd("PostDrawHUD", nil, canRenderHudSafeArgs)
+SF.hookAdd("PreDrawOpaqueRenderables", nil, canRenderHud)
+SF.hookAdd("PostDrawOpaqueRenderables", nil, canRenderHud)
+SF.hookAdd("PreDrawTranslucentRenderables", nil, canRenderHud)
+SF.hookAdd("PostDrawTranslucentRenderables", nil, canRenderHud)
+SF.hookAdd("PreDrawHUD", nil, canRenderHud)
+SF.hookAdd("PostDrawHUD", nil, canRenderHudSecurely)
 SF.hookAdd("CalcView", nil, canCalcview, returnCalcview)
-SF.hookAdd("SetupWorldFog", nil, canRenderHudSafeArgs, function() return true end)
-SF.hookAdd("SetupSkyboxFog", nil, canRenderHudSafeArgs, function() return true end)
+SF.hookAdd("SetupWorldFog", nil, canRenderHud, function() return true end)
+SF.hookAdd("SetupSkyboxFog", nil, canRenderHud, function() return true end)
 
 hook.Add("ShouldDrawLocalPlayer", "SF_DrawLocalPlayerInRenderView", function()
 	if renderingView and drawViewerInView then

--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -186,7 +186,8 @@ local function canRenderHudSafeArgs(instance, ...)
 end
 
 local function canRenderHudSafeArgsParanoid(instance, ...)
-	return SF.IsHUDActive(instance.entity) and (instance.player == SF.Superuser or haspermission(instance, nil, "render.hud")) and not SF.showingPermissionPrompt, {...}
+	local allowed, args = canRenderHudSafeArgs(instance, ...)
+	return allowed and not IsValid(SF.permPanel), args
 end
 
 local function canCalcview(instance, ply, pos, ang, fov, znear, zfar)

--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -316,10 +316,13 @@ if CLIENT then
 	function builtins_library.sendPermissionRequest()
 		if not SF.IsHUDActive(instance.entity) then SF.Throw("Player isn't connected to HUD!", 2) end
 		if sentPermRequest then SF.Throw("Can only send the permission request once!", 2) end
-		if instance.permissionRequest and not SF.Permissions.permissionRequestSatisfied( instance ) then
+		if instance.permissionRequest and not SF.Permissions.permissionRequestSatisfied( instance ) and not IsValid(SF.permPanel) then
 			sentPermRequest = true
 			local pnl = vgui.Create("SFChipPermissions")
-			if pnl then pnl:OpenForChip(instance.entity) end
+			if pnl then
+				pnl:OpenForChip(instance.entity)
+				SF.permPanel = pnl
+			end
 		end
 	end
 


### PR DESCRIPTION
This change prevents `PostDrawHUD` hooks from running if a permission prompt is open. Other hooks are unaffected. It also prevents opening a permission prompt if another one is already open. It does this by storing a boolean in `SF.showingPermissionPrompt`.

I think this change is necessary to prevent a [clickjacking](https://en.wikipedia.org/wiki/Clickjacking#Browserless) attack, where a malicious chip could trick users into accepting permissions they would not normally accept by **rendering on top of the permission prompt** and tricking the user into thinking the chip is asking for a different set of permissions.

[Here's a proof of concept script that I have used successfully on multiple victims.](https://gist.github.com/x4fx77x4f/3bcfa9cf74b030ccbeeaf6946920515f) It asks for the `console.command` permission, but uses the `postdrawhud` hook to make it look like it's asking for `http.get` instead. The payload will make you speak in chat, spin around for 5 seconds, and kick yourself from the server.