### PR TITLE
Add ``WebSocket`` type based on chromium/awesomium

### DIFF
--- a/lua/starfall/libs_cl/socket.lua
+++ b/lua/starfall/libs_cl/socket.lua
@@ -132,6 +132,7 @@ sourcet["default"] = sourcet["until-closed"]
 socket.source = socket.choose(sourcet)
 
 --- Socket library. Only usable by owner of starfall.
+-- See the WebSocket type for a version of this that doesn't require a DLL, and supports secure websockets (wss)
 -- Beware "Blocking" functions; they will freeze the game. See http://w3.impa.br/~diego/software/luasocket/socket.html
 -- Install the gmcl_socket.core_*.dll binary file to lua/bin and create a 'gm_socket_whitelist.txt' file in steamapps/common
 -- Each line in the whitelist will allow luasocket to access the specified domain and port. They are formatted as 'domain:port' e.g. 'garrysmod.com:80', '*.com:80' '95.123.12.22:27015'

--- a/lua/starfall/libs_cl/websocket.lua
+++ b/lua/starfall/libs_cl/websocket.lua
@@ -162,8 +162,12 @@ local Callbacks = {
 -- @param v function
 function websocket_meta:__newindex(k, v)
 	local cb = Callbacks[k]
-	if cb and type(v) == "function" or v == nil then
-		unwrap(self)[k] = function(_, arg) v(self, arg) end
+	if cb then
+		if type(v) == "function" then
+			unwrap(self)[k] = function(_, arg) v(self, arg) end
+		elseif v == nil then
+			unwrap(self)[k] = nil
+		end
 	end
 end
 

--- a/lua/starfall/libs_cl/websocket.lua
+++ b/lua/starfall/libs_cl/websocket.lua
@@ -1,0 +1,152 @@
+--[[
+	Websocket Library
+]]
+
+local WebSocket = {}
+WebSocket.__index = WebSocket
+
+local function make_html(address)
+	address = string.JavascriptSafe(address)
+	return [[
+	<script>
+		var sf_websocket = new WebSocket("]] .. address .. [[");
+
+		sf_websocket.onmessage = function(event) { sf.on_message(event.data);             };
+		sf_websocket.onopen = function()         { sf.on_open();                          };
+		sf_websocket.onclose = function()        { sf.on_close(false);                    };
+		sf_websocket.onerror = function()        { sf.on_close(true);                     };
+
+		// Exposed functions to lua
+		sf.send = function(data) { sf_websocket.send(data); };
+
+		console.log("SF: Opened websocket to ]] .. address .. [[");
+	</script>
+	]]
+end
+
+local function hook_call(self, event)
+	return function(arg)
+		if self["on" .. event] then
+			self["on" .. event](self, arg)
+		end
+	end
+end
+
+function WebSocket.new(addr, port, secure)
+	return setmetatable({
+		callback = {},
+		address = (secure and "wss" or "ws") .. "://" .. addr .. ":" .. (port or "443"),
+	}, WebSocket)
+end
+
+function WebSocket:connect()
+	local panel = vgui.Create("DFrame", nil, nil)
+	panel:SetSize(0, 0)
+	panel:SetTitle("")
+	panel:SetDeleteOnClose(true)
+	panel.Paint = function() end
+
+	local html = vgui.Create("DHTML", p, nil)
+	html:AddFunction("sf", "on_message", hook_call(self, "Message"))
+	html:AddFunction("sf", "on_open", hook_call(self, "Connected"))
+	html:AddFunction("sf", "on_close", hook_call(self, "Disconnected"))
+	html:AddFunction("sf", "on_status", hook_call(self, "Status"))
+	html:SetAllowLua(false)
+	html:SetHTML(make_html(self.address))
+
+	self.html = html
+	self.panel = panel
+end
+
+function WebSocket:close()
+	local html = assert( self.html, "WebSocket not connected" )
+	html:RunJavascript("sf_websocket.close()")
+
+	self.panel:Clear()
+	self.panel:Remove()
+end
+
+function WebSocket:write(msg)
+	local html = assert( self.html, "WebSocket not connected" )
+	html:RunJavascript([[
+		if (sf_websocket.readyState == 1) {
+			sf_websocket.send("]] .. string.JavascriptSafe(msg) .. [[");
+		}
+	]])
+end
+
+--[[
+	End of Websocket library
+]]
+
+local checkluatype = SF.CheckLuaType
+
+--- Websocket Type. Create a websocket with websocket.new
+-- @name WebSocket
+-- @class type
+-- @libtbl websocket_methods
+-- @libtbl websocket_meta
+SF.RegisterType("WebSocket", true, false, WebSocket)
+
+return function(instance)
+
+if LocalPlayer() ~= instance.player then return end
+
+local websocket_methods, websocket_meta, wrap, unwrap = instance.Types.WebSocket.Methods, instance.Types.WebSocket, instance.Types.WebSocket.Wrap, instance.Types.WebSocket.Unwrap
+
+local websocket_list = {}
+
+--- Creates a new websocket object.
+-- @name builtins_library.WebSocket
+-- @param string addr Address of the websocket server.
+-- @param number? port Port of the websocket server.
+-- @param boolean? secure Whether to use secure connection (wss).
+-- @return WebSocket The websocket object. Use WebSocket:connect() to connect.
+function instance.env.WebSocket(addr, port, secure)
+	checkluatype(addr, TYPE_STRING)
+	if port ~= nil then checkluatype(port, TYPE_NUMBER) end
+	if secure ~= nil then checkluatype(secure, TYPE_BOOL) end
+
+	local websocket =  WebSocket.new(addr, port, secure)
+	websocket_list[websocket] = true
+	return wrap(websocket)
+end
+
+--- Closes the websocket connection. Does nothing if already closed
+function websocket_methods:close()
+	unwrap(self):close()
+end
+
+--- Sends a message to the connected websocket stream.
+-- @param string msg What to send
+function websocket_methods:write(msg)
+	unwrap(self):write(msg)
+end
+
+--- Connects to the websocket server.
+function websocket_methods:connect()
+	unwrap(self):connect()
+end
+
+local Callbacks = {
+	["onMessage"] = true,
+	["onConnected"] = true,
+	["onDisconnected"] = true
+}
+
+function websocket_meta:__newindex(k, v)
+	local cb = Callbacks[k]
+	if cb and type(v) == "function" or v == nil then
+		unwrap(self)[k] = v
+	end
+end
+
+instance:AddHook("deinitialize", function()
+	for socket in pairs(websocket_list) do
+		if socket.html then
+			socket:close()
+		end
+	end
+end)
+
+end


### PR DESCRIPTION
This is a version of the ``socket`` library which is much simpler and based on awesomium/chromium websockets, so it doesn't require a binary module.

Api is based off [GWSockets](https://github.com/FredyH/GWSockets). Originally had a library to create this like ``websocket.new`` but that seemed pointless for one method, so it's used as a builtin ``WebSocket`` just like something like ``Vector``.

Any thoughts on how the api should be structured (or if it is fine as is) would be appreciated.

There's no permissions set up right now (strictly owner only), but this should be fine to allow beyond just the owner using it since it doesn't require a binary module (if there was a whitelist added).