### PR TITLE
Add Hologram.setMoveType and fix FVPHYSICS docs

### DIFF
--- a/lua/starfall/libs_sh/enum.lua
+++ b/lua/starfall/libs_sh/enum.lua
@@ -425,6 +425,7 @@ env.EF = {
 	FOLLOWBONE = EF_FOLLOWBONE
 }
 
+--- ENUMs of physics object flags
 -- @name builtins_library.FVPHYSICS
 -- @class table
 -- @field CONSTRAINT_STATIC
@@ -454,6 +455,36 @@ env.FVPHYSICS = {
 	["PENETRATING"] = FVPHYSICS_PENETRATING,
 	["PLAYER_HELD"] = FVPHYSICS_PLAYER_HELD,
 	["WAS_THROWN"] = FVPHYSICS_WAS_THROWN,
+}
+
+--- ENUMs of entity move types
+-- @name builtins_library.MOVETYPE
+-- @class table
+-- @field NONE
+-- @field ISOMETRIC
+-- @field WALK
+-- @field STEP
+-- @field FLY
+-- @field FLYGRAVITY
+-- @field VPHYSICS
+-- @field PUSH
+-- @field NOCLIP
+-- @field LADDER
+-- @field OBSERVER
+-- @field CUSTOM
+env.MOVETYPE = {
+	NONE = MOVETYPE_NONE,
+	ISOMETRIC = MOVETYPE_ISOMETRIC,
+	WALK = MOVETYPE_WALK,
+	STEP = MOVETYPE_STEP,
+	FLY = MOVETYPE_FLY,
+	FLYGRAVITY = MOVETYPE_FLYGRAVITY,
+	VPHYSICS = MOVETYPE_VPHYSICS,
+	PUSH = MOVETYPE_PUSH,
+	NOCLIP = MOVETYPE_NOCLIP,
+	LADDER = MOVETYPE_LADDER,
+	OBSERVER = MOVETYPE_OBSERVER,
+	CUSTOM = MOVETYPE_CUSTOM,
 }
 
 --- ENUMs of in_keys for use with player:keyDown

--- a/lua/starfall/libs_sh/holograms.lua
+++ b/lua/starfall/libs_sh/holograms.lua
@@ -258,7 +258,7 @@ if SERVER then
 	-- @param number Movetype to set, either MOVETYPE.NOCLIP (default) or MOVETYPE.NONE
 	function hologram_methods:setMoveType(move)
 		if move ~= MOVETYPE_NONE and move ~= MOVETYPE_NOCLIP then
-			SF.Throw("Invalid movetype provided, must be either MOVETYPE.NOCLIP or MOVETYPE.NONE")
+			SF.Throw("Invalid movetype provided, must be either MOVETYPE.NOCLIP or MOVETYPE.NONE", 2)
 		end
 		local holo = getholo(self)
 		checkpermission(instance, holo, "hologram.setMoveType")

--- a/lua/starfall/libs_sh/holograms.lua
+++ b/lua/starfall/libs_sh/holograms.lua
@@ -26,7 +26,10 @@ local cl_hologram_meta = {
 	__eq = entmeta.__eq,
 }
 
-if CLIENT then
+if SERVER then
+	registerprivilege("hologram.setMoveType", "Set MoveType", "Allows the user to set hologram's movetype", { entities = {} })
+
+else
 	registerprivilege("hologram.setParent", "Set Parent", "Allows the user to parent a hologram", { entities = {} })
 
 	local function parentChildren(ent)
@@ -250,7 +253,17 @@ if SERVER then
 		holo:SetLocalAngularVelocity(aunwrap(angvel))
 	end
 
-
+	--- Sets the hologram's movetype
+	-- @server
+	-- @param number Movetype to set, either MOVETYPE.NOCLIP (default) or MOVETYPE.NONE
+	function hologram_methods:setMoveType(move)
+		if move ~= MOVETYPE_NONE and move ~= MOVETYPE_NOCLIP then
+			SF.Throw("Invalid movetype provided, must be either MOVETYPE.NOCLIP or MOVETYPE.NONE")
+		end
+		local holo = getholo(self)
+		checkpermission(instance, holo, "hologram.setMoveType")
+		holo:SetMoveType(move)
+	end
 
 else
 	--- Sets the hologram's position.


### PR DESCRIPTION
Did not find any issues when setting movetypes on holograms post creation.

- Add `MOVETYPE` enums
- Add serverside `hologram.setMoveType` permission
- Add serverside `Hologram.setMoveType` *(only `MOVETYPE_NONE` and `MOVETYPE_NOCLIP` are allowed)*
- Fix `FVPHYSICS` not displaying in the docs
