### PR TITLE
add function, else, elseif to auto indenter

### DIFF
--- a/lua/starfall/editor/tabhandlers/tab_wire.lua
+++ b/lua/starfall/editor/tabhandlers/tab_wire.lua
@@ -2500,7 +2500,7 @@ function PANEL:_OnKeyCodeTyped(code)
 				end
 				local row = string_gsub(row,'%b""',"") -- erase strings on this line
 				if countMatches(row,{"{"},"}") > 0 or 
-					countMatches(row,{"%sthen%s","%sdo%s","%sfunction[%s%(]"},"%send%s") > 0 or 
+					countMatches(row,{"%sthen%s","%sdo%s","%sfunction[%s%(]","%selse%s"},"%send%s") > 0 or 
 					countMatches(row,{"%srepeat%s"},"%suntil%s") > 0 then 
 						tabs = tabs .. "    "
 				end


### PR DESCRIPTION
auto indenter now handles function, else, elseif correctly

the auto re-indent code no longer re-indents if the character following is either a space or a round bracket (previously only space). may cause unintended side effects such as not un-indenting if you type `end(` which might be wrong depending on how you look at it. but it's intended to catch `elseif(` and `until(` so it's good enough with that tradeoff imo

also slightly refactored the un-indent and re-indent code to have less code duplication