### PR TITLE
Fix editor's 'close all others' button not working

### DIFF
--- a/lua/starfall/editor/sfframe.lua
+++ b/lua/starfall/editor/sfframe.lua
@@ -164,6 +164,7 @@ function Editor:Init()
 	self.GuiClick = 0
 	self.SimpleGUI = false
 	self.Location = ""
+	self.closePopups = {}
 
 	self.C = {}
 	self.Components = {}
@@ -699,15 +700,26 @@ function Editor:CloseTab(_tab,dontask)
 			end
 		end
 	end
+	
+	if not IsValid(activetab) then return end
+	
 	local ed = activetab:GetPanel()
-	if not ed:IsSaved() and not dontask and not ed.IsOnline then
-		if IsValid(self.closeDialogue) then
-			self.closeDialogue:MakePopup()
-		else
-			self.closeDialogue = SF.Editor.Query("Are you sure?", string.format("Do you want to close <color=255,30,30>%q</color> ?", activetab:GetText()), "Close", function()
+	if ed and not ed:IsSaved() and not dontask and not ed.IsOnline then
+		
+		local popup = self.closePopups[activetab]
+		if not IsValid(popup) then
+			local newPopup = SF.Editor.Query("Unsaved changes!", string.format("Do you want to close <color=255,30,30>%q</color> ?", activetab:GetText()), "Close", function()
 				self:CloseTab(activetab, true)
+				self.closePopups[activetab] = nil
 			end, "Cancel", function() end)
+			self.closePopups[activetab] = newPopup
 		end
+		
+		if IsValid(popup) then
+			popup:Center()
+			popup:MakePopup()
+		end
+		
 		return
 	end
 

--- a/lua/starfall/libs_sv/entities.lua
+++ b/lua/starfall/libs_sv/entities.lua
@@ -14,7 +14,6 @@ registerprivilege("entities.setPos", "Set Position", "Allows the user to telepor
 registerprivilege("entities.setAngles", "Set Angles", "Allows the user to rotate an entity to another orientation", { entities = {} })
 registerprivilege("entities.setEyeAngles", "Set eye angles", "Allows the user to rotate the view of an entity to another orientation", { entities = {} })
 registerprivilege("entities.setVelocity", "Set Velocity", "Allows the user to change the velocity of an entity", { entities = {} })
-registerprivilege("entities.setFrozen", "Set Frozen", "Allows the user to freeze and unfreeze an entity", { entities = {} })
 registerprivilege("entities.setSolid", "Set Solid", "Allows the user to change the solidity of an entity", { entities = {} })
 registerprivilege("entities.setMass", "Set Mass", "Allows the user to change the mass of an entity", { entities = {} })
 registerprivilege("entities.setInertia", "Set Inertia", "Allows the user to change the inertia of an entity", { entities = {} })
@@ -520,28 +519,6 @@ function ents_methods:use(usetype, value)
     ent:Use(instance.player, instance.entity, usetype, value)
 end
 
---- Sets the entity frozen state
--- @param boolean freeze Should the entity be frozen?
-function ents_methods:setFrozen(freeze)
-	local ent = getent(self)
-	local phys = ent:GetPhysicsObject()
-	if not phys:IsValid() then SF.Throw("Physics object is invalid", 2) end
-
-	checkpermission(instance, ent, "entities.setFrozen")
-
-	phys:EnableMotion(not (freeze and true or false))
-	phys:Wake()
-end
-
---- Checks the entities frozen state
--- @return boolean True if entity is frozen
-function ents_methods:isFrozen()
-	local ent = getent(self)
-	local phys = ent:GetPhysicsObject()
-	if not phys:IsValid() then SF.Throw("Physics object is invalid", 2) end
-	return not phys:IsMoveable()
-end
-
 --- Sets the entity to be Solid or not.
 -- @param boolean solid Should the entity be solid?
 function ents_methods:setSolid(solid)
@@ -696,6 +673,20 @@ function ents_methods:enableMotion(move)
 	phys:Wake()
 end
 
+--- Sets the entity frozen state, same as `Entity.enableMotion` but inverted
+-- @param boolean freeze Should the entity be frozen?
+function ents_methods:setFrozen(freeze)
+	self:enableMotion(not freeze)
+end
+
+--- Checks the entities frozen state
+-- @return boolean True if entity is frozen
+function ents_methods:isFrozen()
+	local ent = getent(self)
+	local phys = ent:GetPhysicsObject()
+	if not phys:IsValid() then SF.Throw("Physics object is invalid", 2) end
+	return not phys:IsMoveable()
+end
 
 --- Sets the physics of an entity to be a sphere
 -- @param boolean enabled Should the entity be spherical?


### PR DESCRIPTION
8f768a6b20c86f23d5bc862c94ab9749e3bf3aec broke functionality of the editor's tab `close all others` button, because it limited the popups to 1.  
Also changed popup's title to `Unsaved changes!` and made it re-center when it's brought up for the second time.