### PR TITLE
Fix crash from calling render.drawTexturedRectUV with a malformed color

### DIFF
--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -1266,6 +1266,7 @@ function render_library.drawTexturedRectUV(x, y, w, h, startU, startV, endU, end
 
 	makeQuad(x, y, w, h)
 	mesh.Begin(MATERIAL_QUADS, 1)
+	local success, err = pcall(function()
 		mesh.Position( quad_v1 )
 		mesh.Color( r,g,b,a )
 		mesh.TexCoord( 0, startU, startV )
@@ -1282,7 +1283,11 @@ function render_library.drawTexturedRectUV(x, y, w, h, startU, startV, endU, end
 		mesh.Color( r,g,b,a )
 		mesh.TexCoord( 0, startU, endV )
 		mesh.AdvanceVertex()
+	end)
 	mesh.End()
+	if not success then
+		error(err, 2)
+	end
 end
 
 --- Draws a rotated, textured rectangle.

--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -1262,11 +1262,10 @@ function render_library.drawTexturedRectUV(x, y, w, h, startU, startV, endU, end
 	checkluatype (endU, TYPE_NUMBER)
 	checkluatype (endV, TYPE_NUMBER)
 
-	local r,g,b,a = currentcolor.r, currentcolor.g, currentcolor.b, currentcolor.a
-
 	makeQuad(x, y, w, h)
 	mesh.Begin(MATERIAL_QUADS, 1)
-	local success, err = pcall(function()
+	local success, err = pcall(function(startU, startV, endU, endV)
+		local r,g,b,a = currentcolor.r, currentcolor.g, currentcolor.b, currentcolor.a
 		mesh.Position( quad_v1 )
 		mesh.Color( r,g,b,a )
 		mesh.TexCoord( 0, startU, startV )
@@ -1283,7 +1282,7 @@ function render_library.drawTexturedRectUV(x, y, w, h, startU, startV, endU, end
 		mesh.Color( r,g,b,a )
 		mesh.TexCoord( 0, startU, endV )
 		mesh.AdvanceVertex()
-	end)
+	end, startU, startV, endU, endV)
 	mesh.End()
 	if not success then
 		error(err, 2)


### PR DESCRIPTION
One can call guest `render.setColor` with a malformed color, as it does not do any sanity checking. Most render functions will fail safely with a malformed color (I tested most of them), but guest `render.drawTexturedRectUV` uses host `mesh.Begin`. A malformed color will cause host `mesh.Color` to throw an error, which without this commit will result in `mesh.End` not being called, which will result in a crash. Relevant Garry's Mod issues: [#3805](https://github.com/Facepunch/garrysmod-issues/issues/3805), [#2665](https://github.com/Facepunch/garrysmod-issues/issues/2665), [#2594](https://github.com/Facepunch/garrysmod-issues/issues/2594)
Average execution time with fix is about 3 microseconds, compared to about 2 microseconds before. This could probably be brought down with some micro-optimizations (such as caching the `mesh` functions, or omitting the type checks).
Measured performance impact with this script:
```lua
--@client
--@superuser
local _timer_systime = timer.systime
local _render_drawTexturedRectUV = render.drawTexturedRectUV
enableHud(player(), true)
hook.add('renderoffscreen', '', function()
    hook.remove('renderoffscreen', '')
    local bench_avg, bench_min, bench_max
    for i=1, 100000 do
        local start = _timer_systime()
            _render_drawTexturedRectUV(0, 0, 256, 256, 0, 0, 1, 1)
        local stop = _timer_systime()
        local time = (stop-start)*1000*1000
        bench_avg = bench_avg and (bench_avg+time)/2 or time
        bench_min = bench_min and math.min(bench_min, time) or time
        bench_max = bench_max and math.max(bench_max, time) or time
    end
    printHud(string.format("avg: %.2fus, min: %dus, max: %dus", bench_avg, bench_min, bench_max))
end)
```
Related notes: Why does `render.pushViewMatrix` validate its parameters? Why does `render.captureImage` *not* validate its parameters? Neither `render.pushViewMatrix` nor `render.renderView` protect against the use of an `__index` metamethod, although I don't think that's exploitable. `render.readPixel` doesn't check that if you've called `render.capturePixels`, although I haven't heard of this causing problems in practice.