### PR TITLE
Add basic middleclass example + Change holoScreen and setpos_methods

### DIFF
--- a/lua/starfall/examples/classes.lua
+++ b/lua/starfall/examples/classes.lua
@@ -1,0 +1,49 @@
+--@name Basic Classes Example
+--@author Vurv
+--@shared
+
+-- This is more of a generic example for middleclass / classes in StarfallEx
+-- If you want to see classes in action, see other examples like the fireplace and tcpclient examples
+
+local Student = class("Student")
+
+-- This is the function that will be called on Class:new(...)
+-- Aka the 'constructor'
+function Student:initialize(name, school)
+    self.name = name
+    self.school = school
+end
+
+function Student:work()
+    print(self.name .. " is doing some work")
+end
+
+-- Make a class that derives from Student
+local CollegeStudent = class("CollegeStudent", Student)
+
+-- This overrides Student's initialize so that won't be called alongside this.
+function CollegeStudent:initialize(name, school, procrastinating)
+    self.name = name
+    self.school = school
+    self.procrastinating = false
+end
+
+-- Add a function specifically to the CollegeStudent subclass
+function CollegeStudent:procrastinate()
+    print(self.name .. " is procrastinating")
+    self.procrastinating = true
+end
+
+--- Now to use these classes we just made
+
+local Jim = Student:new("Jim", "Cool School")
+
+local Bob = CollegeStudent:new("Bob", "Cooler School")
+
+Jim:work()
+Bob:work() -- CollegeStudent is a subclass so it inherits all of the methods of Student
+
+Bob:procrastinate()
+
+print(Jim.procrastinating) -- 'Student' class does not have a procrastinating field, so this will be nil
+print(Bob.procrastinating)

--- a/lua/starfall/examples/holoScreen.lua
+++ b/lua/starfall/examples/holoScreen.lua
@@ -2,45 +2,51 @@
 --@author LightRobin
 --@client
 
--- This will create a render screen using holograms.
--- Making a screen this way means that you do not need to run a render hook 24/7, thus using less clientside cpu time
--- This is especially useful in applications where the screen does not need to be updated very often
+-- This will create a render screen using a hologram.
+-- Also has FPS limiting, which is especially useful in applications where the screen does not need to be updated very often
 
-local scrSize = 69 -- size of the screen in source units
-local FPS = 30 -- how many frames to draw every second
+local scrSize = 69 -- Size of the screen in source units
+local FPS = 60 -- How many frames to draw every second
+
+local next_frame = 0 -- Save when the next frame should happen so we can calculate whether enough time has passed to render another frame
+local fps_delta = 1/FPS -- Calculate how many ms in between frames to be used with fps limiting. (Don't want to constantly recalculate it)
 
 -- Create a render target to draw onto
 render.createRenderTarget("screenRT")
+
 -- Create a new material, we will set the hologram's material to this later
 local screenMat = material.create("UnlitGeneric") 
+
 -- Set the material's texture to the render target that we've just created
 screenMat:setTextureRenderTarget("$basetexture", "screenRT") 
+
 -- Clear the material's flags
 screenMat:setInt("$flags", 0)
 
 -- Create the screen hologram
 local screen = holograms.create(chip():localToWorld(Vector(0, 0, scrSize/2)), Angle(90,-90,0), "models/holograms/plane.mdl")
-screen:setSize(Vector(scrSize, scrSize, scrSize))    
+screen:setSize(Vector(scrSize, scrSize, scrSize))
 screen:setParent(chip())
 
 -- Set the screen hologram's material to the material that we created earlier
 screen:setMaterial("!" .. screenMat:getName())
 
--- create a function to update the screen, in future we will call this whenever the screen needs to be updated
-local function updateScreen()
-    -- create a renderoffscreen hook, no need for a render hook as we are not drawing to a hud/screen
-    hook.add("renderoffscreen","",function()
-        hook.remove("renderoffscreen","") -- remove the hook since we only want it to draw a single frame per call of this function
-        render.selectRenderTarget("screenRT") -- select our render target
-        render.clear() -- clear the screen, if we don't do this then whatever we draw will be drawn on top of our last frame
-        
-        -- do all your drawing from here on as you would normally with a regular screen
-        -- keep in mind that we are using a render target which is 1024x1024 pixels, whereas a screen would be 512x512 pixels
-        -- draw a funky box that oscillates back and forth in the middle of the screen.
-        render.setColor(Color(math.random(100, 255), math.random(100, 255), math.random(100, 255)))
-        render.drawRect(math.sin(timer.curtime() * 2) * 380 + (512 - 100), 512 / 2, 200, 400)
-    end)
-end
+-- Create a renderoffscreen hook, no need for a render hook as we are not drawing to a hud/screen
+-- This hook always runs since we can't tell the game when the holo screen needs to render.
+hook.add("renderoffscreen", "", function()
+    -- Limit the FPS by calculating the time in between frames to see if we should render another frame
+    local now = timer.systime()
+    if next_frame > now then return end
+    next_frame = now + fps_delta
+    -- You can also get difference in these frames by subtracting now from last_frame,
+    -- Or if you only need that, just use timer.frametime rather than storing the frames.
 
--- create a timer to update the screen FPS times a second
-timer.create("updateScreen", 1/FPS, 0, updateScreen)
+    render.selectRenderTarget("screenRT") -- select our render target
+    render.clear() -- clear the screen, if we don't do this then whatever we draw will be drawn on top of our last frame
+    
+    -- Do all your drawing from here on as you would normally with a regular screen
+    -- Keep in mind that we are using a render target which is 1024x1024 pixels, whereas a screen would be 512x512 pixels
+    -- Draw a funky box that oscillates back and forth in the middle of the screen.
+    render.setColor(Color(math.random(100, 255), math.random(100, 255), math.random(100, 255)))
+    render.drawRect(math.sin(now * 2) * 380 + (512 - 100), 512 / 2, 200, 400)
+end)

--- a/lua/starfall/examples/setpos_methods.lua
+++ b/lua/starfall/examples/setpos_methods.lua
@@ -23,37 +23,45 @@ The greenbox has setPos on the physicsObject.
 
 ]]--
 
---ignore this bit, it's for creating the prop
-function create( c )
-    p = prop.create( Vector( 0), Angle( 0 ), "models/props_junk/wood_crate001a.mdl", 1 )
+-- Ignore this bit, it's for creating the prop
+local function create( c )
+    p = prop.create( Vector(0), Angle(0), "models/props_junk/wood_crate001a.mdl", 1 )
     p:setColor( c ) 
     return p
 end
 
---hook
-hook.add( "tick", "runtime", function() 
-    --movement code
-    Motion = chip():getPos() + Vector( math.sin( timer.systime() * 4 ) * 64, 0, 48 )
-    --spawns prop when it doesn't exist
-    normal = ( ( not normal or not normal:isValid() ) and prop.canSpawn() ) and create( Color( 255, 0, 0, 255 ) ) or normal        
-    --check
-    if normal and normal:isValid() and normal:isValidPhys() then
-        
-        --This is setpos WITHOUT getting the entities getPhysicsObject()
-        --There is NO interpolation!
-        normal:setPos( Motion )
-    end
-    --movement code
-    Motion = Motion + Vector( 0, 0, 48 ) 
-    --spawns prop when it doesn't exist
-    normalandphys = ( ( not normalandphys or not normalandphys:isValid() ) and prop.canSpawn() ) and create( Color( 0, 255, 0, 255 ) ) or normalandphys        
-    --check
-    if normalandphys and normalandphys:isValid() and normalandphys:isValidPhys() then
-        
-        --This is setpos With getting the entities getPhysicsObject()
-        --Interpolation will work!
-        normalandphys:getPhysicsObject():setPos( Motion )
-        --            __________________
+-- Localize our variables, makes code more efficient
+local smooth, normal
+
+-- Change prop positions every tick
+hook.add( "tick", "runtime", function()
+    -- Movement code
+    local motion = chip():getPos() + Vector( math.sin( timer.systime() * 4 ) * 64, 0, 48 )
+    
+    -- Spawns prop when it doesn't exist
+    
+    -- If the prop exists, setPos to the movement else try and respawn it
+    if normal and normal:isValid() then
+        -- This is setpos WITHOUT getting the entities getPhysicsObject()
+        -- There is NO interpolation!
+        normal:setPos( motion )
+    else
+        if prop.canSpawn() then
+            normal = create( Color( 255, 0, 0, 255) )
+        end
     end
     
-end )
+    -- Movement code
+    motion = motion + Vector( 0, 0, 48 ) 
+    
+    -- If the prop exists, set the physobj position to the movement else try and respawn it
+    if smooth and smooth:isValid() and smooth:isValidPhys() then
+        -- This is setpos With getting the entities getPhysicsObject()
+        -- Interpolation will work!
+        smooth:getPhysicsObject():setPos( motion )
+    else
+        if prop.canSpawn() then
+            smooth = create( Color( 0, 255, 0, 255) )
+        end
+    end
+end)


### PR DESCRIPTION
* Added a more basic middleclass example with subclasses, references tcpclient and fireplace for real uses for classes in SF.

* Heavily modified holoScreen.lua, it was very inefficient and created a hook each frame which should definitely not be done. It now uses timer.systime to limit fps. It should be noted the new example uses like ~5 more us but that's just because the old example wouldn't actually ever go past ~30fps.

* Made setpos_methods.lua simpler since the ternary stuff for prop creation might be confusing. Also localized variables where needed for speed

All of these are more efficient now, and I changed the coding style a bit to be more readable for comments and whitespace in calls