### PR TITLE
Validate LZMA header to avoid crashes

### DIFF
--- a/lua/starfall/libs_sh/bit.lua
+++ b/lua/starfall/libs_sh/bit.lua
@@ -637,27 +637,24 @@ end
 --- Decompresses a string using LZMA.
 -- @param string s Compressed string to decode
 -- @return string Decompressed string or nil if the input was invalid
-function bit_library.decompress(s)
+function bit_library.decompress(s, maxSize)
 	checkluatype(s, TYPE_STRING)
+	if maxSize ~= nil then
+		checkluatype(maxSize, TYPE_NUMBER)
+		if maxSize > 1e8 then
+			SF.Throw("specified maximum size is too large")
+		end
+	else
+		maxSize = 1e8
+	end
 	if #s > 1e8 then SF.Throw("String is too long!") end
 	if #s <= 13 then return nil end -- Size of header is 13 bytes, so it can't possibly have any data if it's that size or smaller.
-	local uncompressedSize = string.sub(s, 6, 13)
-	if uncompressedSize == '\xff\xff\xff\xff\xff\xff\xff\xff' then
+	if string.sub(s, 6, 13) == '\xff\xff\xff\xff\xff\xff\xff\xff' then
 		-- "streamed" means the uncompressed size isn't specified in the header.
-		-- XZ Utils will always produce streamed LZMA. Use the older LZMA Utils if you need non-streamed.
-		SF.Throw("streamed LZMA not supported")
+		-- XZ Utils will always produce streamed LZMA. Use the older LZMA Utils or util.Compress if you need non-streamed.
+		SF.Throw("streamed LZMA is not supported")
 	end
-	if string.sub(uncompressedSize, 5, 8) ~= '\x00\x00\x00\x00' then
-		-- 32-bit ints can fit okay in doubles, but 64-bit can't, so just don't even try if it can't be represented as 32-bit.
-		SF.Throw("uncompressed string would be too long")
-	end
-	-- Decode unsigned little-endian 32-bit integer (actually 64-bit, but see previous comment)
-	local b1, b2, b3, b4 = string.byte(uncompressedSize, 1, 4)
-	uncompressedSize = b1+b2*0x100+b3*0x10000+b4*0x1000000
-	if uncompressedSize > 1e8 then
-		SF.Throw("uncompressed string would be too long")
-	end
-	local ret = util.Decompress(s)
+	local ret = util.Decompress(s, maxSize)
 	instance:checkCpu()
 	return ret
 end

--- a/lua/starfall/libs_sh/bit.lua
+++ b/lua/starfall/libs_sh/bit.lua
@@ -623,7 +623,7 @@ function bit_library.stringToTable(s)
 	return SF.StringToTable(s, instance)
 end
 
---- Compresses a string
+--- Compresses a string using LZMA.
 -- @param string s String to compress
 -- @return string Compressed string
 function bit_library.compress(s)
@@ -634,7 +634,7 @@ function bit_library.compress(s)
 	return ret
 end
 
---- Decompresses a string
+--- Decompresses a string using LZMA.
 -- @param string s Compressed string to decode
 -- @return string Decompressed string or nil if the input was invalid
 function bit_library.decompress(s)

--- a/lua/starfall/libs_sh/bit.lua
+++ b/lua/starfall/libs_sh/bit.lua
@@ -625,7 +625,7 @@ end
 
 --- Compresses a string using LZMA.
 -- @param string s String to compress
--- @return string Compressed string
+-- @return string? Compressed string, or nil if compression failed
 function bit_library.compress(s)
 	checkluatype(s, TYPE_STRING)
 	if #s > 1e8 then SF.Throw("String is too long!") end
@@ -635,8 +635,10 @@ function bit_library.compress(s)
 end
 
 --- Decompresses a string using LZMA.
--- @param string s Compressed string to decode
--- @return string Decompressed string or nil if the input was invalid
+-- XZ Utils will always produce streamed (i.e. the decompressed size is not specified in the header) LZMA data. If you're trying to compress data from outside of GMod and then decompress it inside of GMod, it probably won't work unless you use the older, deprecated 'LZMA Utils', or util.Compress.
+-- @param string s String to decompress
+-- @param number? maxSize Maximum allowed size of decompressed data
+-- @return string? Decompressed string, or nil if decompression failed
 function bit_library.decompress(s, maxSize)
 	checkluatype(s, TYPE_STRING)
 	if maxSize ~= nil then
@@ -650,9 +652,7 @@ function bit_library.decompress(s, maxSize)
 	if #s > 1e8 then SF.Throw("String is too long!") end
 	if #s <= 13 then return nil end -- Size of header is 13 bytes, so it can't possibly have any data if it's that size or smaller.
 	if string.sub(s, 6, 13) == '\xff\xff\xff\xff\xff\xff\xff\xff' then
-		-- "streamed" means the uncompressed size isn't specified in the header.
-		-- XZ Utils will always produce streamed LZMA. Use the older LZMA Utils or util.Compress if you need non-streamed.
-		SF.Throw("streamed LZMA is not supported")
+		return nil--, "streamed LZMA is not supported"
 	end
 	local ret = util.Decompress(s, maxSize)
 	instance:checkCpu()


### PR DESCRIPTION
Attempting to decompress LZMA compressed data where the uncompressed size defined in the header is extremely large or undefined (such as in the case of "streamed" files produced by XZ Utils) will cause a crash. This PR prevents that by reading the header and throwing an error if the uncompressed size is not within certain bounds.
This still isn't ideal, as there may be other vulnerabilities in `util.Decompress` we don't know about yet. Ideally, compression and decompression would be implemented in pure Lua, which would result in a much lower chance of vulnerabilities and would allow making it to make use of coroutines like `mesh.createFromObj`, at the possible cost of performance.
Test script (this will cause a crash without the PR!):
```lua
--@shared
if player() ~= owner() then
    return
end
local data = bit.compress("Hello world"):sub(14)
local function hexify(c)
    return string.format("\\x%02x", string.byte(c))
end
local i = 0
local function test(header)
    i = i+1
    print(string.format("testing #%d... %s", i, header:gsub('.', hexify)))
    print(pcall(bit.decompress, header..data))
    local threshold = timer.systime()+1
    while timer.systime() < threshold do
        coroutine.yield()
    end
end
local thread = coroutine.wrap(function()
    -- properties
    test('\x5d\x00\x00\x80\x00\x0b\x00\x00\x00\x00\x00\x00\x00')
    test('\x00\x00\x00\x80\x00\x0b\x00\x00\x00\x00\x00\x00\x00')
    test('\xff\x00\x00\x80\x00\x0b\x00\x00\x00\x00\x00\x00\x00')
    -- dictionary size
    test('\x5d\x00\x00\x80\x00\x0b\x00\x00\x00\x00\x00\x00\x00')
    test('\x5d\x00\x00\x01\x00\x0b\x00\x00\x00\x00\x00\x00\x00')
    test('\x5d\x00\x00\x00\x00\x0b\x00\x00\x00\x00\x00\x00\x00')
    test('\x5d\xff\xff\xff\xff\x0b\x00\x00\x00\x00\x00\x00\x00')
    test('\x5d\xfe\xff\xff\xff\x0b\x00\x00\x00\x00\x00\x00\x00')
    -- decompressed size
    test('\x5d\x00\x00\x80\x00\xff\xff\xff\xff\xff\xff\xff\xff') -- streamed (or, naively, 2^64-1 bytes)
    test('\x5d\x00\x00\x80\x00\x0b\x00\x00\x00\x00\x00\x00\x00') -- 11 bytes
    test('\x5d\x00\x00\x80\x00\xfe\xff\xff\xff\xff\xff\xff\xff') -- 2^64-2 bytes
    test('\x5d\x00\x00\x80\x00\xff\xff\xff\xff\x00\x00\x00\x00') -- 2^32-1 bytes
    test('\x5d\x00\x00\x80\x00\x00\xe1\xf5\x05\x00\x00\x00\x00') -- 1e8 bytes
    test('\x5d\x00\x00\x80\x00\x01\xe1\xf5\x05\x00\x00\x00\x00') -- 1e8+1 bytes
    print("success!")
    hook.remove('think', '')
end)
hook.add('think', '', thread)
```