### PR TITLE
Prevent calling function on nil Value

### DIFF
--- a/lua/starfall/libs_cl/bass.lua
+++ b/lua/starfall/libs_cl/bass.lua
@@ -231,8 +231,7 @@ end
 -- @return boolean Boolean of whether the bass is valid.
 function bass_methods:isValid()
 	local uw = unwrap(self)
-	if !uw then return false end
-	return uw:IsValid()
+	return uw.IsValid and uw:IsValid()
 end
 
 --- Gets the left and right levels of the audio channel

--- a/lua/starfall/libs_cl/bass.lua
+++ b/lua/starfall/libs_cl/bass.lua
@@ -231,6 +231,7 @@ end
 -- @return boolean Boolean of whether the bass is valid.
 function bass_methods:isValid()
 	local uw = unwrap(self)
+	if !uw then return false end
 	return uw:IsValid()
 end
 


### PR DESCRIPTION
Getting this error:
```
Hook 'postdrawopaquerenderables' errored with: addons/starfallex/lua/starfall/libs_cl/bass.lua:234: attempt to call method 'IsValid' (a nil value)
stack traceback:
	addons/starfallex/lua/starfall/libs_cl/bass.lua:234: in function 'isValid'
```