### PR TITLE
Add various missing functions, and also fix a crash

### DIFF
--- a/lua/starfall/libs_sh/entities.lua
+++ b/lua/starfall/libs_sh/entities.lua
@@ -1691,4 +1691,13 @@ function ents_methods:getBoundingRadius()
 	return getent(self):BoundingRadius()
 end
 
+--- Returns whether the entity is dormant or not, i.e. whether or not information about the entity is being sent to your client. Not to be confused with PhysObj:isAsleep
+-- Clientside, this will usually be true if the object is outside of your PVS (potentially visible set).
+-- Serverside, this will almost always be false.
+-- @shared
+-- @return boolean Whether entity is dormant or not.
+function ents_methods:isDormant()
+	return getent(self):IsDormant()
+end
+
 end

--- a/lua/starfall/libs_sh/entities.lua
+++ b/lua/starfall/libs_sh/entities.lua
@@ -1700,4 +1700,13 @@ function ents_methods:isDormant()
 	return getent(self):IsDormant()
 end
 
+--- Performs a Ray-Orientated Bounding Box intersection from the given position to the origin of the OBBox with the entity and returns the hit position on the OBBox.
+-- This relies on the entity having a collision mesh (not a physics object) and will be affected by SOLID_NONE
+-- @shared
+-- @param Vector The vector to start the intersection from.
+-- @return Vector The nearest hit point of the entity's bounding box in world coordinates, or Vector(0, 0, 0) for some entities such as worldspawn.
+function ents_methods:getNearestPoint(pos)
+	return vwrap(getent(self):NearestPoint(vunwrap(pos)))
+end
+
 end

--- a/lua/starfall/libs_sh/entities.lua
+++ b/lua/starfall/libs_sh/entities.lua
@@ -487,6 +487,16 @@ function ents_methods:getBodygroupName(id)
 	return getent(self):GetBodygroupName(id)
 end
 
+--- Returns the number of possible values for this bodygroup.
+-- Note that bodygroups are 0-indexed, so this will not return the maximum allowed value.
+-- @param number id The ID of the bodygroup to get the count for.
+-- @return number Number of values of specified bodygroup, or 0 if there are none.
+function ents_methods:getBodygroupCount(id)
+	checkluatype(id, TYPE_NUMBER)
+	checkbodygroup(id)
+	return getent(self):GetBodygroupCount(id)
+end
+
 --- Sets the skin of the entity
 -- @shared
 -- @param number skinIndex Index of the skin to use.

--- a/lua/starfall/libs_sh/entities.lua
+++ b/lua/starfall/libs_sh/entities.lua
@@ -423,7 +423,7 @@ end
 local checkbodygroup
 do
 	local maxid = 2^31-1 -- Maximum signed 32-bit integer ("long") value
-	local minid = -maxid
+	local minid = 0 -- One can go lower, but there's no point since the negative indexes are never used.
 	function checkbodygroup(id)
 		if id < minid or id > maxid then
 			SF.Throw("invalid bodygroup id", 3)

--- a/lua/starfall/libs_sh/entities.lua
+++ b/lua/starfall/libs_sh/entities.lua
@@ -1658,4 +1658,11 @@ function ents_methods:getNWVarTable()
 	return instance.Sanitize(getent(self):GetNWVarTable())
 end
 
+--- Returns the distance between the center of the entity's bounding box and whichever corner of the bounding box is farthest away.
+-- @shared
+-- @return number The radius of the bounding box, or 0 for some entities such as worldspawn
+function ents_methods:getBoundingRadius()
+	return getent(self):BoundingRadius()
+end
+
 end

--- a/lua/starfall/libs_sh/entities.lua
+++ b/lua/starfall/libs_sh/entities.lua
@@ -419,12 +419,26 @@ function ents_methods:setSubMaterial(index, material)
 	end
 end
 
+-- Invalid bodygroup IDs can cause crashes, so it's necessary to check that they are within range.
+local checkbodygroup
+do
+	local maxid = 2^31-1 -- Maximum signed 32-bit integer ("long") value
+	local minid = -maxid
+	function checkbodygroup(id)
+		if id < minid or id > maxid then
+			SF.Throw("invalid bodygroup id", 3)
+		end
+	end
+	SF.CheckBodygroup = checkbodygroup
+end
+
 --- Sets the bodygroup of the entity
 -- @shared
 -- @param number bodygroup The ID of the bodygroup you're setting.
 -- @param number value The value you're setting the bodygroup to.
 function ents_methods:setBodygroup(bodygroup, value)
 	checkluatype(bodygroup, TYPE_NUMBER)
+	checkbodygroup(bodygroup)
 	checkluatype(value, TYPE_NUMBER)
 
 	local ent = getent(self)
@@ -443,6 +457,7 @@ end
 -- @return number The bodygroup value
 function ents_methods:getBodygroup(id)
 	checkluatype(id, TYPE_NUMBER)
+	checkbodygroup(id)
 	return getent(self):GetBodygroup(id)
 end
 
@@ -468,6 +483,7 @@ end
 -- @return string The bodygroup name
 function ents_methods:getBodygroupName(id)
 	checkluatype(id, TYPE_NUMBER)
+	checkbodygroup(id)
 	return getent(self):GetBodygroupName(id)
 end
 

--- a/lua/starfall/libs_sh/physobj.lua
+++ b/lua/starfall/libs_sh/physobj.lua
@@ -188,6 +188,19 @@ function physobj_methods:setMaterial(material)
 	end
 end
 
+--- Returns the surface area of the object in Hammer units squared.
+-- @return number? Surface area, or nil if a generated sphere or box
+function physobj_methods:getSurfaceArea()
+	return unwrap(self):GetSurfaceArea()
+end
+
+--- Returns whether the entity is able to move.
+-- Inverse of Entity:isFrozen
+-- @return boolean Whether the object is moveable
+function physobj_methods:isMoveable()
+	return unwrap(self):IsMoveable()
+end
+
 if SERVER then
 	--- Sets the position of the physics object. Will cause interpolation of the entity in clientside, use entity.setPos to avoid this.
 	-- @server
@@ -523,7 +536,14 @@ if SERVER then
 	function physobj_methods:getVolume()
 		return unwrap(self):GetVolume()
 	end
-
+	
+	--- Returns the stress of the entity.
+	-- @server
+	-- @return number External stress. Usually about the mass of the object if on the ground, usually 0 if in freefall.
+	-- @return number Internal stress. Usually about the mass of every object resting on top of it combined.
+	function physobj_methods:getStress()
+		return unwrap(self):GetStress()
+	end
 end
 
 end


### PR DESCRIPTION
While writing a compatibility layer for running Expression 2 code in StarfallEx, I noticed a few functions were missing. This adds some of those functions, as well as some others I have noticed were missing.
Tested by updating [my ESP chip](https://gist.github.com/x4fx77x4f/446c4bfae2bddab0b62e110d2830c894) to use `Entity:isDormant`, and using [chat commands](https://github.com/x4fx77x4f/sfc2).

- Expose `Entity:BoundingRadius` as `Entity:getBoundingRadius` (for parity with Expression 2 `entity:radius()`)
- Expose `Entity:NearestPoint` as `Entity:getNearestPoint` (for parity with Expression 2 `entity:nearestPoint(vector)`)
- Expose `Entity:GetBodygroupCount` as `Entity:getBodygroupCount` (for parity with Expression 2 `entity:getBodygroups(number)`)
- Expose `PhysObj:GetSurfaceArea` as `PhysObj:getSurfaceArea` (for parity with Expression 2 `entity:surfaceArea()`)
- Expose `PhysObj:GetVolume` as `PhysObj:getVolume` (for parity with Expression 2 `entity:volume()`)
- Expose `PhysObj:GetStress` as `PhysObj:getStress` (for parity with Expression 2 `entity:stress()`) (Did you know this has a second, undocumented return value?)
- Expose `Entity:IsDormant` as `Entity:isDormant` (not available in Expression 2, but added because I needed it for ESP)
- Expose `PhysObj:IsMoveable` as `PhysObj:isMoveable` (used by Expression 2 for `entity:isFrozen()`, which is also used by StarfallEx `Entity:isFrozen`)
- **Fix a crash from using invalid bodygroup IDs** (`mesh.getModelMeshes` does not appear to be affected, and thus did not get the fix.) (I happened to notice this while implementing `Entity:getBodygroupCount`.)