### PR TITLE
Add 'identifier' keyword to editor themes as well as separate constant values from keywords

### DIFF
--- a/lua/starfall/editor/syntaxmodes/starfall.lua
+++ b/lua/starfall/editor/syntaxmodes/starfall.lua
@@ -34,9 +34,9 @@ local keywords = {
 	["and"] = kwCanParenthesis,
 	["or"] = kwCanParenthesis,
 	["not"] = kwCanParenthesis,
-	["do"] = kwCanParenthesis,
 
 	-- keywords that cannot be followed by a "(":
+	["do"] = kwNoParenthesis,
 	["goto"] = kwNoParenthesis,
 	["else"] = kwNoParenthesis,
 	["break"] = kwNoParenthesis,

--- a/lua/starfall/editor/tabhandlers/tab_wire.lua
+++ b/lua/starfall/editor/tabhandlers/tab_wire.lua
@@ -116,6 +116,9 @@ local function createWireLibraryMap()
 			libMap.Methods[methodname] = true
 		end
 	end
+	for methodname, val in pairs(SF.Docs.Libraries.string.methods) do
+		libMap.Methods[methodname] = true
+	end
 	for libname, lib in pairs(SF.Docs.Libraries) do
 		local tbl
 		if libname == "builtins" then

--- a/lua/starfall/editor/themes.lua
+++ b/lua/starfall/editor/themes.lua
@@ -184,7 +184,7 @@ local function parseTextMate(text)
 		["Constant"] = { "constant", "directive" },
 		["Constants"] = { "constant", "directive" },
 		["Function name"] = { "function", "userfunction", "method" },
-		["Funtion"] = { "function", "userfunction", "method" },
+		["Function"] = { "function", "userfunction", "method" },
 		["Library function"] = { "function", "userfunction", "method" },
 		["String"] = { "string" },
 		["Number"] = { "number" },
@@ -192,6 +192,7 @@ local function parseTextMate(text)
 		["Class name"] = { "library" },
 		["Operators"] = { "operator" },
 		["Storage type"] = { "storageType" },
+		["Variable"] = { "identifier" }
 	}
 
 	local newmap = {}
@@ -211,9 +212,10 @@ local function parseTextMate(text)
 		if not v.name then continue end
 		local names = string.Explode(",",v.name:gsub("%s",""):lower())
 		for _,name in pairs(names) do
-			if map [name] then
-				debugPrint("Parsing %q as %s", name, table.concat(map[name], ","))
-				for k, v in pairs(map[name]) do
+			local token = map[name] -- Potential token
+			if token then
+				debugPrint("Parsing %q as %s", name, table.concat(token, ","))
+				for k, v in pairs(token) do
 					tbl[v] = { foreground, background, fontStyle }
 				end
 			else
@@ -276,6 +278,7 @@ SF.Editor.Themes.AddTheme("default", {
 	["bracket"] = { Color(230, 230, 230), nil, 0 },
 	["userfunction"] = { Color(166, 226, 42), nil, 0 },
 	["constant"] = { Color(174, 129, 255), nil, 0 },
+	["identifier"] = { Color(230, 230, 230), nil, 0 }
 })
 
 SF.Editor.Themes.Load()


### PR DESCRIPTION
* Any text that can be a variable is now an 'identifier'. Same default color as 'notfound'
* _G, self, ..., nil, true and false are now constants.
* String methods will now highlight when using colon syntax sugar
* Added 'Variable' type for textmate themes, changes 'identifier' color

Previews:
![](https://cdn.discordapp.com/attachments/818295480932892693/832041408248283165/unknown.png)
With a theme I made
![](https://cdn.discordapp.com/attachments/818295480932892693/832043709574414376/unknown.png)