### PR TITLE
Add trace.aimVector

### DIFF
--- a/lua/starfall/libs_sh/trace.lua
+++ b/lua/starfall/libs_sh/trace.lua
@@ -174,4 +174,20 @@ function trace_library.pointContents(position)
 	return util.PointContents(vunwrap(position))
 end
 
+--- Calculates the aim vector from a 2D screen position. This is essentially a generic version of input.screenToVector, where you can define the view angles and screen size manually.
+-- @param Angle viewAngles View angles
+-- @param number viewFOV View field of view
+-- @param number x X position on the screen
+-- @param number y Y position on the screen
+-- @param number screenWidth Screen width
+-- @param number screenHeight Screen height
+function trace_library.aimVector(viewAngles, viewFOV, x, y, screenWidth, screenHeight)
+	checkluatype(viewFOV, TYPE_NUMBER)
+	checkluatype(x, TYPE_NUMBER)
+	checkluatype(y, TYPE_NUMBER)
+	checkluatype(screenWidth, TYPE_NUMBER)
+	checkluatype(screenHeight, TYPE_NUMBER)
+	return util.AimVector(aunwrap(viewAngles), viewFOV, x, y, screenWidth, screenHeight)
+end
+
 end

--- a/lua/starfall/libs_sh/trace.lua
+++ b/lua/starfall/libs_sh/trace.lua
@@ -181,13 +181,14 @@ end
 -- @param number y Y position on the screen
 -- @param number screenWidth Screen width
 -- @param number screenHeight Screen height
+-- @return Vector The aim vector
 function trace_library.aimVector(viewAngles, viewFOV, x, y, screenWidth, screenHeight)
 	checkluatype(viewFOV, TYPE_NUMBER)
 	checkluatype(x, TYPE_NUMBER)
 	checkluatype(y, TYPE_NUMBER)
 	checkluatype(screenWidth, TYPE_NUMBER)
 	checkluatype(screenHeight, TYPE_NUMBER)
-	return util.AimVector(aunwrap(viewAngles), viewFOV, x, y, screenWidth, screenHeight)
+	return vwrap(util.AimVector(aunwrap(viewAngles), viewFOV, x, y, screenWidth, screenHeight))
 end
 
 end


### PR DESCRIPTION
```
trace.aimVector(viewAngles, viewFOV, x, y, screenWidth, screenHeight)
```

Calculates the aim vector from a 2D screen position. Does the same as `input.screenToVector`, but you can define the view angles and screen size manually.

_It simply calls util.AimVector._