### PR TITLE
Add installation instructions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,5 +1,15 @@
 Starfall Scripting Environment
 ----------
+### Installation
+
+1. Download source code `Code > Download Zip`
+2. Extract zip contents `StarfallEx-master` to Garry's Mod addons
+
+```
+C:\path\to\Steam\steamapps\common\GarrysMod\garrysmod\addons
+```
+
+### Resources
 
 - Discord Server: [`https://discord.gg/yFBU8PU`](https://discord.gg/yFBU8PU)
 - Documentation: [`http://thegrb93.github.io/StarfallEx/`](http://thegrb93.github.io/StarfallEx/)


### PR DESCRIPTION
If you're smart, unlike me, you can _probably_ deduce the fact that this repo is the direct addon files. Notably from the `addon.txt` file. But if you're not smart, or didn't look too closely at the repo, you're bound to search "install" in the Discord and find: 
https://discord.com/channels/268423739123826688/280721129176563713/833069933784858665

Promptly followed by a facepalm.