### PR TITLE
Added StringStream:readEntity(function? callback) and StringStream:writeEntity(Entity)

### DIFF
--- a/lua/starfall/libs_sh/bit.lua
+++ b/lua/starfall/libs_sh/bit.lua
@@ -503,7 +503,6 @@ end
 -- @param Entity e The entity to be written
 function ss_methods:writeEntity(e)
 	self:writeInt16(getent(e):EntIndex())
-	return true
 end
 
 --- Returns the buffer as a string

--- a/lua/starfall/libs_sh/bit.lua
+++ b/lua/starfall/libs_sh/bit.lua
@@ -499,6 +499,13 @@ function ss_methods:writeString(str)
 	self:write("\0")
 end
 
+--- Writes an entity to the buffer and advances the buffer pointer.
+-- @param Entity e The entity to be written
+function ss_methods:writeEntity(e)
+	self:writeInt16(getent(e):EntIndex())
+	return true
+end
+
 --- Returns the buffer as a string
 -- @return string The buffer as a string
 function ss_methods:getString()
@@ -690,6 +697,22 @@ function bit_library.sha1(s)
 	local ret = util.SHA1(s)
 	instance:checkCpu()
 	return ret
+end
+
+--- Reads an entity from the byte stream and advances the buffer pointer.
+-- @param function? callback (Client only) optional callback to be ran whenever the entity becomes valid; returns nothing if this is used. The callback passes the entity if it succeeds or nil if it fails.
+-- @return Entity The entity that was read
+function ss_methods:readEntity(callback)
+	local index = self:readUInt16()
+	if callback ~= nil and CLIENT then
+		checkluatype(callback, TYPE_FUNCTION)
+		SF.WaitForEntity(index, function(ent)
+			if ent ~= nil then ent = instance.WrapObject(ent) end
+			instance:runFunction(callback, ent)
+		end)
+	else
+		return instance.WrapObject(Entity(index))
+	end
 end
 
 end


### PR DESCRIPTION
Added StringStream:readEntity(function? callback) and StringStream:writeEntity(Entity) which act identically to the net library counterparts. This allows reading entities via callback not necessarily immediately. Also allows me to add callback entity reading to my own networking library.
Resolves #1199