### PR TITLE
Add syntax highlighting support for single parameter functions with string literal or table literal

### DIFF
--- a/lua/starfall/editor/syntaxmodes/starfall.lua
+++ b/lua/starfall/editor/syntaxmodes/starfall.lua
@@ -442,7 +442,7 @@ function EDITOR:SyntaxColorLine(row)
 						local pos = self.position -- We are saving that, so we can move tokenizer back
 						local c = self.character
 						local td = self.tokendata
-						if self:NextPattern("%s*%(") then -- we are checking if there is ( after name
+						if self:NextPattern("%s*[({'\"]") then -- we are checking if there is ( after name, or if single parameter function with string literal or table literal
 							tokenname = "function"
 							self.position = pos -- We dont want to move tokenizer as we were just checking without parsing
 							self.character = c


### PR DESCRIPTION
As many know, in lua you can call a single parameter function without parenthesis if you use a literal string or table.   I thought Id add syntax highlighting support for this.

Im not sure if this is the best way to add this, but here it is.

To test:
 - Call any function that can take in a string literal or a table literal.  Such as:  
     - require"myfile.txt"
     - print"Hello World" 
     - printTable{"Hello", "World!"}

Bugs:
 - none that I am aware of.