### PR TITLE
Added sf_input_lock_cooldown for input.lockControls(true)

### DIFF
--- a/lua/starfall/instance.lua
+++ b/lua/starfall/instance.lua
@@ -21,6 +21,7 @@ else
 	SF.softLockProtectionOwner = CreateConVar("sf_timebuffersoftlock_cl_owner", 1, FCVAR_ARCHIVE, "If sf_timebuffersoftlock_cl is 0, this enabled will make it only your own chips will be affected.")
 	SF.RamCap = CreateConVar("sf_ram_max_cl", 1500000, FCVAR_ARCHIVE, "If ram exceeds this limit (in kB), starfalls will be terminated")
 	SF.AllowSuperUser = CreateConVar("sf_superuserallowed", 0, {FCVAR_ARCHIVE, FCVAR_REPLICATED}, "Whether the starfall superuser feature is allowed")
+	SF.InputLockCooldown = CreateConVar("sf_input_lock_cooldown", 10, FCVAR_ARCHIVE, "Cooldown for input.lockControls() in seconds", 0)
 end
 
 SF.Instance = {}

--- a/lua/starfall/instance.lua
+++ b/lua/starfall/instance.lua
@@ -21,7 +21,6 @@ else
 	SF.softLockProtectionOwner = CreateConVar("sf_timebuffersoftlock_cl_owner", 1, FCVAR_ARCHIVE, "If sf_timebuffersoftlock_cl is 0, this enabled will make it only your own chips will be affected.")
 	SF.RamCap = CreateConVar("sf_ram_max_cl", 1500000, FCVAR_ARCHIVE, "If ram exceeds this limit (in kB), starfalls will be terminated")
 	SF.AllowSuperUser = CreateConVar("sf_superuserallowed", 0, {FCVAR_ARCHIVE, FCVAR_REPLICATED}, "Whether the starfall superuser feature is allowed")
-	SF.InputLockCooldown = CreateConVar("sf_input_lock_cooldown", 10, FCVAR_ARCHIVE, "Cooldown for input.lockControls() in seconds", 0)
 end
 
 SF.Instance = {}

--- a/lua/starfall/libs_sh/input.lua
+++ b/lua/starfall/libs_sh/input.lua
@@ -2,6 +2,7 @@
 local registerprivilege = SF.Permissions.registerPrivilege
 local haspermission = SF.Permissions.hasAccess
 local checkluatype = SF.CheckLuaType
+local inputLockCooldown = SF.InputLockCooldown
 
 -- This should manage the player button hooks for singleplayer games.
 local PlayerButtonDown, PlayerButtonUp
@@ -311,10 +312,10 @@ function input_library.lockControls(enabled)
 	end
 
 	if enabled then
-		if lockedControlCooldown > CurTime() then
+		if lockedControlCooldown + inputLockCooldown:getFloat() > CurTime() then
 			SF.Throw("Cannot lock the player's controls yet", 2)
 		end
-		lockedControlCooldown = CurTime() + 10
+		lockedControlCooldown = CurTime()
 		lockControls(instance)
 	else
 		unlockControls(instance)

--- a/lua/starfall/libs_sh/input.lua
+++ b/lua/starfall/libs_sh/input.lua
@@ -2,7 +2,7 @@
 local registerprivilege = SF.Permissions.registerPrivilege
 local haspermission = SF.Permissions.hasAccess
 local checkluatype = SF.CheckLuaType
-local inputLockCooldown = SF.InputLockCooldown
+local inputLockCooldown = CreateConVar("sf_input_lock_cooldown", 10, FCVAR_ARCHIVE, "Cooldown for input.lockControls() in seconds", 0)
 
 -- This should manage the player button hooks for singleplayer games.
 local PlayerButtonDown, PlayerButtonUp

--- a/lua/starfall/libs_sh/input.lua
+++ b/lua/starfall/libs_sh/input.lua
@@ -333,7 +333,7 @@ end
 -- @client
 -- @return boolean Whether the player's control can be locked
 function input_library.canLockControls()
-	return SF.IsHUDActive(instance.entity) and lockedControlCooldown <= CurTime()
+	return SF.IsHUDActive(instance.entity) and lockedControlCooldown + inputLockCooldown:GetFloat() <= CurTime()
 end
 
 

--- a/lua/starfall/libs_sh/input.lua
+++ b/lua/starfall/libs_sh/input.lua
@@ -312,7 +312,7 @@ function input_library.lockControls(enabled)
 	end
 
 	if enabled then
-		if lockedControlCooldown + inputLockCooldown:getFloat() > CurTime() then
+		if lockedControlCooldown + inputLockCooldown:GetFloat() > CurTime() then
 			SF.Throw("Cannot lock the player's controls yet", 2)
 		end
 		lockedControlCooldown = CurTime()


### PR DESCRIPTION
Resolves #1246 (reasoning is described there)
Added a client side convar `sf_input_lock_cooldown` that allows setting the cooldown for `input.lockControls(true)`. Defaults to 10. Min of 0. Convar can be changed mid-execution and take effect.