### PR TITLE
Fix (kinda) for navmesh removal on deletion

### DIFF
--- a/lua/starfall/libs_sv/navmesh.lua
+++ b/lua/starfall/libs_sv/navmesh.lua
@@ -54,7 +54,7 @@ return function(instance)
 		plyCount:free(instance.player, 1)
 
 		if navarea and navarea:IsValid() then
-			nav:Remove()
+			navarea:Remove()
 		end
 
 
@@ -68,9 +68,6 @@ return function(instance)
 
 	instance:AddHook("deinitialize", function()
 		for navarea in pairs(navareas) do
-			if navarea and navarea:IsValid() then
-				navarea:Remove()
-			end
 			destroy(navarea)
 		end
 	end)


### PR DESCRIPTION
2 separate removal functions were being called on deinitialize. One of them had a typo which caused a Lua error on chip removal. Nav areas did still get deleted though.