### PR TITLE
Fix pattern injection in requiredir/dodir allowing for denial of service

### DIFF
--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -727,6 +727,7 @@ function builtins_library.requiredir(path, loadpriority)
 
 	local curdir = string.match(debug.getinfo(2, "S").short_src, "SF:(.*[/\\])") or ""
 	path = SF.ChoosePath(path, curdir, function(testpath)
+		testpath = string.PatternSafe(testpath)
 		for file in pairs(instance.scripts) do
 			if string.match(file, "^"..testpath.."/[^/]+%.txt$") or string.match(file, "^"..testpath.."/[^/]+%.lua$") then
 				return true
@@ -748,6 +749,7 @@ function builtins_library.requiredir(path, loadpriority)
 		end
 	end
 
+	path = string.PatternSafe(path)
 	for file in pairs(instance.scripts) do
 		if not alreadyRequired[file] and (string.match(file, "^"..path.."/[^/]+%.txt$") or string.match(file, "^"..path.."/[^/]+%.lua$")) then
 			returns[file] = instance:require(file)
@@ -780,6 +782,7 @@ function builtins_library.dodir(path, loadpriority)
 
 	local curdir = string.match(debug.getinfo(2, "S").short_src, "SF:(.*[/\\])") or ""
 	path = SF.ChoosePath(path, curdir, function(testpath)
+		testpath = string.PatternSafe(testpath)
 		for file in pairs(instance.scripts) do
 			if string.match(file, "^"..testpath.."/[^/]+%.txt$") or string.match(file, "^"..testpath.."/[^/]+%.lua$") then
 				return true
@@ -801,6 +804,7 @@ function builtins_library.dodir(path, loadpriority)
 		end
 	end
 
+	path = string.PatternSafe(path)
 	for file in pairs(instance.scripts) do
 		if not alreadyRequired[file] and (string.match(file, "^"..path.."/[^/]+%.txt$") or string.match(file, "^"..path.."/[^/]+%.lua$")) then
 			returns[file] = instance.scripts[file]()

--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -708,7 +708,7 @@ end
 function builtins_library.require(path)
 	checkluatype(path, TYPE_STRING)
 
-	local curdir = string.match(debug.getinfo(2, "S").short_src, "SF:(.*[/\\])") or ""
+	local curdir = string.match(debug.getinfo(2, "S").short_src, "^SF:(.*[/\\])") or ""
 	path = SF.ChoosePath(path, curdir, function(testpath)
 		return instance.scripts[testpath]
 	end) or path
@@ -725,7 +725,7 @@ function builtins_library.requiredir(path, loadpriority)
 	checkluatype(path, TYPE_STRING)
 	if loadpriority~=nil then checkluatype(loadpriority, TYPE_TABLE) end
 
-	local curdir = string.match(debug.getinfo(2, "S").short_src, "SF:(.*[/\\])") or ""
+	local curdir = string.match(debug.getinfo(2, "S").short_src, "^SF:(.*[/\\])") or ""
 	path = SF.ChoosePath(path, curdir, function(testpath)
 		testpath = string.PatternSafe(testpath)
 		for file in pairs(instance.scripts) do
@@ -765,7 +765,7 @@ end
 -- @return ... Return value(s) of the script
 function builtins_library.dofile(path)
 	checkluatype(path, TYPE_STRING)
-	local curdir = string.match(debug.getinfo(2, "S").short_src, "SF:(.*[/\\])") or ""
+	local curdir = string.match(debug.getinfo(2, "S").short_src, "^SF:(.*[/\\])") or ""
 	path = SF.ChoosePath(path, curdir, function(testpath)
 		return instance.scripts[testpath]
 	end) or path
@@ -780,7 +780,7 @@ function builtins_library.dodir(path, loadpriority)
 	checkluatype(path, TYPE_STRING)
 	if loadpriority ~= nil then checkluatype(loadpriority, TYPE_TABLE) end
 
-	local curdir = string.match(debug.getinfo(2, "S").short_src, "SF:(.*[/\\])") or ""
+	local curdir = string.match(debug.getinfo(2, "S").short_src, "^SF:(.*[/\\])") or ""
 	path = SF.ChoosePath(path, curdir, function(testpath)
 		testpath = string.PatternSafe(testpath)
 		for file in pairs(instance.scripts) do


### PR DESCRIPTION
Guest `requiredir` and `dodir` create and use patterns based on the parameter given to `testfunc` by host `SF.ChoosePath`. Without this patch, the parameter (which is a path, and user controlled) is not sanitized, allowing for injection of arbitrary patterns into the "needle". The "haystack" is also user controlled, which allows for a malicious chip to include a file by the name of `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.lua`, and then call `requiredir` or `dodir` with a parameter of `.-.-.-.-.-.-.-.-.-.-.-b` (or some other malicious pattern), causing a hang.
Malicious haystack and needle copied from [here](https://github.com/Facepunch/garrysmod-requests/issues/1878#issuecomment-864294803).