### PR TITLE
Only create sf_input_lock_cooldown on the client

### DIFF
--- a/lua/starfall/libs_sh/input.lua
+++ b/lua/starfall/libs_sh/input.lua
@@ -2,7 +2,10 @@
 local registerprivilege = SF.Permissions.registerPrivilege
 local haspermission = SF.Permissions.hasAccess
 local checkluatype = SF.CheckLuaType
-local inputLockCooldown = CreateConVar("sf_input_lock_cooldown", 10, FCVAR_ARCHIVE, "Cooldown for input.lockControls() in seconds", 0)
+local inputLockCooldown
+if CLIENT then
+	inputLockCooldown = CreateConVar("sf_input_lock_cooldown", 10, FCVAR_ARCHIVE, "Cooldown for input.lockControls() in seconds", 0)
+end
 
 -- This should manage the player button hooks for singleplayer games.
 local PlayerButtonDown, PlayerButtonUp


### PR DESCRIPTION
Slight oversight. I originally had the convar creation happening only on the client but it was in instance.lua and when I moved it to input.lua, I forgot to only create it on the client.
Resolves #1248