### PR TITLE
Remove GLua specific syntax

### DIFF
--- a/lua/entities/starfall_processor/cl_init.lua
+++ b/lua/entities/starfall_processor/cl_init.lua
@@ -45,7 +45,7 @@ function ENT:GetOverlayText()
 		serverstr = "None"
 	end
 	
-	local authorstr =  self.author and self.author:Trim() != "" and "\nAuthor: " .. self.author or ""
+	local authorstr =  self.author and self.author:Trim() ~= "" and "\nAuthor: " .. self.author or ""
 	
 	return "- Starfall Processor -\n[ " .. self.name .. " ]"..authorstr.."\nServer CPU: " .. serverstr .. "\nClient CPU: " .. clientstr
 end

--- a/lua/starfall/editor/editor.lua
+++ b/lua/starfall/editor/editor.lua
@@ -183,10 +183,10 @@ if CLIENT then
 	end
 
 	function SF.Editor.createGlobalPermissionsPanel(client, server)
-		if server != false then -- default to true
+		if server ~= false then -- default to true
 			server = true
 		end
-		if client != false then -- defualt to true
+		if client ~= false then -- defualt to true
 			client = true
 		end
 		local permsPanel = vgui.Create("StarfallPermissions")

--- a/lua/starfall/editor/sfderma.lua
+++ b/lua/starfall/editor/sfderma.lua
@@ -935,7 +935,7 @@ function PANEL:Think()
 	local scrollPanel = self.permissionsPanel:GetChild( self.area - 1 )
 	local VBar = scrollPanel:GetVBar()
 	local dest = self.reservedTall + math.Clamp( scrollPanel:GetCanvas():GetTall(), 0, ScrH() - self.reservedTall )
-	if self:GetTall() != dest then
+	if self:GetTall() ~= dest then
 		self.tallAnimation = true
 		VBar:SetAlpha( 0 )
 		local step = Lerp( 0.6, 0, dest - self:GetTall() )
@@ -1131,7 +1131,7 @@ function PANEL:getFont(tab)
 	local weight = tab.weight or 500
 	local blursize = tab.blursize or 0
 	local scanlines = tab.scanlines or 0
-	local antialias = (tab.antialias != false) and 1 or 0
+	local antialias = (tab.antialias ~= false) and 1 or 0
 	local underline = tab.underline and 1 or 0
 	local italic = tab.italic and 1 or 0
 	local strikeout = tab.strikeout and 1 or 0
@@ -1196,7 +1196,7 @@ function PANEL:Init()
 	local function setupItem(item, name)
 		item:SetValue(self.FontData[name])
 		item.OnChange = function(_, val)
-			if val != nil then
+			if val ~= nil then
 				self.FontData[name] = val
 			else
 				self.FontData[name] = item:GetValue()

--- a/lua/starfall/editor/sfframe.lua
+++ b/lua/starfall/editor/sfframe.lua
@@ -448,7 +448,7 @@ function Editor:UpdateTabText(tab, title)
 	local tabtext = title or text
 	tab:SetToolTip(ed.chosenfile)
 	tabtext = tabtext or "Generic"
-	if not ed:IsSaved() and tabtext:sub(-1) != "*" then
+	if not ed:IsSaved() and tabtext:sub(-1) ~= "*" then
 		tabtext = tabtext.." *"
 	end
 
@@ -886,7 +886,7 @@ function Editor:InitComponents()
 
 				local awesomePeople = "List of awesome people that contributed to StarfallEx:\n";
 				for k,v in ipairs(data) do
-					if v.login != "web-flow" then
+					if v.login ~= "web-flow" then
 						awesomePeople = awesomePeople .. "\n" .. v.login
 					end
 				end

--- a/lua/starfall/editor/syntaxmodes/starfall.lua
+++ b/lua/starfall/editor/syntaxmodes/starfall.lua
@@ -717,7 +717,7 @@ function EDITOR:PopulateContextMenu(menu)
 				ColorPicker.OnColorPicked = function(_, color)
 					self.Start = {caret[1], startpos}
 					self.Caret = {caret[1], endpos + 1}
-					if a or color.a != 255 then
+					if a or color.a ~= 255 then
 						self:SetSelection(string.format("%d, %d, %d, %d", color.r, color.g, color.b, color.a))
 					else
 						self:SetSelection(string.format("%d, %d, %d", color.r, color.g, color.b))

--- a/lua/starfall/editor/tabhandlers/tab_wire.lua
+++ b/lua/starfall/editor/tabhandlers/tab_wire.lua
@@ -279,8 +279,8 @@ function TabHandler:RegisterSettings()
 end
 
 local PANEL = {}
-function PANEL:OnValidate(s, r, m, goto)
-	if s or not goto then return end
+function PANEL:OnValidate(s, r, m, go_to)
+	if s or not go_to then return end
 	self:SetCaret({ r, 0 })
 end
 
@@ -1166,7 +1166,7 @@ function PANEL:Paint()
 	surface_DrawRect(self.LineNumberWidth + 5, 0, self:GetWide() - (self.LineNumberWidth + 5), self:GetTall())
 
 	local scr  = math_floor(self.ScrollBar:GetScroll() + 1)
-	if scr != prevScroll then
+	if scr ~= prevScroll then
 		local cScroll = 0
 
 		for k,v in ipairs(self.Rows) do
@@ -2800,7 +2800,7 @@ function PANEL:Think()
 		line = lines[self.RealLine[line]] or lines[line]
 
 		if line and line[2] and line[2].foldable then
-			if self.cur != "pointer" then
+			if self.cur ~= "pointer" then
 				self:SetCursor("hand")
 				self.cur = "pointer"
 			end

--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -1972,7 +1972,7 @@ function render_library.renderView(tbl)
 	end
 
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
-	if !renderdata.isScenic then SF.Throw("Can't use render.renderView outside of renderscene hook.", 2) end
+	if not renderdata.isScenic then SF.Throw("Can't use render.renderView outside of renderscene hook.", 2) end
 
 	if renderdata.renderingView then
 		SF.Throw("Already rendering a view.", 2)

--- a/lua/starfall/libs_sh/mesh.lua
+++ b/lua/starfall/libs_sh/mesh.lua
@@ -272,7 +272,7 @@ do
 		for k, point in pairs( points ) do
 			if not isValid(point.ent) then continue end
 			local cur_pos = point.ent:getPos()
-			if not changed and ( not point.vec or point.vec != cur_pos ) then changed = true end
+			if not changed and ( not point.vec or point.vec ~= cur_pos ) then changed = true end
 
 			point.vec = cur_pos
 			point.x = point.vec.x

--- a/lua/starfall/libs_sh/table.lua
+++ b/lua/starfall/libs_sh/table.lua
@@ -215,7 +215,7 @@ function table_library.copy( tbl, lookup_table )
 	local copy = {}
 	setmetatable( copy, meta )
 	for i, v in pairs( tbl ) do
-		if ( !istable( v ) ) then
+		if ( not istable( v ) ) then
 			copy[ i ] = v
 		else
 			lookup_table = lookup_table or {}

--- a/lua/starfall/libs_sh/vmatrix.lua
+++ b/lua/starfall/libs_sh/vmatrix.lua
@@ -281,11 +281,11 @@ function vmatrix_methods:getAxisAngle()
 		m20, m21, m22, m23 = unwrap(self):Unpack()
 
 	if math.abs(m01-m10)< epsilon and math.abs(m02-m20)< epsilon and math.abs(m12-m21)< epsilon then
-		// singularity found
+		-- singularity found
 		if math.abs(m01+m10) < epsilon and math.abs(m02+m20) < epsilon and math.abs(m12+m21) < epsilon and math.abs(m00+m11+m22-3) < epsilon then
 			return vwrap2({1,0,0}), 0
 		end
-		// otherwise this singularity is angle = math.pi
+		-- otherwise this singularity is angle = math.pi
 		local xx = (m00+1)/2
 		local yy = (m11+1)/2
 		local zz = (m22+1)/2

--- a/lua/weapons/gmod_tool/stools/starfall_component.lua
+++ b/lua/weapons/gmod_tool/stools/starfall_component.lua
@@ -136,7 +136,7 @@ function TOOL:LeftClick(trace)
 
 		local const
 		if trace.Entity:IsValid() then
-			if self:GetClientNumber( "parent", 0 ) != 0 then
+			if self:GetClientNumber( "parent", 0 ) ~= 0 then
 				sf:SetParent(trace.Entity)
 			else
 				const = constraint.Weld(sf, trace.Entity, 0, trace.PhysicsBone, 0, true, true)
@@ -167,7 +167,7 @@ function TOOL:LeftClick(trace)
 
 		local const
 		if trace.Entity:IsValid() then
-			if self:GetClientNumber( "parent", 0 ) != 0 then
+			if self:GetClientNumber( "parent", 0 ) ~= 0 then
 				sf:SetParent(trace.Entity)
 			else
 				const = constraint.Weld(sf, trace.Entity, 0, trace.PhysicsBone, 0, true, true)

--- a/lua/weapons/gmod_tool/stools/starfall_processor.lua
+++ b/lua/weapons/gmod_tool/stools/starfall_processor.lua
@@ -100,7 +100,7 @@ function TOOL:LeftClick(trace)
 		if sf==ent then return end
 		local ret
 		if ent:IsValid() then
-			if self:GetClientNumber( "parent", 0 ) != 0 then
+			if self:GetClientNumber( "parent", 0 ) ~= 0 then
 				sf:SetParent(ent)
 			else
 				local const = constraint.Weld(sf, ent, 0, trace.PhysicsBone, 0, true, true)


### PR DESCRIPTION
Changes stuff like `!=` -> `~=` or `//` -> `--`, also fixes usage of the `goto` keyword as a variable.