### PR TITLE
Fix script error when a directory has an invalid name in data/starfall or data/sf_filedata

### DIFF
--- a/lua/starfall/editor/sfderma.lua
+++ b/lua/starfall/editor/sfderma.lua
@@ -247,6 +247,8 @@ end
 local function addFiles(search, dir, node)
 	local found = false
 	local allFiles, allFolders = file.Find(dir .. "/*", "DATA")
+	allFiles = allFiles or {}
+	allFolders = allFolders or {}
 	sort(allFiles)
 	sort(allFolders)
 	if search=="" then


### PR DESCRIPTION
Previously, if Starfall encountered an invalid directory (for which [`file.Find`](https://wiki.facepunch.com/gmod/file.Find) would return `nil, nil` for) while populating the editor file list, it would spam script errors and make the entire screen black.
Example of invalid path:
`ì╖ò¬ùp`
![Screenshot](https://user-images.githubusercontent.com/70858634/118010781-58ca2b80-b31d-11eb-930f-32da82f60a4b.png)
On a related note, populating the file list should be asynchronous. The game freezes for around 5 seconds every time I open the editor due to how many files I have.