### PR TITLE
Allow for EntityTakeDamage hook to block damage

### DIFF
--- a/lua/starfall/libs_sh/hook.lua
+++ b/lua/starfall/libs_sh/hook.lua
@@ -1,6 +1,10 @@
 -- Global to all starfalls
 local checkluatype = SF.CheckLuaType
 local haspermission = SF.Permissions.hasAccess
+local registerprivilege = SF.Permissions.registerPrivilege
+
+-- Register privileges
+registerprivilege("entities.blockDamage", "Block Damage", "Allows the user to block incoming entity damage", { entities = {} })
 
 --Can only return if you are the first argument
 local function returnOnlyOnYourself(instance, args, ply)
@@ -199,6 +203,10 @@ if SERVER then
 			instance.Types.Vector.Wrap(dmg:GetDamagePosition()),
 			instance.Types.Vector.Wrap(dmg:GetDamageForce())
 		}
+	end, function(instance, args, target)
+		if args[1] and args[2] == true and (instance.player == SF.Superuser or haspermission(instance, target, "entities.blockDamage")) then
+			return true
+		end
 	end)
 
 	--- Called whenever an NPC is killed.

--- a/lua/starfall/libs_sh/hook.lua
+++ b/lua/starfall/libs_sh/hook.lua
@@ -3,9 +3,6 @@ local checkluatype = SF.CheckLuaType
 local haspermission = SF.Permissions.hasAccess
 local registerprivilege = SF.Permissions.registerPrivilege
 
--- Register privileges
-registerprivilege("entities.blockDamage", "Block Damage", "Allows the user to block incoming entity damage", { entities = {} })
-
 --Can only return if you are the first argument
 local function returnOnlyOnYourself(instance, args, ply)
 	if args[1] and instance.player == ply then return args[2] end
@@ -181,6 +178,9 @@ if SERVER then
 	-- @param Player ply Player
 	-- @param Weapon wep Weapon
 	add("PlayerCanPickupWeapon", nil, nil, returnOnlyOnYourselfFalse)
+
+	-- Register privileges
+	registerprivilege("entities.blockDamage", "Block Damage", "Allows the user to block incoming entity damage", { entities = {} })
 
 	--- Called when an entity is damaged
 	-- @name EntityTakeDamage

--- a/lua/starfall/libs_sh/hook.lua
+++ b/lua/starfall/libs_sh/hook.lua
@@ -193,6 +193,7 @@ if SERVER then
 	-- @param number type Type of the damage
 	-- @param Vector position Position of the damage
 	-- @param Vector force Force of the damage
+	-- @return boolean? Return true to prevent the entity from taking damage
 	add("EntityTakeDamage", nil, function(instance, target, dmg)
 		return true, {
 			instance.WrapObject(target),


### PR DESCRIPTION
Tested thoroughly on breakables, NPCs and in multiplayer. All seems to be ok.
Issue was saying to allow for returning `false`, but GMod needs it to be `true`, less confusing if we stick with `true` I think.

Fixes: #1245