### PR TITLE
Don't draw hologram if setNoDraw is true and add Entity.getNoDraw

### DIFF
--- a/lua/entities/starfall_hologram/cl_init.lua
+++ b/lua/entities/starfall_hologram/cl_init.lua
@@ -37,15 +37,7 @@ function ENT:OnScaleChanged(name, old, scale)
 	end
 end
 
-function ENT:Think()
-	if self.AutomaticFrameAdvance then
-		self:FrameAdvance(0)
-	end
-end
-
-function ENT:Draw()
-	if self:GetNoDraw() then return end
-	
+function ENT:Draw(flags)
 	local clipCount = 0
 	local prevClip
 	if next(self.clips) then
@@ -68,10 +60,10 @@ function ENT:Draw()
 	
 	if self:GetSuppressEngineLighting() then
 		render.SuppressEngineLighting(true)
-		self:DrawModel()
+		self:DrawModel(flags)
 		render.SuppressEngineLighting(false)
 	else
-		self:DrawModel()
+		self:DrawModel(flags)
 	end
 	
 	if filter_mag then render.PopFilterMag() end
@@ -82,6 +74,10 @@ function ENT:Draw()
 			render.PopCustomClipPlane()
 		end
 		render.EnableClipping(prevClip)
+	end
+	
+	if self.AutomaticFrameAdvance then
+		self:FrameAdvance(0)
 	end
 end
 

--- a/lua/entities/starfall_hologram/cl_init.lua
+++ b/lua/entities/starfall_hologram/cl_init.lua
@@ -37,11 +37,13 @@ function ENT:OnScaleChanged(name, old, scale)
 	end
 end
 
-function ENT:Draw()
+function ENT:Think()
 	if self.AutomaticFrameAdvance then
 		self:FrameAdvance(0)
 	end
-	
+end
+
+function ENT:Draw()
 	if self:GetNoDraw() then return end
 	
 	local clipCount = 0

--- a/lua/entities/starfall_hologram/cl_init.lua
+++ b/lua/entities/starfall_hologram/cl_init.lua
@@ -38,6 +38,12 @@ function ENT:OnScaleChanged(name, old, scale)
 end
 
 function ENT:Draw()
+	if self.AutomaticFrameAdvance then
+		self:FrameAdvance(0)
+	end
+	
+	if self:GetNoDraw() then return end
+	
 	local clipCount = 0
 	local prevClip
 	if next(self.clips) then
@@ -74,10 +80,6 @@ function ENT:Draw()
 			render.PopCustomClipPlane()
 		end
 		render.EnableClipping(prevClip)
-	end
-	
-	if self.AutomaticFrameAdvance then
-		self:FrameAdvance(0)
 	end
 end
 

--- a/lua/starfall/libs_sh/entities.lua
+++ b/lua/starfall/libs_sh/entities.lua
@@ -327,6 +327,13 @@ function ents_methods:setNoDraw(draw)
 	ent:SetNoDraw(draw and true or false)
 end
 
+--- Checks whether the entity should be drawn
+-- @shared
+-- @return boolean True if should draw, False otherwise
+function ents_methods:getNoDraw()
+	return getent(self):GetNoDraw()
+end
+
 --- Sets the material of the entity
 -- @shared
 -- @param string material New material name.


### PR DESCRIPTION
- Don't draw holograms if `SetNoDraw` is `false`
- Handle animations in new `ENT.Think` hook instead of `ENT.Draw`
- Add shared `Entity.getNoDraw`

When a hologram is bonemerged using `EF.BONEMERGE` effect, it will be drawn despite having `0/1` alpha or using `SetNoDraw`.  
If we also allow the animations to continue playing, it will essentially allow us to share animations between models:
```lua
--@client
local owner, client, chip, world = owner(), player(), chip(), entity(0)

local holo1 = holograms.create(chip:getPos(), chip:getAngles(), "models/gman_high.mdl")
local holo2 = holograms.create(chip:getPos(), chip:getAngles(), "models/alyx.mdl")
holo2:setNoDraw(true)

holo1:setParent(holo2)
holo1:addEffects(EF.BONEMERGE)
holo2:setAnimation("sexyidle")
```
![image](https://user-images.githubusercontent.com/7283019/158865057-42e443aa-2b8f-4aee-83fc-bdfe865215e9.png)
