### PR TITLE
Use mode 'rb' instead of 'r' when opening files in editor (fixes #1200)

### DIFF
--- a/lua/starfall/editor/sfframe.lua
+++ b/lua/starfall/editor/sfframe.lua
@@ -1611,7 +1611,7 @@ end
 function Editor:LoadFile(Line, forcenewtab)
 	if not Line or file.IsDir(Line, "DATA") then return end
 
-	local f = file.Open(Line, "r", "DATA")
+	local f = file.Open(Line, "rb", "DATA")
 	if not f then
 		ErrorNoHalt("Erroring opening file: " .. Line)
 	else


### PR DESCRIPTION
The 'b' flag indicates the file should be interpreted as binary data. Not using it can cause problems for certain byte sequences. This resolves issue #1200. Note that this doesn't make *editing* binary files any easier, it just the opportunities for corruption of binary files. Also note that this does not remove the conversion of tabs to spaces or the removal of carriage returns, which should be addressed separately.