### PR TITLE
Add Hologram.followBone and fix clientside re-parenting offset desync

### DIFF
--- a/lua/entities/starfall_hologram/cl_init.lua
+++ b/lua/entities/starfall_hologram/cl_init.lua
@@ -8,6 +8,7 @@ ENT.Material = ENT.DefaultMaterial
 function ENT:Initialize()
 	self.clips = {}
 	self.sf_userrenderbounds = false
+	self:SetupBones()
 	self:OnScaleChanged(nil, nil, self:GetScale())
 end
 

--- a/lua/starfall/libs_sh/entities.lua
+++ b/lua/starfall/libs_sh/entities.lua
@@ -300,11 +300,11 @@ function ents_methods:getLinkedComponents()
 	return list
 end
 
---- Parents or unparents an entity
+--- Parents or unparents an entity. Only holograms can be parented to players and, in clientside, only clientside holograms can be parented.
 -- @param Entity? parent Entity parent (nil to unparent)
 -- @param number|string? attachment Optional attachment name or ID
 -- @param number|string? bone Optional bone name or ID. Can't be used at the same time as attachment
-function hologram_methods:setParent(parent, attachment, bone)
+function ents_methods:setParent(parent, attachment, bone)
 	local child = getholo(self)
 	if CLIENT and debug.getmetatable(child)~=SF.Cl_Hologram_Meta then SF.Throw("Can only setParent clientside holograms in the clientside!", 2) end
 	checkpermission(instance, child, "hologram.setParent")

--- a/lua/starfall/libs_sh/entities.lua
+++ b/lua/starfall/libs_sh/entities.lua
@@ -2,7 +2,7 @@
 local checkluatype = SF.CheckLuaType
 local registerprivilege = SF.Permissions.registerPrivilege
 
-registerprivilege("entities.parent", "Parent", "Allows the user to parent an entity to another entity", { entities = {} })
+registerprivilege("entities.setParent", "Parent", "Allows the user to parent an entity to another entity", { entities = {} })
 registerprivilege("entities.setRenderProperty", "RenderProperty", "Allows the user to change the rendering of an entity", { client = (CLIENT and {} or nil), entities = {} })
 registerprivilege("entities.setPlayerRenderProperty", "PlayerRenderProperty", "Allows the user to change the rendering of themselves", {})
 registerprivilege("entities.setPersistent", "SetPersistent", "Allows the user to change entity's persistent state", { entities = {} })
@@ -305,9 +305,9 @@ end
 -- @param number|string? attachment Optional attachment name or ID
 -- @param number|string? bone Optional bone name or ID. Can't be used at the same time as attachment
 function ents_methods:setParent(parent, attachment, bone)
-	local child = getholo(self)
+	local child = getent(self)
 	if CLIENT and debug.getmetatable(child)~=SF.Cl_Hologram_Meta then SF.Throw("Can only setParent clientside holograms in the clientside!", 2) end
-	checkpermission(instance, child, "hologram.setParent")
+	checkpermission(instance, child, "entities.setParent")
 	if attachment~=nil and bone~=nil then SF.Throw("Can't have both attachment and bone args set!", 2) end
 	if parent ~= nil then
 		parent = getent(parent)
@@ -335,7 +335,7 @@ function ents_methods:setParent(parent, attachment, bone)
 			type = "entity"
 		end
 
-		SF_Parent(parent, child, type, param)
+		SF.Parent(parent, child, type, param)
 	else
 		local sf_parent = child.sf_parent
 		if sf_parent then

--- a/lua/starfall/libs_sh/entities.lua
+++ b/lua/starfall/libs_sh/entities.lua
@@ -2,6 +2,7 @@
 local checkluatype = SF.CheckLuaType
 local registerprivilege = SF.Permissions.registerPrivilege
 
+registerprivilege("entities.parent", "Parent", "Allows the user to parent an entity to another entity", { entities = {} })
 registerprivilege("entities.setRenderProperty", "RenderProperty", "Allows the user to change the rendering of an entity", { client = (CLIENT and {} or nil), entities = {} })
 registerprivilege("entities.setPlayerRenderProperty", "PlayerRenderProperty", "Allows the user to change the rendering of themselves", {})
 registerprivilege("entities.setPersistent", "SetPersistent", "Allows the user to change entity's persistent state", { entities = {} })
@@ -297,6 +298,50 @@ function ents_methods:getLinkedComponents()
 	end
 
 	return list
+end
+
+--- Parents or unparents an entity
+-- @param Entity? parent Entity parent (nil to unparent)
+-- @param number|string? attachment Optional attachment name or ID
+-- @param number|string? bone Optional bone name or ID. Can't be used at the same time as attachment
+function hologram_methods:setParent(parent, attachment, bone)
+	local child = getholo(self)
+	if CLIENT and debug.getmetatable(child)~=SF.Cl_Hologram_Meta then SF.Throw("Can only setParent clientside holograms in the clientside!", 2) end
+	checkpermission(instance, child, "hologram.setParent")
+	if attachment~=nil and bone~=nil then SF.Throw("Can't have both attachment and bone args set!", 2) end
+	if parent ~= nil then
+		parent = getent(parent)
+		if parent:IsPlayer() and not child.IsSFHologram then SF.Throw("Can only setParent holograms onto players!", 2) end
+		local param, type
+		if bone~=nil then
+			if isstring(bone) then
+				bone = parent:LookupBone(bone) or -1
+			elseif not isnumber(bone) then
+				SF.ThrowTypeError("string or number", SF.GetType(bone), 2)
+			end
+			if bone < 0 or bone > 255 then SF.Throw("Invalid bone provided", 2) end
+			type = "bone"
+			param = bone
+		elseif attachment~=nil then
+			if isstring(attachment) then
+				attachment = parent:LookupAttachment(attachment)
+			elseif not isnumber(attachment) then
+				SF.ThrowTypeError("string or number", SF.GetType(attachment), 2)
+			end
+			if attachment < 0 or attachment > 255 then SF.Throw("Invalid attachment provided", 2) end
+			type = "attachment"
+			param = attachment
+		else
+			type = "entity"
+		end
+
+		SF_Parent(parent, child, type, param)
+	else
+		local sf_parent = child.sf_parent
+		if sf_parent then
+			sf_parent:setParent()
+		end
+	end
 end
 
 --- Sets the color of the entity

--- a/lua/starfall/libs_sh/holograms.lua
+++ b/lua/starfall/libs_sh/holograms.lua
@@ -383,15 +383,13 @@ else
 		if parent ~= nil then
 			parent = getent(parent)
 			if bone ~= nil then checkluatype(bone, TYPE_BOOL) end
-			if attachment ~= nil then
+			if attachment ~= nil or bone then
 				if isstring(attachment) then
 					attachment = bone and parent:LookupBone(attachment) or parent:LookupAttachment(attachment)
 				elseif not isnumber(attachment) then
 					SF.ThrowTypeError("string or number", SF.GetType(attachment), 2)
 				end
 				if attachment < 0 or attachment > 255 then SF.Throw("Invalid attachment/bone provided", 2) end
-			elseif bone then
-				attachment = 0
 			end
 			
 			local parentFunc = bone and "FollowBone" or "SetParent"

--- a/lua/starfall/libs_sh/holograms.lua
+++ b/lua/starfall/libs_sh/holograms.lua
@@ -250,6 +250,9 @@ if SERVER then
 	end
 
 	local parentChainTooLong = SF.ParentChainTooLong
+	--- Parents a hologram to the specified parent's bone
+	-- @param Entity? parent Entity parent (nil to unparent)
+	-- @param number bone Bone ID
 	function hologram_methods:followBone(parent, bone)
 		local holo = getent(self)
 		if parent then

--- a/lua/starfall/libs_sh/holograms.lua
+++ b/lua/starfall/libs_sh/holograms.lua
@@ -408,7 +408,7 @@ else
 			
 			-- Clear residue stuff from FollowBone if we switch to SetParent
 			if not bone and holo.sf_parent and holo.sf_parent.sf_children[ent].func == "FollowBone" then
-				holo:FollowBone()
+				clearParentFix(holo, true)
 			end
 			
 			setParentFix(holo, parent, attachment, bone and "FollowBone" or "SetParent")

--- a/lua/starfall/libs_sh/holograms.lua
+++ b/lua/starfall/libs_sh/holograms.lua
@@ -27,6 +27,7 @@ local cl_hologram_meta = {
 }
 
 local setParentFix, clearParentFix
+local parentChainTooLong = SF.ParentChainTooLong
 if CLIENT then
 	registerprivilege("hologram.setParent", "Set Parent", "Allows the user to parent a hologram", { entities = {} })
 	
@@ -276,7 +277,6 @@ if SERVER then
 		holo:SetLocalAngularVelocity(aunwrap(angvel))
 	end
 
-	local parentChainTooLong = SF.ParentChainTooLong
 	--- Parents a hologram to the specified parent's bone
 	-- @param Entity? parent Entity parent (nil to unparent)
 	-- @param number bone Bone ID
@@ -395,6 +395,7 @@ else
 			attachment = attachment or -1
 			checkluatype(attachment, TYPE_NUMBER)
 			
+			if parentChainTooLong(parent, holo) then SF.Throw("Parenting chain of entities can't exceed 16 or crash may occur", 2) end
 			setParentFix(holo, parent, attachment, "SetParent")
 			holo:SetParent(parent, attachment)
 		else
@@ -414,6 +415,7 @@ else
 			parent = getent(parent)
 			checkluatype(bone, TYPE_NUMBER)
 			
+			if parentChainTooLong(parent, holo) then SF.Throw("Parenting chain of entities can't exceed 16 or crash may occur", 2) end
 			setParentFix(holo, parent, bone, "FollowBone")
 			holo:FollowBone(parent, bone)
 		else

--- a/lua/starfall/libs_sh/holograms.lua
+++ b/lua/starfall/libs_sh/holograms.lua
@@ -374,8 +374,8 @@ else
 	
 	--- Parents a hologram
 	-- @param Entity? parent Entity parent (nil to unparent)
-	-- @param number|string? attachment Optional attachment name or ID
-	-- @param boolean? bone True to parent to a bone instead of an attachment (`attachment` parameter must be a number)
+	-- @param number|string? attachment Optional attachment (or bone) name or ID
+	-- @param boolean? bone True to parent to a bone instead of an attachment (requires the `attachment` parameter to be set)
 	function hologram_methods:setParent(parent, attachment, bone)
 		local holo = getholo(self)
 		checkpermission(instance, holo, "hologram.setParent")

--- a/lua/starfall/libs_sh/holograms.lua
+++ b/lua/starfall/libs_sh/holograms.lua
@@ -57,8 +57,7 @@ else
 	function clearParentFix(ent, unparent)
 		if ent.sf_parent and ent.sf_parent:IsValid() then
 			if unparent then
-				local func = ent.sf_parent.sf_children[ent].func
-				func(ent, nil, func == "FollowBone" and 0 or nil)
+				ent.sf_parent.sf_children[ent].func()
 			end
 			
 			ent.sf_parent.sf_children[ent] = nil
@@ -71,7 +70,7 @@ else
 			if child and child:IsValid() then
 				child:SetPos(parent:LocalToWorld(data.pos))
 				child:SetAngles(parent:LocalToWorldAngles(data.ang))
-				child[data.func](child, parent, data.bone)
+				data.func(child, parent, data.bone)
 				
 				if child.sf_children then
 					return reparentChildren(child)
@@ -415,11 +414,19 @@ function hologram_methods:setParent(parent, attachment, bone)
 			ent:SetParent(parent)
 		end
 		local function parentBone(ent, parent, target)
-			ent:FollowBone(parent)
+			if parent then
+				ent:FollowBone(parent, target)
+			else
+				ent:FollowBone()
+			end
 		end
 		local function parentAttachment(ent, parent, target)
-			ent:SetParent(parent)
-			ent:Fire("SetParentAttachmentMaintainOffset", bone, 0.01)
+			if parent then
+				ent:SetParent(parent)
+				ent:Fire("SetParentAttachmentMaintainOffset", bone, 0.01)
+			else
+				ent:SetParent()
+			end
 		end
 
 		local target
@@ -454,7 +461,7 @@ function hologram_methods:setParent(parent, attachment, bone)
 				clearParentFix(holo, true)
 			end
 		end
-		
+
 		setParentFix(holo, parent, target, parentFunc)
 	else
 		clearParentFix(holo, true)

--- a/lua/starfall/libs_sh/holograms.lua
+++ b/lua/starfall/libs_sh/holograms.lua
@@ -48,11 +48,11 @@ if CLIENT then
 			ang  = parent:WorldToLocalAngles(ent:GetAngles())
 		}
 		
-		ent[func](parent, bone)
+		ent[func](ent, parent, bone)
 	end
 	
 	function clearParentFix(ent, unparent)
-		if ent.sf_parent then
+		if ent.sf_parent and ent.sf_parent:IsValid() then
 			if unparent then
 				-- Call parenting function with no arguments to unparent
 				local func = ent.sf_parent.sf_children[ent]
@@ -401,9 +401,10 @@ else
 		
 		if parent ~= nil then
 			parent = getent(parent)
-			attachment = attachment or -1
+			if bone ~= nil then checkluatype(bone, TYPE_BOOL) end
+			attachment = attachment or (bone and 0 or -1)
 			checkluatype(attachment, TYPE_NUMBER)
-			if bone ~= nil then checkluatype(bone, TYPE_BOOLEAN) end
+			
 			if parentChainTooLong(parent, holo) then SF.Throw("Parenting chain of entities can't exceed 16 or crash may occur", 2) end
 			
 			-- Clear residue stuff from FollowBone if we switch to SetParent

--- a/lua/starfall/libs_sh/holograms.lua
+++ b/lua/starfall/libs_sh/holograms.lua
@@ -410,12 +410,12 @@ function hologram_methods:setParent(parent, attachment, bone)
 		parent = getent(parent)
 		if parentChainTooLong(parent, holo) then SF.Throw("Parenting chain of entities can't exceed 16 or crash may occur", 2) end
 
-		local function parent(ent, parent)
-			ent:SetParent(parent)
+		local function parent(ent, ...)
+			ent:SetParent(...)
 		end
-		local function parentBone(ent, parent, target)
+		local function parentBone(ent, ...)
 			if parent then
-				ent:FollowBone(parent, target)
+				ent:FollowBone(...)
 			else
 				ent:FollowBone()
 			end
@@ -423,7 +423,7 @@ function hologram_methods:setParent(parent, attachment, bone)
 		local function parentAttachment(ent, parent, target)
 			if parent then
 				ent:SetParent(parent)
-				ent:Fire("SetParentAttachmentMaintainOffset", bone, 0.01)
+				ent:Fire("SetParentAttachmentMaintainOffset", target, 0.01)
 			else
 				ent:SetParent()
 			end

--- a/lua/starfall/libs_sh/holograms.lua
+++ b/lua/starfall/libs_sh/holograms.lua
@@ -382,14 +382,15 @@ else
 		
 		if parent ~= nil then
 			parent = getent(parent)
-			if bone ~= nil then checkluatype(bone, TYPE_BOOL) else bone = false end
+			if bone ~= nil then checkluatype(bone, TYPE_BOOL) end
 			if attachment ~= nil or bone then
-				if isstring(attachment) then
+				if isnumber(attachment) then
+				elseif isstring(attachment) then
 					attachment = bone and parent:LookupBone(attachment) or parent:LookupAttachment(attachment)
-					if attachment < 0 then SF.Throw("Invalid attachment/bone name provided", 2) end
-				elseif not isnumber(attachment) then
+				else
 					SF.ThrowTypeError("string or number", SF.GetType(attachment), 2)
 				end
+				if attachment < 0 or attachment > 255 then SF.Throw("Invalid attachment/bone name provided", 2) end
 			end
 			
 			local parentFunc = bone and "FollowBone" or "SetParent"

--- a/lua/starfall/libs_sh/holograms.lua
+++ b/lua/starfall/libs_sh/holograms.lua
@@ -26,8 +26,34 @@ local cl_hologram_meta = {
 	__eq = entmeta.__eq,
 }
 
+local setParentFix, clearParentFix
 if CLIENT then
 	registerprivilege("hologram.setParent", "Set Parent", "Allows the user to parent a hologram", { entities = {} })
+	
+	function setParentFix(ent, parent, bone, func)
+		if not parent.sf_children then
+			parent.sf_children = {}
+		end
+		
+		if ent.sf_parent and ent.sf_parent ~= parent then
+			ent.sf_parent.sf_children[ent] = nil
+		end
+		
+		ent.sf_parent = parent
+		parent.sf_children[ent] = {
+			func = func,
+			bone = bone, -- or attachment, dep. on `func`
+			pos  = parent:WorldToLocal(ent:GetPos()),
+			ang  = parent:WorldToLocalAngles(ent:GetAngles())
+		}
+	end
+	
+	function clearParentFix(ent)
+		if ent.sf_parent then
+			ent.sf_parent.sf_children[ent] = nil
+			ent.sf_parent = nil
+		end
+	end
 	
 	local function reparentChildren(parent)
 		for child, data in pairs(parent.sf_children) do
@@ -354,31 +380,6 @@ else
 			holo.HoloMatrix = nil
 			holo:DisableMatrix("RenderMultiply")
 		end
-	end
-
-	local function clearParentFix(ent)
-		if ent.sf_parent then
-			ent.sf_parent.sf_children[ent] = nil
-			ent.sf_parent = nil
-		end
-	end
-	
-	local function setParentFix(ent, parent, bone, func)
-		if not parent.sf_children then
-			parent.sf_children = {}
-		end
-		
-		if ent.sf_parent and ent.sf_parent ~= parent then
-			ent.sf_parent.sf_children[ent] = nil
-		end
-		
-		ent.sf_parent = parent
-		parent.sf_children[ent] = {
-			func = func,
-			bone = bone, -- or attachment, dep. on `func`
-			pos  = parent:WorldToLocal(ent:GetPos()),
-			ang  = parent:WorldToLocalAngles(ent:GetAngles())
-		}
 	end
 	
 	--- Parents a hologram

--- a/lua/starfall/libs_sh/holograms.lua
+++ b/lua/starfall/libs_sh/holograms.lua
@@ -255,6 +255,8 @@ if SERVER then
 	-- @param number bone Bone ID
 	function hologram_methods:followBone(parent, bone)
 		local holo = getent(self)
+		checkpermission(instance, holo, "hologram.setParent")
+		
 		if parent then
 			parent = getent(parent)
 			checkluatype(bone, TYPE_NUMBER)

--- a/lua/starfall/libs_sh/holograms.lua
+++ b/lua/starfall/libs_sh/holograms.lua
@@ -385,7 +385,11 @@ else
 			if bone ~= nil then checkluatype(bone, TYPE_BOOL) end
 			if attachment ~= nil or bone then
 				if isstring(attachment) then
-					attachment = bone and parent:LookupBone(attachment) or parent:LookupAttachment(attachment)
+					if bone then
+						attachment = parent:LookupBone(attachment) or 0
+					else
+						attachment = parent:LookupAttachment(attachment)
+					end
 				elseif not isnumber(attachment) then
 					SF.ThrowTypeError("string or number", SF.GetType(attachment), 2)
 				end

--- a/lua/starfall/libs_sh/holograms.lua
+++ b/lua/starfall/libs_sh/holograms.lua
@@ -383,13 +383,15 @@ else
 		if parent ~= nil then
 			parent = getent(parent)
 			if bone ~= nil then checkluatype(bone, TYPE_BOOL) end
-			if attachment ~= nil or bone then
+			if attachment ~= nil then
 				if isstring(attachment) then
 					attachment = bone and parent:LookupBone(attachment) or parent:LookupAttachment(attachment)
 				elseif not isnumber(attachment) then
 					SF.ThrowTypeError("string or number", SF.GetType(attachment), 2)
 				end
 				if attachment < 0 or attachment > 255 then SF.Throw("Invalid attachment/bone provided", 2) end
+			elseif bone then
+				attachment = 0
 			end
 			
 			local parentFunc = bone and "FollowBone" or "SetParent"

--- a/lua/starfall/libs_sh/holograms.lua
+++ b/lua/starfall/libs_sh/holograms.lua
@@ -416,26 +416,6 @@ else
 			clearParentFix(holo, true)
 		end
 	end
-	
-	--- Parents a hologram to the specified parent's bone
-	-- @param Entity? parent Entity parent (nil to unparent)
-	-- @param number bone Bone ID
-	function hologram_methods:followBone(parent, bone)
-		local holo = getent(self)
-		checkpermission(instance, holo, "hologram.setParent")
-		
-		if parent ~= nil then
-			parent = getent(parent)
-			checkluatype(bone, TYPE_NUMBER)
-			
-			if parentChainTooLong(parent, holo) then SF.Throw("Parenting chain of entities can't exceed 16 or crash may occur", 2) end
-			setParentFix(holo, parent, bone, "FollowBone")
-			holo:FollowBone(parent, bone)
-		else
-			clearParentFix(holo)
-			holo:FollowBone()
-		end
-	end
 
 	--- Manually draws a hologram, requires a 3d render context
 	-- @client

--- a/lua/starfall/libs_sh/holograms.lua
+++ b/lua/starfall/libs_sh/holograms.lua
@@ -384,10 +384,9 @@ else
 			parent = getent(parent)
 			if bone ~= nil then checkluatype(bone, TYPE_BOOL) end
 			if attachment ~= nil or bone then
-				if isnumber(attachment) then
-				elseif isstring(attachment) then
+				if isstring(attachment) then
 					attachment = bone and parent:LookupBone(attachment) or parent:LookupAttachment(attachment)
-				else
+				elseif not isnumber(attachment) then
 					SF.ThrowTypeError("string or number", SF.GetType(attachment), 2)
 				end
 				if attachment < 0 or attachment > 255 then SF.Throw("Invalid attachment/bone provided", 2) end

--- a/lua/starfall/libs_sh/holograms.lua
+++ b/lua/starfall/libs_sh/holograms.lua
@@ -390,7 +390,7 @@ else
 				else
 					SF.ThrowTypeError("string or number", SF.GetType(attachment), 2)
 				end
-				if attachment < 0 or attachment > 255 then SF.Throw("Invalid attachment/bone name provided", 2) end
+				if attachment < 0 or attachment > 255 then SF.Throw("Invalid attachment/bone provided", 2) end
 			end
 			
 			local parentFunc = bone and "FollowBone" or "SetParent"

--- a/lua/starfall/libs_sh/holograms.lua
+++ b/lua/starfall/libs_sh/holograms.lua
@@ -109,6 +109,7 @@ instance:AddHook("initialize", function()
 end)
 
 local function hologramOnDestroy(holo)
+	clearParentFix(holo)
 	holograms[holo] = nil
 	plyCount:free(instance.player, 1)
 end

--- a/lua/starfall/libs_sh/holograms.lua
+++ b/lua/starfall/libs_sh/holograms.lua
@@ -249,13 +249,17 @@ if SERVER then
 		holo:SetLocalAngularVelocity(aunwrap(angvel))
 	end
 
-	-- TODO: Limit parent chain to 16 just like Entity.setParent
+	local parentChainTooLong = SF.ParentChainTooLong
 	function hologram_methods:followBone(parent, bone)
+		local holo = getent(self)
 		if parent then
+			parent = getent(parent)
 			checkluatype(bone, TYPE_NUMBER)
-			getent(self):FollowBone(getent(parent), bone)
+			
+			if parentChainTooLong(parent, holo) then SF.Throw("Parenting chain of entities can't exceed 16 or crash may occur", 2) end
+			holo:FollowBone(parent, bone)
 		else
-			getent(self):FollowBone()
+			holo:FollowBone()
 		end
 	end
 

--- a/lua/starfall/libs_sh/holograms.lua
+++ b/lua/starfall/libs_sh/holograms.lua
@@ -382,16 +382,13 @@ else
 		
 		if parent ~= nil then
 			parent = getent(parent)
-			if bone ~= nil then checkluatype(bone, TYPE_BOOL) end
-			if bone then
-				attachment = attachment or 0
-				checkluatype(attachment, TYPE_NUMBER)
-			else
+			if bone ~= nil then checkluatype(bone, TYPE_BOOL) else bone = false end
+			if attachment ~= nil or bone then
 				if isstring(attachment) then
-					attachment = parent:LookupAttachment(attachment)
-				else
-					attachment = attachment or -1
-					checkluatype(attachment, TYPE_NUMBER)
+					attachment = bone and parent:LookupBone(attachment) or parent:LookupAttachment(attachment)
+					if attachment < 0 then SF.Throw("Invalid attachment/bone name provided", 2) end
+				elseif not isnumber(attachment) then
+					SF.ThrowTypeError("string or number", SF.GetType(attachment), 2)
 				end
 			end
 			

--- a/lua/starfall/libs_sh/holograms.lua
+++ b/lua/starfall/libs_sh/holograms.lua
@@ -34,7 +34,7 @@ if CLIENT then
 			if child and child:IsValid() then
 				child:SetPos(parent:LocalToWorld(data.pos))
 				child:SetAngles(parent:LocalToWorldAngles(data.ang))
-				child[data.func](parent, data.bone)
+				child[data.func](child, parent, data.bone)
 				
 				if child.sf_children then
 					return reparentChildren(child)
@@ -265,11 +265,15 @@ else
 	-- @param Vector vec New position
 	function hologram_methods:setPos(vec)
 		local holo = getholo(self)
-		local vec = vunwrap(vec)
-
+		local pos = SF.clampPos(vunwrap(vec))
 		checkpermission(instance, holo, "hologram.setRenderProperty")
-
-		holo:SetPos(SF.clampPos(vec))
+		
+		holo:SetPos(pos)
+		
+		local parent = holo.sf_parent
+		if parent and parent:IsValid() then
+			parent.sf_children[holo].pos = parent:WorldToLocal(pos)
+		end
 	end
 
 	--- Sets the hologram's angles.
@@ -277,11 +281,15 @@ else
 	-- @param Angle ang New angles
 	function hologram_methods:setAngles(ang)
 		local holo = getholo(self)
-		local ang = aunwrap(ang)
-
+		local angle = aunwrap(ang)
 		checkpermission(instance, holo, "hologram.setRenderProperty")
 
-		holo:SetAngles(ang)
+		holo:SetAngles(angle)
+		
+		local parent = holo.sf_parent
+		if parent and parent:IsValid() then
+			parent.sf_children[holo].ang = parent:WorldToLocalAngles(angle)
+		end
 	end
 
 	--- Sets the texture filtering function when viewing a close texture

--- a/lua/starfall/libs_sh/holograms.lua
+++ b/lua/starfall/libs_sh/holograms.lua
@@ -118,7 +118,7 @@ instance:AddHook("initialize", function()
 end)
 
 local function hologramOnDestroy(holo)
-	clearParentFix(holo)
+	if CLIENT then clearParentFix(holo) end
 	holograms[holo] = nil
 	plyCount:free(instance.player, 1)
 end

--- a/lua/starfall/libs_sh/holograms.lua
+++ b/lua/starfall/libs_sh/holograms.lua
@@ -283,25 +283,7 @@ if SERVER then
 
 		holo:SetLocalAngularVelocity(aunwrap(angvel))
 	end
-
-	--- Parents a hologram to the specified parent's bone
-	-- @param Entity? parent Entity parent (nil to unparent)
-	-- @param number bone Bone ID
-	function hologram_methods:followBone(parent, bone)
-		local holo = getent(self)
-		checkpermission(instance, holo, "hologram.setParent")
-		
-		if parent then
-			parent = getent(parent)
-			checkluatype(bone, TYPE_NUMBER)
-			
-			if parentChainTooLong(parent, holo) then SF.Throw("Parenting chain of entities can't exceed 16 or crash may occur", 2) end
-			holo:FollowBone(parent, bone)
-		else
-			holo:FollowBone()
-		end
-	end
-
+	
 else
 	--- Sets the hologram's position.
 	-- @shared

--- a/lua/starfall/libs_sh/holograms.lua
+++ b/lua/starfall/libs_sh/holograms.lua
@@ -386,7 +386,7 @@ else
 			if attachment ~= nil or bone then
 				if isstring(attachment) then
 					if bone then
-						attachment = parent:LookupBone(attachment) or 0
+						attachment = parent:LookupBone(attachment) or -1
 					else
 						attachment = parent:LookupAttachment(attachment)
 					end

--- a/lua/starfall/libs_sv/entities.lua
+++ b/lua/starfall/libs_sv/entities.lua
@@ -100,8 +100,6 @@ function ents_methods:setParent(parent, attachment, bone)
 			end
 			if attachment < 0 or attachment > 255 then SF.Throw("Invalid bone provided", 2) end
 			
-			-- Undo previous FollowBone, otherwise offset will be kept
-			if ent.sf_parent == "FollowBone" then ent:FollowBone(nil, 0) end
 			ent.sf_parent = "FollowBone"
 			ent:FollowBone(parentent, attachment)
 		else

--- a/lua/starfall/libs_sv/entities.lua
+++ b/lua/starfall/libs_sv/entities.lua
@@ -66,27 +66,7 @@ end)
 
 -- ------------------------- Methods ------------------------- --
 
-local function chainTooLong(parent, child)
-	local index = parent
-	local parentLength = 0
-	while index:IsValid() do
-		parentLength = parentLength + 1
-		index = index:GetParent()
-	end
-
-	local function getChildLength(curchild, count)
-		if count > 16 then return count end
-		local max = 0
-		for k, v in pairs(curchild:GetChildren()) do
-			max = math.max(max, getChildLength(v, count + 1))
-		end
-		return math.max(max, count)
-	end
-	local childLength = getChildLength(child, 1)
-
-	return parentLength + childLength > 16
-end
-
+local parentChainTooLong = SF.ParentChainTooLong
 --- Parents the entity to another entity
 -- @param Entity? parent Entity to parent to. nil to unparent
 -- @param string? attachment Optional string attachment name to parent to
@@ -105,7 +85,7 @@ function ents_methods:setParent(parent, attachment)
 			checkpermission(instance, parentent, "entities.parent")
 		end
 
-		if chainTooLong(parentent, ent) then SF.Throw("Parenting chain of entities can't exceed 16 or crash may occur", 2) end
+		if parentChainTooLong(parentent, ent) then SF.Throw("Parenting chain of entities can't exceed 16 or crash may occur", 2) end
 		ent:SetParent(parentent)
 
 		if attachment~=nil then

--- a/lua/starfall/libs_sv/entities.lua
+++ b/lua/starfall/libs_sv/entities.lua
@@ -79,8 +79,10 @@ function ents_methods:setParent(parent, attachment, bone)
 
 	if parent ~= nil then
 		local parentent = getent(parent)
+		local isEntHologram = ent:GetClass() == "starfall_hologram"
+		if bone and not isEntHologram then SF.Throw("Entity must be a hologram to bone parent", 2) end
 		if parentent:IsPlayer() then
-			if ent:GetClass()~="starfall_hologram" then
+			if not isEntHologram then
 				SF.Throw("Insufficient permissions", 2)
 			end
 		else

--- a/lua/starfall/libs_sv/entities.lua
+++ b/lua/starfall/libs_sv/entities.lua
@@ -6,8 +6,6 @@ local huge = math.huge
 local abs = math.abs
 
 -- Register privileges
-registerprivilege("entities.parent", "Parent", "Allows the user to parent an entity to another entity", { entities = {} })
-registerprivilege("entities.unparent", "Unparent", "Allows the user to remove the parent of an entity", { entities = {} })
 registerprivilege("entities.applyDamage", "Apply damage", "Allows the user to apply damage to an entity", { entities = {} })
 registerprivilege("entities.applyForce", "Apply force", "Allows the user to apply force to an entity", { entities = {} })
 registerprivilege("entities.setPos", "Set Position", "Allows the user to teleport an entity to another location", { entities = {} })
@@ -64,49 +62,6 @@ instance:AddHook("deinitialize", function()
 end)
 
 -- ------------------------- Methods ------------------------- --
-
-local parentChainTooLong = SF.ParentChainTooLong
---- Parents the entity to another entity
--- @param Entity? parent Entity to parent to. nil to unparent
--- @param number|string? attachment Optional attachment (or bone) name or ID
-function ents_methods:setParent(parent, attachment)
-	local ent = getent(self)
-	if ent:IsPlayer() then SF.Throw("Target is a player!", 2) end
-	checkpermission(instance, ent, "entities.parent")
-
-	if parent ~= nil then
-		local parentent = getent(parent)
-		if parentent:IsPlayer() then SF.Throw("Target parent is a player", 2) end
-		checkpermission(instance, parentent, "entities.parent")
-		if parentChainTooLong(parentent, ent) then SF.Throw("Parenting chain of entities can't exceed 16 or crash may occur", 2) end
-
-		ent:SetParent(parentent)
-
-		if attachment~=nil then
-			if isnumber(attachment) then
-				local attachments = parentent:GetAttachments()
-				if attachments and attachments[attachment] then
-					attachment = attachments[attachment].name
-				else
-					SF.Throw("Invalid attachment provided", 2)
-				end
-			elseif not isstring(attachment) then
-				SF.ThrowTypeError("string or number", SF.GetType(attachment), 2)
-			end
-			ent:Fire("SetParentAttachmentMaintainOffset", attachment, 0.01)
-		end
-		
-	else
-		ent:SetParent()
-	end
-end
-
---- Unparents the entity from another entity
-function ents_methods:unparent()
-	local ent = getent(self)
-	checkpermission(instance, ent, "entities.unparent")
-	ent:SetParent(nil)
-end
 
 --- Links starfall components to a starfall processor or vehicle. Screen can only connect to processor. HUD can connect to processor and vehicle.
 -- @param Entity? e Entity to link the component to, a vehicle or starfall for huds, or a starfall for screens. nil to clear links.

--- a/lua/starfall/libs_sv/entities.lua
+++ b/lua/starfall/libs_sv/entities.lua
@@ -69,8 +69,8 @@ end)
 local parentChainTooLong = SF.ParentChainTooLong
 --- Parents the entity to another entity
 -- @param Entity? parent Entity to parent to. nil to unparent
--- @param number|string? attachment Optional attachment name or ID
--- @param boolean? bone True to parent to a bone instead of an attachment (`attachment` parameter must be a number)
+-- @param number|string? attachment Optional attachment (or bone) name or ID
+-- @param boolean? bone True to parent to a bone instead of an attachment (requires the `attachment` to be set)
 function ents_methods:setParent(parent, attachment, bone)
 	local ent = getent(self)
 	if bone ~= nil then checkluatype(bone, TYPE_BOOL) end

--- a/lua/starfall/libs_sv/entities.lua
+++ b/lua/starfall/libs_sv/entities.lua
@@ -91,9 +91,7 @@ function ents_methods:setParent(parent, attachment, bone)
 		if parentChainTooLong(parentent, ent) then SF.Throw("Parenting chain of entities can't exceed 16 or crash may occur", 2) end
 		
 		if bone then
-			if attachment == nil then
-				attachment = 0
-			elseif isstring(attachment) then
+			if isstring(attachment) then
 				attachment = parentent:LookupBone(attachment)
 			elseif not isnumber(attachment) then
 				SF.ThrowTypeError("string or number", SF.GetType(attachment), 2)

--- a/lua/starfall/sflib.lua
+++ b/lua/starfall/sflib.lua
@@ -467,7 +467,7 @@ SF.BlockedList = {
 setmetatable(SF.BlockedList, SF.BlockedList)
 
 
-local SF.Parent = {
+SF.Parent = {
 	__index = {
 		updateTransform = function(self)
 			self.pos, self.ang = WorldToLocal(self.ent:GetPos(), self.ent:GetAngles(), self.parent:GetPos(), self.parent:GetAngles())
@@ -532,17 +532,23 @@ local SF.Parent = {
 		end,
 
 		fix = function(self)
+			local empty = true
 			if self.parent and self.parent:IsValid() then
 				self:applyTransform()
 				self:setParentType()
+				empty = false
 			end
-			for child, data in pairs(self.children) do	
+			for child, data in pairs(self.children) do
 				if child:IsValid() then
 					data:applyTransform()
 					data:setParentType()
+					empty = false
 				else
 					self.children[child] = nil
 				end
+			end
+			if empty then
+				self.ent.sf_parent = nil
 			end
 		end,
 	},

--- a/lua/starfall/sflib.lua
+++ b/lua/starfall/sflib.lua
@@ -1059,6 +1059,28 @@ function SF.NormalizePath(path)
 	return table.concat(pathtbl, "/")
 end
 
+--- Returns True if parent chain length is going to exceed 16
+function SF.ParentChainTooLong(parent, child)
+	local index = parent
+	local parentLength = 0
+	while index:IsValid() do
+		parentLength = parentLength + 1
+		index = index:GetParent()
+	end
+
+	local function getChildLength(curchild, count)
+		if count > 16 then return count end
+		local max = 0
+		for k, v in pairs(curchild:GetChildren()) do
+			max = math.max(max, getChildLength(v, count + 1))
+		end
+		return math.max(max, count)
+	end
+	local childLength = getChildLength(child, 1)
+
+	return parentLength + childLength > 16
+end
+
 -- This function clamps the position before moving the entity
 local minx, miny, minz = -16384, -16384, -16384
 local maxx, maxy, maxz = 16384, 16384, 16384


### PR DESCRIPTION
- Globalized the function responsible for checking whether parent chain length is too long as `SF.ParentChainTooLong`
- Added shared `Hologram.followBone(Entity parent, number bone)`
- Modified the previous clientside hologram re-parenting fix to also use it with `followBone`
- **Didn't** add a new permission, using `entities.setParent` instead, I think it's sufficient
- Made clientside's hologram `setPos` and `setAng` also update it's relative positions and angles for the re-parent fix *(weird how nobody noticed that before)*

I didn't test `followBone` with other players' PAC outfits, but mine doesn't seem to be affected in any way on a local server.

Fixes #815, #1282