### PR TITLE
Add Midi Library

### DIFF
--- a/lua/starfall/libs_cl/midi.lua
+++ b/lua/starfall/libs_cl/midi.lua
@@ -7,7 +7,7 @@ if not SF.Require("midi") then return function() end end
 SF.RegisterLibrary("midi")
 
 return function(instance)
--- Only usable by the owner of the starfal chip
+-- Only usable by the owner of the starfall chip
 if LocalPlayer() ~= instance.player then return end
 
 local midi_library = instance.Libraries.midi
@@ -15,7 +15,7 @@ local midi_library = instance.Libraries.midi
 -- Event hook for midi
 -- @class hook
 -- @client
--- @lib_tbl midi_library
+-- @libtbl midi_library
 -- @param number time the exact systime which the event occured
 -- @param number command the command code of the event.  First 4 bits are the command code and last 4 are the channel
 -- @param varargs the different parameters of the midi event.  Can have 1 or more.

--- a/lua/starfall/libs_cl/midi.lua
+++ b/lua/starfall/libs_cl/midi.lua
@@ -47,7 +47,9 @@ SF.hookAdd("MIDI", "midi")
 -- @return string the name of the midi device opened at the given port.
 function midi_library.openPort(port)
 	checkluatype(port, TYPE_NUMBER)
-	if midi_library.isPortOpen(port) then return end
+	if midi_library.isPortOpen(port) then 
+		SF.Throw("This port is already open!")
+	end
 	return midi.Open(port)
 end
 

--- a/lua/starfall/libs_cl/midi.lua
+++ b/lua/starfall/libs_cl/midi.lua
@@ -1,6 +1,9 @@
 if not SF.Require("midi") then return function() end end
 
---Midi Library
+local checkluatype = SF.CheckLuaType
+
+-- Midi Library
+-- Polls midi event information from midi devices.
 -- @name midi
 -- @class library
 -- @libtbl midi_library
@@ -12,71 +15,70 @@ if LocalPlayer() ~= instance.player then return end
 
 local midi_library = instance.Libraries.midi
 
--- Event hook for midi
+-- Event hook for midi devices.  Everytime a midi device outputs a signal, the callback function on the hook is called.
 -- @class hook
 -- @client
 -- @libtbl midi_library
 -- @param number time the exact systime which the event occured
 -- @param number command the command code of the event.  First 4 bits are the command code and last 4 are the channel
--- @param varargs the different parameters of the midi event.  Can have 1 or more.
+-- @param ... number parameters.  Each command has their own set of parameters, see below
+-- Commands and their parameters:
+-- 0x80 "NOTE_OFF" : param1 = key, param2 = velocity
+-- 0x90 "NOTE_ON" : param1 = key, param2 = velocity
+-- 0xA0 "AFTERTOUCH" : param1 = key, param2 = touch
+-- 0xB0 "CONTINUOUS_CONTROLLER" : param1 = button_number, param2 = button_value
+-- 0xC0 "PATCH_CHANGE" : param1 = patch number
+-- 0xD0 "CHANNEL_PRESSURE" : param1 = pressure
+-- 0xE0 "PITCH_BEND" : param1 = lsb(least signifigant byte), param2 = msb(most signifigant byte)
 SF.hookAdd("MIDI", "midi")
 
--- Gets a table of all midi devices' ports.
--- @return table table of all midi ports.
-function midi_library.getPorts()
-    return midi.GetPorts()
-end
-
 -- Opens the midi port to make it available to grab events from.  This must be called before the hook.
--- @param number portNumber the midi port to open.
+-- @param number port the midi port to open. Passing nothing defaults to 0.
 -- @return string the name of the midi device opened at the given port.
-function midi_library.openPort(portNumber)
-    local portNumber = portNumber or 0
-    if midi.IsOpened(portNumber) then
-        midi.Close(portNumber)
+function midi_library.openPort(port)
+    checkluatype(port, TYPE_NUMBER)
+    if midi_library.isPortOpen(port) then
+        midi_library.closePort(port)
     end
-    return midi.Open(portNumber)
+    return midi.Open(port)
 end
 
 -- Checks if the midi port is currently opened.
 -- @return boolean if the port is open
-function midi_library.isPortOpened(portNumber)
-    return midi.IsOpened(portNumber)
+function midi_library.isPortOpen(port)
+    checkluatype(port, TYPE_NUMBER)
+    return midi.IsOpened(port)
 end
 
--- Closes the midi port
--- @param number portNumber the midi port to close.
+-- Closes the midi port. Checks if they are open to prevent binary library failure.
+-- @param number port the midi port to close.
 -- @return string the name of the midi device closed at the given port.
-function midi_library.closePort(portNumber)
-    return midi.Close(portNumber)
+function midi_library.closePort(port)
+    if not midi_library.isPortOpen(port) then return end
+    return midi.Close(port)
 end
 
--- Closes all midi ports.  Only closes them if they are open.
+-- Closes all midi ports.
 function midi_library.closeAllPorts()
-    local midiPorts = midi.GetPorts()
-    for k, v in pairs(midiPorts) do
-        if midi.IsOpened(k) then
-            midi.Close(k)
-        end
+    for k, v in pairs(midi_library.getPorts()) do
+        midi_library.closePort(k)
     end
 end
 
+-- Gets a table of all midi devices' ports.
+-- @return table table of all midi ports.
+midi_library.getPorts = midi.GetPorts
+
 -- Grabs the current midi command code from the command. Essentially does: bit.band(command, 0xF0)
 -- @return number the command code
-function midi_library.getCommandCode(command)
-    return midi.GetCommandCode(command)
-end
+midi_library.getCommandCode = midi.GetCommandCode
 
--- Grabs the current midi channel from the command. Essentially does: bit.band(command, 0x0F)
+-- Grabs the current midi channel from the command. Essentially does: bit.rshift(command, 8)
 -- @return number the midi channel
-function midi_library.getCommandChannel(command)
-    return midi.GetCommandChannel(command)
-end
+midi_library.getCommandChannel = midi.GetCommandChannel
 
 -- Grabs the command code in a readable name.
 -- @return string command name
-function midi_library.getCommandName(command)
-    return midi.GetCommandName(command)
-end
+midi_library.getCommandName = midi.GetCommandName
 
 end

--- a/lua/starfall/libs_cl/midi.lua
+++ b/lua/starfall/libs_cl/midi.lua
@@ -23,13 +23,13 @@ local midi_library = instance.Libraries.midi
 -- @param number command the command code of the event.  First 4 bits are the command code and last 4 are the channel
 -- @param number ... Each command has their own set of parameters, see below
 -- Commands and their parameters:
--- 0x80 "NOTE_OFF" : param1 = key, param2 = velocity
--- 0x90 "NOTE_ON" : param1 = key, param2 = velocity
--- 0xA0 "AFTERTOUCH" : param1 = key, param2 = touch
--- 0xB0 "CONTINUOUS_CONTROLLER" : param1 = button_number, param2 = button_value
--- 0xC0 "PATCH_CHANGE" : param1 = patch number
--- 0xD0 "CHANNEL_PRESSURE" : param1 = pressure
--- 0xE0 "PITCH_BEND" : param1 = lsb(least signifigant byte), param2 = msb(most signifigant byte)
+-- 0x80 "NOTE_OFF"              : param1 = key                         param2 = velocity
+-- 0x90 "NOTE_ON"               : param1 = key                         param2 = velocity
+-- 0xA0 "AFTERTOUCH"            : param1 = key                         param2 = touch
+-- 0xB0 "CONTINUOUS_CONTROLLER" : param1 = button_number               param2 = button_value
+-- 0xC0 "PATCH_CHANGE"          : param1 = patch number
+-- 0xD0 "CHANNEL_PRESSURE"      : param1 = pressure
+-- 0xE0 "PITCH_BEND"            : param1 = lsb(least signifigant bit)  param2 = msb(most signifigant bit)
 SF.hookAdd("MIDI", "midi")
 
 -- Opens the midi port to make it available to grab events from.  This must be called before the hook.

--- a/lua/starfall/libs_cl/midi.lua
+++ b/lua/starfall/libs_cl/midi.lua
@@ -4,6 +4,9 @@ local checkluatype = SF.CheckLuaType
 
 --- Midi Library
 -- Polls midi event information from midi devices.
+-- Requires a custom binary -> https://github.com/FPtje/gmcl_midi/releases/tag/v0.2.0
+-- GNU/Linux and MacOS users will have to compile their own binaries, as the ones provided in the release section are outdated.
+-- Instructions here -> https://github.com/FPtje/gmcl_midi/blob/master/Compiling.md
 -- @name midi
 -- @class library
 -- @libtbl midi_library

--- a/lua/starfall/libs_cl/midi.lua
+++ b/lua/starfall/libs_cl/midi.lua
@@ -21,22 +21,25 @@ instance:AddHook("deinitialize", function()
 	midi_library.closeAllPorts()
 end)
 
---- Event hook for midi devices.  Everytime a midi device outputs a signal, the callback function on the hook is called. Look at ENUMS
+--- Event hook for midi devices.  
+-- Everytime a midi device outputs a signal, the callback function on the hook is called.
+-- Read up on the MIDI protocol to make better sense of everything -> https://ccrma.stanford.edu/~craig/articles/linuxmidi/misc/essenmidi.html
 -- @name midi
 -- @class hook
 -- @client
 -- @libtbl midi_library
 -- @param number time the exact systime which the event occured
 -- @param number command the command code of the event.  First 4 bits are the command code and last 4 are the channel
--- @param ...number parameters Each command has their own set of parameters, see below
+-- @param number param1 Each command has their own set of parameters, see above
+-- @param number param2 Each command has their own set of parameters, see above
 -- Commands and their parameters:
--- 0x80 "NOTE_OFF"              : param1 = key                         param2 = velocity
--- 0x90 "NOTE_ON"               : param1 = key                         param2 = velocity
--- 0xA0 "AFTERTOUCH"            : param1 = key                         param2 = touch
--- 0xB0 "CONTINUOUS_CONTROLLER" : param1 = button_number               param2 = button_value
--- 0xC0 "PATCH_CHANGE"          : param1 = patch number
--- 0xD0 "CHANNEL_PRESSURE"      : param1 = pressure
--- 0xE0 "PITCH_BEND"            : param1 = lsb(least signifigant bit)  param2 = msb(most signifigant bit)
+-- 0x80 NOTE_OFF              : param1 = key;                         param2 = velocity
+-- 0x90 NOTE_ON               : param1 = key;                         param2 = velocity
+-- 0xA0 AFTERTOUCH            : param1 = key;                         param2 = touch
+-- 0xB0 CONTINUOUS_CONTROLLER : param1 = button_number;               param2 = button_value
+-- 0xC0 PATCH_CHANGE          : param1 = patch number;
+-- 0xD0 CHANNEL_PRESSURE      : param1 = pressure;
+-- 0xE0 PITCH_BEND            : param1 = lsb(least signifigant bit);  param2 = msb(most signifigant bit)
 SF.hookAdd("MIDI", "midi")
 
 --- Opens the midi port to make it available to grab events from.  This must be called before the hook.

--- a/lua/starfall/libs_cl/midi.lua
+++ b/lua/starfall/libs_cl/midi.lua
@@ -2,7 +2,7 @@ if not SF.Require("midi") then return function() end end
 
 local checkluatype = SF.CheckLuaType
 
--- Midi Library
+--- Midi Library
 -- Polls midi event information from midi devices.
 -- @name midi
 -- @class library
@@ -18,10 +18,10 @@ local midi_library = instance.Libraries.midi
 -- Close all ports when SF chip is deleted
 -- Ensures that the midi port can still be used in other applications after the SF chip is deleted
 instance:AddHook("deinitialize", function()
-    midi_library.closeAllPorts()
+	midi_library.closeAllPorts()
 end)
 
--- Event hook for midi devices.  Everytime a midi device outputs a signal, the callback function on the hook is called.
+--- Event hook for midi devices.  Everytime a midi device outputs a signal, the callback function on the hook is called. Look at ENUMS
 -- @class hook
 -- @client
 -- @libtbl midi_library
@@ -38,50 +38,60 @@ end)
 -- 0xE0 "PITCH_BEND"            : param1 = lsb(least signifigant bit)  param2 = msb(most signifigant bit)
 SF.hookAdd("MIDI", "midi")
 
--- Opens the midi port to make it available to grab events from.  This must be called before the hook.
+--- Opens the midi port to make it available to grab events from.  This must be called before the hook.
 -- @param number port the midi port to open. Passing nothing defaults to 0.
 -- @return string the name of the midi device opened at the given port.
 function midi_library.openPort(port)
-    checkluatype(port, TYPE_NUMBER)
-    if midi_library.isPortOpen(port) then return end
-    return midi.Open(port)
+	checkluatype(port, TYPE_NUMBER)
+	if midi_library.isPortOpen(port) then return end
+	return midi.Open(port)
 end
 
--- Checks if the midi port is currently opened.
+--- Checks if the specified midi port is currently opened.
 -- @return boolean if the port is open
 function midi_library.isPortOpen(port)
-    checkluatype(port, TYPE_NUMBER)
-    return midi.IsOpened(port)
+	checkluatype(port, TYPE_NUMBER)
+	return midi.IsOpened(port)
 end
 
--- Closes the midi port. Checks if they are open to prevent binary library failure.
+--- Closes the specified midi port.
 -- @param number port the midi port to close.
 -- @return string the name of the midi device closed at the given port.
 function midi_library.closePort(port)
-    if not midi_library.isPortOpen(port) then return end
-    return midi.Close(port)
+	if not midi_library.isPortOpen(port) then 
+		SF.Throw("This port is not open!", 2)
+	end
+	return midi.Close(port)
 end
 
--- Closes all midi ports.
+--- Closes all midi ports.
 function midi_library.closeAllPorts()
-    for k, v in pairs(midi_library.getPorts()) do
-        midi_library.closePort(k)
-    end
+	for k, v in pairs(midi_library.getPorts()) do
+		midi_library.closePort(k)
+	end
 end
 
--- Gets a table of all midi devices' ports.
+--- Gets a table of all midi devices' ports.
+-- @name midi_library.getPorts
+-- @class function
 -- @return table the table of midi ports.  Starts at index 0
 midi_library.getPorts = midi.GetPorts
 
--- Grabs the current midi command code from the command. Essentially does: bit.band(command, 0xF0)
+--- Grabs the current midi command code from the command. Essentially does: bit.band(command, 0xF0)
+-- @name midi_library.getCommandCode
+-- @class function
 -- @return number the command code
 midi_library.getCommandCode = midi.GetCommandCode
 
--- Grabs the current midi channel from the command. Essentially does: bit.rshift(command, 8)
+--- Grabs the current midi channel from the command. Essentially does: bit.rshift(command, 8)
+-- @name midi_library.getCommandChannel
+-- @class function
 -- @return number the midi channel
 midi_library.getCommandChannel = midi.GetCommandChannel
 
--- Grabs the command code in a readable name.
+--- Grabs the command code in a readable name.
+-- @name midi_library.getCommandName
+-- @class function
 -- @return string command name
 midi_library.getCommandName = midi.GetCommandName
 

--- a/lua/starfall/libs_cl/midi.lua
+++ b/lua/starfall/libs_cl/midi.lua
@@ -5,7 +5,7 @@ local checkluatype = SF.CheckLuaType
 --- Midi Library
 -- Polls midi event information from midi devices.
 -- Requires a custom binary -> https://github.com/FPtje/gmcl_midi/releases/tag/v0.2.0
--- GNU/Linux and MacOS users will have to compile their own binaries, as the ones provided in the release section are outdated.
+-- GNU/Linux and MacOS users will have to compile their own binaries.
 -- Instructions here -> https://github.com/FPtje/gmcl_midi/blob/master/Compiling.md
 -- @name midi
 -- @class library

--- a/lua/starfall/libs_cl/midi.lua
+++ b/lua/starfall/libs_cl/midi.lua
@@ -15,6 +15,12 @@ if LocalPlayer() ~= instance.player then return end
 
 local midi_library = instance.Libraries.midi
 
+-- Close all ports when SF chip is deleted
+-- Ensures that the midi port can still be used in other applications after the SF chip is deleted
+instance:AddHook("deinitialize", function()
+    midi_library.closeAllPorts()
+end)
+
 -- Event hook for midi devices.  Everytime a midi device outputs a signal, the callback function on the hook is called.
 -- @class hook
 -- @client
@@ -37,9 +43,7 @@ SF.hookAdd("MIDI", "midi")
 -- @return string the name of the midi device opened at the given port.
 function midi_library.openPort(port)
     checkluatype(port, TYPE_NUMBER)
-    if midi_library.isPortOpen(port) then
-        midi_library.closePort(port)
-    end
+    if midi_library.isPortOpen(port) then return end
     return midi.Open(port)
 end
 

--- a/lua/starfall/libs_cl/midi.lua
+++ b/lua/starfall/libs_cl/midi.lua
@@ -21,7 +21,7 @@ local midi_library = instance.Libraries.midi
 -- @libtbl midi_library
 -- @param number time the exact systime which the event occured
 -- @param number command the command code of the event.  First 4 bits are the command code and last 4 are the channel
--- @param ... number parameters.  Each command has their own set of parameters, see below
+-- @param number ... Each command has their own set of parameters, see below
 -- Commands and their parameters:
 -- 0x80 "NOTE_OFF" : param1 = key, param2 = velocity
 -- 0x90 "NOTE_ON" : param1 = key, param2 = velocity
@@ -66,7 +66,7 @@ function midi_library.closeAllPorts()
 end
 
 -- Gets a table of all midi devices' ports.
--- @return table table of all midi ports.
+-- @return table the table of midi ports.  Starts at index 0
 midi_library.getPorts = midi.GetPorts
 
 -- Grabs the current midi command code from the command. Essentially does: bit.band(command, 0xF0)

--- a/lua/starfall/libs_cl/midi.lua
+++ b/lua/starfall/libs_cl/midi.lua
@@ -58,9 +58,7 @@ end
 -- @param number port the midi port to close.
 -- @return string the name of the midi device closed at the given port.
 function midi_library.closePort(port)
-	if not midi_library.isPortOpen(port) then 
-		SF.Throw("This port is not open!", 2)
-	end
+	if not midi_library.isPortOpen(port) then return end
 	return midi.Close(port)
 end
 

--- a/lua/starfall/libs_cl/midi.lua
+++ b/lua/starfall/libs_cl/midi.lua
@@ -79,22 +79,25 @@ midi_library.getPorts = midi.GetPorts
 -- @return string the name of the midi device closed at the given port.
 midi_library.closePort = midi.Close
 
---- Grabs the current midi command code from the command. Essentially does: bit.band(command, 0xF0)
--- @name midi_library.getCommandCode
+--- Grabs the midi command code from the command.
+-- @name midi_library.getCode
 -- @class function
+-- @param number command the command
 -- @return number the command code
-midi_library.getCommandCode = midi.GetCommandCode
+midi_library.getCode = midi.GetCommandCode
 
---- Grabs the current midi channel from the command. Essentially does: bit.rshift(command, 8)
--- @name midi_library.getCommandChannel
+--- Grabs the midi channel from the command.
+-- @name midi_library.getChannel
 -- @class function
+-- @param number command the command
 -- @return number the midi channel
-midi_library.getCommandChannel = midi.GetCommandChannel
+midi_library.getChannel = midi.GetCommandChannel
 
 --- Grabs the command code in a readable name.
--- @name midi_library.getCommandName
+-- @name midi_library.getName
 -- @class function
+-- @param number command the command
 -- @return string command name
-midi_library.getCommandName = midi.GetCommandName
+midi_library.getName = midi.GetCommandName
 
 end

--- a/lua/starfall/libs_cl/midi.lua
+++ b/lua/starfall/libs_cl/midi.lua
@@ -22,6 +22,7 @@ instance:AddHook("deinitialize", function()
 end)
 
 --- Event hook for midi devices.  Everytime a midi device outputs a signal, the callback function on the hook is called. Look at ENUMS
+-- @name midi
 -- @class hook
 -- @client
 -- @libtbl midi_library
@@ -54,17 +55,10 @@ function midi_library.isPortOpen(port)
 	return midi.IsOpened(port)
 end
 
---- Closes the specified midi port.
--- @param number port the midi port to close.
--- @return string the name of the midi device closed at the given port.
-function midi_library.closePort(port)
-	if not midi_library.isPortOpen(port) then return end
-	return midi.Close(port)
-end
-
 --- Closes all midi ports.
 function midi_library.closeAllPorts()
 	for k, v in pairs(midi_library.getPorts()) do
+		if not midi_library.isPortOpen(k) then continue end
 		midi_library.closePort(k)
 	end
 end
@@ -74,6 +68,13 @@ end
 -- @class function
 -- @return table the table of midi ports.  Starts at index 0
 midi_library.getPorts = midi.GetPorts
+
+--- Closes the specified midi port.
+-- @name midi_library.closePort
+-- @class function
+-- @param number port the midi port to close.
+-- @return string the name of the midi device closed at the given port.
+midi_library.closePort = midi.Close
 
 --- Grabs the current midi command code from the command. Essentially does: bit.band(command, 0xF0)
 -- @name midi_library.getCommandCode

--- a/lua/starfall/libs_cl/midi.lua
+++ b/lua/starfall/libs_cl/midi.lua
@@ -21,7 +21,7 @@ local midi_library = instance.Libraries.midi
 -- @libtbl midi_library
 -- @param number time the exact systime which the event occured
 -- @param number command the command code of the event.  First 4 bits are the command code and last 4 are the channel
--- @param number ... Each command has their own set of parameters, see below
+-- @param ...number parameters Each command has their own set of parameters, see below
 -- Commands and their parameters:
 -- 0x80 "NOTE_OFF"              : param1 = key                         param2 = velocity
 -- 0x90 "NOTE_ON"               : param1 = key                         param2 = velocity

--- a/lua/starfall/libs_cl/midi.lua
+++ b/lua/starfall/libs_cl/midi.lua
@@ -1,0 +1,82 @@
+if not SF.Require("midi") then return function() end end
+
+--Midi Library
+-- @name midi
+-- @class library
+-- @libtbl midi_library
+SF.RegisterLibrary("midi")
+
+return function(instance)
+-- Only usable by the owner of the starfal chip
+if LocalPlayer() ~= instance.player then return end
+
+local midi_library = instance.Libraries.midi
+
+-- Event hook for midi
+-- @class hook
+-- @client
+-- @lib_tbl midi_library
+-- @param number time the exact systime which the event occured
+-- @param number command the command code of the event.  First 4 bits are the command code and last 4 are the channel
+-- @param varargs the different parameters of the midi event.  Can have 1 or more.
+SF.hookAdd("MIDI", "midi")
+
+-- Gets a table of all midi devices' ports.
+-- @return table table of all midi ports.
+function midi_library.getPorts()
+    return midi.GetPorts()
+end
+
+-- Opens the midi port to make it available to grab events from.  This must be called before the hook.
+-- @param number portNumber the midi port to open.
+-- @return string the name of the midi device opened at the given port.
+function midi_library.openPort(portNumber)
+    local portNumber = portNumber or 0
+    if midi.IsOpened(portNumber) then
+        midi.Close(portNumber)
+    end
+    return midi.Open(portNumber)
+end
+
+-- Checks if the midi port is currently opened.
+-- @return boolean if the port is open
+function midi_library.isPortOpened(portNumber)
+    return midi.IsOpened(portNumber)
+end
+
+-- Closes the midi port
+-- @param number portNumber the midi port to close.
+-- @return string the name of the midi device closed at the given port.
+function midi_library.closePort(portNumber)
+    return midi.Close(portNumber)
+end
+
+-- Closes all midi ports.  Only closes them if they are open.
+function midi_library.closeAllPorts()
+    local midiPorts = midi.GetPorts()
+    for k, v in pairs(midiPorts) do
+        if midi.IsOpened(k) then
+            midi.Close(k)
+        end
+    end
+end
+
+-- Grabs the current midi command code from the command. Essentially does: bit.band(command, 0xF0)
+-- @return number the command code
+function midi_library.getCommandCode(command)
+    return midi.GetCommandCode(command)
+end
+
+-- Grabs the current midi channel from the command. Essentially does: bit.band(command, 0x0F)
+-- @return number the midi channel
+function midi_library.getCommandChannel(command)
+    return midi.GetCommandChannel(command)
+end
+
+-- Grabs the command code in a readable name.
+-- @return string command name
+function midi_library.getCommandName(command)
+    return midi.GetCommandName(command)
+end
+
+end

--- a/lua/starfall/libs_sh/enum.lua
+++ b/lua/starfall/libs_sh/enum.lua
@@ -1025,4 +1025,23 @@ env.FSASYNC = {
 	STATUS_UNSERVICED = FSASYNC_STATUS_UNSERVICED
 }
 
+--- Midi Command ENUMS
+-- @name midi_library.MIDI
+-- @class table
+-- @field NOTE_OFF
+-- @field NOTE_ON
+-- @field AFTERTOUCH
+-- @field CONTINUOUS_CONTROLLER
+-- @field PATCH_CHANGE
+-- @field CHANNEL_PRESSURE
+-- @field PITCH_BEND
+env.MIDI = {
+	NOTE_OFF = 0x80,
+	NOTE_ON = 0x90,
+	AFTERTOUCH = 0xA0,
+	CONTINUOUS_CONTROLLER = 0xB0,
+	PATCH_CHANGE = 0xC0,
+	CHANNEL_PRESSURE = 0xD0,
+	PITCH_BEND = 0xE0
+}
 end


### PR DESCRIPTION
My first ever pull request :) 
This is a midi library for use with this GLUA binary: https://github.com/FPtje/gmcl_midi 

The library currently can only poll midi devices because of limitations with the binary itself.  I will eventually update the binary to be able to send midi data to a midi device, when I can figure out what's wrong with the compiler i installed on windows :/ 

I probably need help with getting the documentation to work with it.

To test:
 - First examine the midi ports available with midi.getPorts()
 - Open a midi port with midi.openPort(number)
 - Add the "midi" hook with a callback function that has parameters (time, code, ...)
     * Note that the hook takes in a vararg.  Some midi events have more or less parameters than others.
 - Test polling

Bugs:
As far as I know, everything works bug free.  Could use some polish because I am not the best at Lua. 