### PR TITLE
Add string.escapeMarkup and content alignment in Markup.draw

### DIFF
--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -1581,14 +1581,6 @@ function render_library.parseMarkup(str, maxsize)
 	return markwrap(markup.Parse(str, maxsize))
 end
 
---- Sanitizes text to be used in `render.parseMarkup`
--- @param string Text to sanitize
--- @return string Sanitized text
-function render_library.escapeMarkup(str)
-	checkluatype(str, TYPE_STRING)
-	return markup.Escape(str)
-end
-
 --- Draw the markup object
 -- @param number x number The x offset
 -- @param number y number The x offset

--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -1581,20 +1581,30 @@ function render_library.parseMarkup(str, maxsize)
 	return markwrap(markup.Parse(str, maxsize))
 end
 
+--- Sanitizes text to be used in `render.parseMarkup`
+-- @param string Text to sanitize
+-- @return string Sanitized text
+function render_library.escapeMarkup(str)
+	checkluatype(str, TYPE_STRING)
+	return markup.Escape(str)
+end
+
 --- Draw the markup object
 -- @param number x number The x offset
 -- @param number y number The x offset
--- @param number? xalign number The x TEXT_ALIGN. Default TEXT_ALIGN.LEFT
--- @param number? yalign number The y TEXT_ALIGN. Default TEXT_ALIGN.TOP
+-- @param number? xAlign number The x TEXT_ALIGN. Default TEXT_ALIGN.LEFT
+-- @param number? yAlign number The y TEXT_ALIGN. Default TEXT_ALIGN.TOP
 -- @param number? alpha The alpha to draw it with. Default 255
-function markup_methods:draw(x, y, xalign, yalign, a)
+-- @param number? contentAlign The content alignment TEXT_ALIGN. Default TEXT_ALIGN.LEFT
+function markup_methods:draw(x, y, xAlign, yAlign, alpha, contentAlign)
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	checkluatype(x, TYPE_NUMBER)
 	checkluatype(y, TYPE_NUMBER)
-	if xalign~=nil then checkluatype(xalign, TYPE_NUMBER) end
-	if yalign~=nil then checkluatype(yalign, TYPE_NUMBER) end
-	if a~=nil then checkluatype(a, TYPE_NUMBER) end
-	markunwrap(self):Draw(x, y, xalign, yalign, a)
+	if xAlign~=nil then checkluatype(xAlign, TYPE_NUMBER) end
+	if yAlign~=nil then checkluatype(yAlign, TYPE_NUMBER) end
+	if alpha~=nil then checkluatype(alpha, TYPE_NUMBER) end
+	if contentAlign~=nil then checkluatype(contentAlign, TYPE_NUMBER) end
+	markunwrap(self):Draw(x, y, xAlign, yAlign, alpha, contentAlign)
 end
 
 --- Get the object width

--- a/lua/starfall/libs_sh/string.lua
+++ b/lua/starfall/libs_sh/string.lua
@@ -7,25 +7,18 @@ local checkluatype = SF.CheckLuaType
 -- @libtbl string_library
 SF.RegisterLibrary("string")
 
+local markupEscapeSymbols = {
+	["&"] = "&amp;",
+	["<"] = "&lt;",
+	[">"] = "&gt;"
+}
+
 return function(instance)
 
 local col_meta, cwrap, cunwrap = instance.Types.Color, instance.Types.Color.Wrap, instance.Types.Color.Unwrap
 
 local string_library = instance.Libraries.string
 local sfstring = SF.SafeStringLib
-
-if CLIENT then
-	
-	--- Sanitizes text to be used in `render.parseMarkup`
-	-- @client
-	-- @param string str Text to sanitize
-	-- @return string Sanitized text
-	function string_library.escapeMarkup(str)
-		checkluatype(str, TYPE_STRING)
-		return markup.Escape(str)
-	end
-	
-end
 
 --- Converts color to a string.
 -- @class function
@@ -196,6 +189,15 @@ string_library.niceTime = sfstring.NiceTime
 -- @param string str The string to be sanitized
 -- @return string The sanitized string
 string_library.patternSafe = sfstring.patternSafe
+
+--- Sanitizes text to be used in `render.parseMarkup`
+-- @client
+-- @param string str Text to sanitize
+-- @return string Sanitized text
+function string_library.escapeMarkup(str)
+	checkluatype(str, TYPE_STRING)
+	return ( string.gsub(str, "[&<>]", markupEscapeSymbols) )
+end
 
 --- Repeats the given string n times
 -- @class function

--- a/lua/starfall/libs_sh/string.lua
+++ b/lua/starfall/libs_sh/string.lua
@@ -14,6 +14,19 @@ local col_meta, cwrap, cunwrap = instance.Types.Color, instance.Types.Color.Wrap
 local string_library = instance.Libraries.string
 local sfstring = SF.SafeStringLib
 
+if CLIENT then
+	
+	--- Sanitizes text to be used in `render.parseMarkup`
+	-- @client
+	-- @param string str Text to sanitize
+	-- @return string Sanitized text
+	function string_library.escapeMarkup(str)
+		checkluatype(str, TYPE_STRING)
+		return markup.Escape(str)
+	end
+	
+end
+
 --- Converts color to a string.
 -- @class function
 -- @param Color col The color to put in the string

--- a/lua/starfall/libs_sh/string.lua
+++ b/lua/starfall/libs_sh/string.lua
@@ -7,12 +7,6 @@ local checkluatype = SF.CheckLuaType
 -- @libtbl string_library
 SF.RegisterLibrary("string")
 
-local markupEscapeSymbols = {
-	["&"] = "&amp;",
-	["<"] = "&lt;",
-	[">"] = "&gt;"
-}
-
 return function(instance)
 
 local col_meta, cwrap, cunwrap = instance.Types.Color, instance.Types.Color.Wrap, instance.Types.Color.Unwrap
@@ -195,7 +189,7 @@ string_library.patternSafe = sfstring.patternSafe
 -- @return string Sanitized text
 function string_library.escapeMarkup(str)
 	checkluatype(str, TYPE_STRING)
-	return ( string.gsub(str, "[&<>]", markupEscapeSymbols) )
+	return ( string.gsub(str, "[&<>]", {["&"]="&amp;",["<"]="&lt;",[">"]="&gt;"}) )
 end
 
 --- Repeats the given string n times

--- a/lua/starfall/libs_sh/string.lua
+++ b/lua/starfall/libs_sh/string.lua
@@ -191,7 +191,6 @@ string_library.niceTime = sfstring.NiceTime
 string_library.patternSafe = sfstring.patternSafe
 
 --- Sanitizes text to be used in `render.parseMarkup`
--- @client
 -- @param string str Text to sanitize
 -- @return string Sanitized text
 function string_library.escapeMarkup(str)


### PR DESCRIPTION
- Add `string.escapeMarkup` to sanitize markup text
- Add new content alignment argument to `Markup.draw`
- Change `Markup.draw` params to use `camelCase`