### PR TITLE
Allow variables with repeat, continue, until in them / Make the checker more exact

### DIFF
--- a/lua/starfall/sflib.lua
+++ b/lua/starfall/sflib.lua
@@ -636,7 +636,10 @@ end
 
 --- Compile String but fix a compile error.
 function SF.CompileString(script, identifier, handle_error)
-	if script:match("repeat%s.*continue[;%s].*[%);%s\"']until[(%s\"']") then
+	if
+		script:match("[^%w%d_]repeat[^%w%d_].*[^%w%d_]continue[^%w%d_].*[^%w%d_]until[^%w%d_]")
+		or script:match("[^%w%d_]repeat[^%w%d_]+continue[^%w%d_]+until[^%w%d_]")
+	then
 		return "Using 'continue' in a repeat-until loop has been banned due to a glua bug."
 	end
 	return CompileString(script, identifier, handle_error)

--- a/lua/starfall/sflib.lua
+++ b/lua/starfall/sflib.lua
@@ -634,8 +634,13 @@ function SF.Require(moduleName)
 	return false
 end
 
--- Alias in case we need to patch a compilation bug or something.
-SF.CompileString = CompileString
+--- Compile String but fix a compile error.
+function SF.CompileString(script, identifier, handle_error)
+	if script:match("repeat%s.*continue[;%s].*[%);%s\"']until[(%s\"']") then
+		return "Using 'continue' in a repeat-until loop has been banned due to a glua bug."
+	end
+	return CompileString(script, identifier, handle_error)
+end
 
 --- The safest write file function
 function SF.FileWrite(path, data)

--- a/lua/starfall/sflib.lua
+++ b/lua/starfall/sflib.lua
@@ -637,8 +637,8 @@ end
 --- Compile String but fix a compile error.
 function SF.CompileString(script, identifier, handle_error)
 	if
-		script:match("[^%w%d_]repeat[^%w%d_].*[^%w%d_]continue[^%w%d_].*[^%w%d_]until[^%w%d_]")
-		or script:match("[^%w%d_]repeat[^%w%d_]+continue[^%w%d_]+until[^%w%d_]")
+		script:match("repeat[^%w%d_].*[^%w%d_]continue[^%w%d_].*[^%w%d_]until[^%w%d_]")
+		or script:match("repeat[^%w%d_]+continue[^%w%d_]+until[^%w%d_]")
 	then
 		return "Using 'continue' in a repeat-until loop has been banned due to a glua bug."
 	end

--- a/lua/starfall/sflib.lua
+++ b/lua/starfall/sflib.lua
@@ -636,10 +636,7 @@ end
 
 --- Compile String but fix a compile error.
 function SF.CompileString(script, identifier, handle_error)
-	if
-		script:match("repeat[^%w%d_].*[^%w%d_]continue[^%w%d_].*[^%w%d_]until[^%w%d_]")
-		or script:match("repeat[^%w%d_]+continue[^%w%d_]+until[^%w%d_]")
-	then
+	if string.match(script "%f[%w_]repeat%f[^%w_].*%f[%w_]continue%f[^%w_].*%f[%w_]until%f[^%w_]") then
 		return "Using 'continue' in a repeat-until loop has been banned due to a glua bug."
 	end
 	return CompileString(script, identifier, handle_error)

--- a/lua/starfall/sflib.lua
+++ b/lua/starfall/sflib.lua
@@ -634,13 +634,8 @@ function SF.Require(moduleName)
 	return false
 end
 
-
-function SF.CompileString(str, name, handle)
-	if string.find(str, "repeat.*continue.*until") then
-		return "Due to a glua bug. Use of the string 'continue' in repeat-until loops has been banned"
-	end
-	return CompileString(str, name, handle)
-end
+-- Alias in case we need to patch a compilation bug or something.
+SF.CompileString = CompileString
 
 --- The safest write file function
 function SF.FileWrite(path, data)


### PR DESCRIPTION
The glua bug that came with the continue keyword should've been fixed like ~February and I can't reproduce the bug from https://gist.github.com/CapsAdmin/89093e968353a44b4ef8f3a860a58014. (Just prints "this should run once" and then exits properly as expected.)

https://github.com/Facepunch/garrysmod-issues/issues/4802

The find was super restrictive so you couldn't even use comments/variables/strings with the keywords in it so this will help a lot. If you can reproduce it i'll just edit this to change the pattern so it doesn't match most variables at least..