### PR TITLE
Refactor entities.setParent

### DIFF
--- a/lua/starfall/libs_sh/entities.lua
+++ b/lua/starfall/libs_sh/entities.lua
@@ -300,50 +300,54 @@ function ents_methods:getLinkedComponents()
 	return list
 end
 
---- Parents or unparents an entity. Only holograms can be parented to players and, in clientside, only clientside holograms can be parented.
+--- Parents or unparents an entity. Only holograms can be parented to players and clientside holograms can only be parented in the CLIENT realm.
 -- @param Entity? parent Entity parent (nil to unparent)
--- @param number|string? attachment Optional attachment name or ID
+-- @param number|string? attachment Optional attachment name or ID.
 -- @param number|string? bone Optional bone name or ID. Can't be used at the same time as attachment
 function ents_methods:setParent(parent, attachment, bone)
 	local child = getent(self)
-	if CLIENT and debug.getmetatable(child)~=SF.Cl_Hologram_Meta then SF.Throw("Can only setParent clientside holograms in the clientside!", 2) end
 	checkpermission(instance, child, "entities.setParent")
-	if attachment~=nil and bone~=nil then SF.Throw("Can't have both attachment and bone args set!", 2) end
+	if CLIENT and debug.getmetatable(child) ~= SF.Cl_Hologram_Meta then SF.Throw("Only clientside holograms can be parented in the CLIENT realm!", 2) end
+	if attachment ~= nil and bone ~= nil then SF.Throw("Arguments `attachment` and `bone` are mutually exclusive!", 2) end
+	
 	if parent ~= nil then
 		parent = getent(parent)
-		if parent:IsPlayer() and not child.IsSFHologram then SF.Throw("Can only setParent holograms onto players!", 2) end
-		local param, type
-		if bone~=nil then
+		if parent:IsPlayer() and not child.IsSFHologram then SF.Throw("Only holograms can be parented to players!", 2) end
+		
+		local type, param
+		if attachment ~= nil then
+			if CLIENT then SF.Throw("Parenting to an attachment is not supported in clientside!", 2) end
+			if isnumber(attachment) then
+				local attachments = parent:GetAttachments()
+				if attachments and attachments[attachment] then
+					attachment = attachments[attachment].name
+				else
+					SF.Throw("Invalid attachment ID provided!", 2)
+				end
+			elseif not isstring(attachment) then
+				SF.ThrowTypeError("string or number", SF.GetType(attachment), 2)
+			end
+			if parent:LookupAttachment(attachment) < 1 then SF.Throw("Invalid attachment provided!", 2) end
+			
+			type = "attachment"
+			param = attachment
+		elseif bone ~= nil then
 			if isstring(bone) then
 				bone = parent:LookupBone(bone) or -1
 			elseif not isnumber(bone) then
 				SF.ThrowTypeError("string or number", SF.GetType(bone), 2)
 			end
-			if bone < 0 or bone > 255 then SF.Throw("Invalid bone provided", 2) end
+			if bone < 0 or bone > 255 then SF.Throw("Invalid bone provided!", 2) end
+			
 			type = "bone"
 			param = bone
-		elseif attachment~=nil then
-			if CLIENT then SF.Throw("Can't use attachment argument in clientside!", 2) end
-			if isstring(attachment) then
-				attachment = parent:LookupAttachment(attachment)
-			elseif not isnumber(attachment) then
-				SF.ThrowTypeError("string or number", SF.GetType(attachment), 2)
-			end
-			if attachment < 0 or attachment > 255 then SF.Throw("Invalid attachment provided", 2) end
-			type = "attachment"
-			param = attachment
 		else
 			type = "entity"
 		end
-
-		SF.Parent(parent, child, type, param)
+		
+		SF.Parent(child, parent, type, param)
 	else
-		local sf_parent = child.sf_parent
-		if sf_parent then
-			sf_parent:setParent()
-		else
-			child:SetParent()
-		end
+		SF.Parent(child)
 	end
 end
 -- Backward compatability

--- a/lua/starfall/libs_sh/entities.lua
+++ b/lua/starfall/libs_sh/entities.lua
@@ -309,12 +309,10 @@ function ents_methods:setParent(parent, attachment, bone)
 	checkpermission(instance, child, "entities.setParent")
 	if CLIENT and debug.getmetatable(child) ~= SF.Cl_Hologram_Meta then SF.Throw("Only clientside holograms can be parented in the CLIENT realm!", 2) end
 	if attachment ~= nil and bone ~= nil then SF.Throw("Arguments `attachment` and `bone` are mutually exclusive!", 2) end
-	
 	if parent ~= nil then
 		parent = getent(parent)
 		if parent:IsPlayer() and not child.IsSFHologram then SF.Throw("Only holograms can be parented to players!", 2) end
-		
-		local type, param
+		local param, type
 		if bone ~= nil then
 			if isstring(bone) then
 				bone = parent:LookupBone(bone) or -1
@@ -322,29 +320,28 @@ function ents_methods:setParent(parent, attachment, bone)
 				SF.ThrowTypeError("string or number", SF.GetType(bone), 2)
 			end
 			if bone < 0 or bone > 255 then SF.Throw("Invalid bone provided!", 2) end
-			
 			type = "bone"
 			param = bone
 		elseif attachment ~= nil then
 			if CLIENT then SF.Throw("Parenting to an attachment is not supported in clientside!", 2) end
-			if isnumber(attachment) then
+			if isstring(attachment) then
+				if parent:LookupAttachment(attachment) < 1 then SF.Throw("Invalid attachment provided!", 2) end
+			elseif isnumber(attachment) then
 				local attachments = parent:GetAttachments()
 				if attachments and attachments[attachment] then
 					attachment = attachments[attachment].name
 				else
 					SF.Throw("Invalid attachment ID provided!", 2)
 				end
-			elseif not isstring(attachment) then
+			else
 				SF.ThrowTypeError("string or number", SF.GetType(attachment), 2)
 			end
-			if parent:LookupAttachment(attachment) < 1 then SF.Throw("Invalid attachment provided!", 2) end
-			
 			type = "attachment"
 			param = attachment
 		else
 			type = "entity"
 		end
-		
+
 		SF.Parent(child, parent, type, param)
 	else
 		SF.Parent(child)

--- a/lua/starfall/libs_sh/entities.lua
+++ b/lua/starfall/libs_sh/entities.lua
@@ -315,7 +315,17 @@ function ents_methods:setParent(parent, attachment, bone)
 		if parent:IsPlayer() and not child.IsSFHologram then SF.Throw("Only holograms can be parented to players!", 2) end
 		
 		local type, param
-		if attachment ~= nil then
+		if bone ~= nil then
+			if isstring(bone) then
+				bone = parent:LookupBone(bone) or -1
+			elseif not isnumber(bone) then
+				SF.ThrowTypeError("string or number", SF.GetType(bone), 2)
+			end
+			if bone < 0 or bone > 255 then SF.Throw("Invalid bone provided!", 2) end
+			
+			type = "bone"
+			param = bone
+		elseif attachment ~= nil then
 			if CLIENT then SF.Throw("Parenting to an attachment is not supported in clientside!", 2) end
 			if isnumber(attachment) then
 				local attachments = parent:GetAttachments()
@@ -331,16 +341,6 @@ function ents_methods:setParent(parent, attachment, bone)
 			
 			type = "attachment"
 			param = attachment
-		elseif bone ~= nil then
-			if isstring(bone) then
-				bone = parent:LookupBone(bone) or -1
-			elseif not isnumber(bone) then
-				SF.ThrowTypeError("string or number", SF.GetType(bone), 2)
-			end
-			if bone < 0 or bone > 255 then SF.Throw("Invalid bone provided!", 2) end
-			
-			type = "bone"
-			param = bone
 		else
 			type = "entity"
 		end

--- a/lua/starfall/libs_sh/holograms.lua
+++ b/lua/starfall/libs_sh/holograms.lua
@@ -251,9 +251,9 @@ else
 		holo:SetPos(pos)
 
 		if CLIENT then
-			local sf_parent = holo.sf_parent
-			if sf_parent and sf_parent.parent and sf_parent.parent:IsValid() then
-				sf_parent:updateTransform()
+			local sfParent = holo.sfParent
+			if sfParent and sfParent.parent and sfParent.parent:IsValid() then
+				sfParent:updateTransform()
 			end
 		end
 	end
@@ -269,9 +269,9 @@ else
 		holo:SetAngles(angle)
 		
 		if CLIENT then
-			local sf_parent = holo.sf_parent
-			if sf_parent and sf_parent.parent and sf_parent.parent:IsValid() then
-				sf_parent:updateTransform()
+			local sfParent = holo.sfParent
+			if sfParent and sfParent.parent and sfParent.parent:IsValid() then
+				sfParent:updateTransform()
 			end
 		end
 	end

--- a/lua/starfall/sflib.lua
+++ b/lua/starfall/sflib.lua
@@ -579,7 +579,6 @@ if CLIENT then
 	hook.Add("NotifyShouldTransmit", "SF_HologramParentFix", function(ent)
 		local sfParent = ent.sfParent
 		if sfParent then
-			print("SF_HologramParentFix", sfParent.ent)
 			sfParent:fix()
 		end
 	end)

--- a/lua/starfall/sflib.lua
+++ b/lua/starfall/sflib.lua
@@ -506,7 +506,7 @@ SF.Parent = {
 			}
 		},
 		
-		init = function(self, parent, type, param)
+		setParent = function(self, parent, type, param)
 			if self.parent and self.parent:IsValid() then
 				self:remove()
 				self.parent.sfParent.children[self.ent] = nil
@@ -515,15 +515,15 @@ SF.Parent = {
 			if parent then
 				self.param = param
 				self.parent = parent
-				self.set, self.remove = unpack(self.types[type])
+				self.init, self.remove = unpack(self.types[type])
 				parent.sfParent.children[self.ent] = self
 				
 				self:updateTransform()
-				self:set()
+				self:init()
 			else
 				self.param = nil
 				self.parent = nil
-				self.set, self.remove = nil, nil
+				self.init, self.remove = nil, nil
 			end
 		end,
 		
@@ -532,7 +532,7 @@ SF.Parent = {
 			for child, data in pairs(self.children) do
 				if child:IsValid() then
 					data:applyTransform()
-					data:set()
+					data:init()
 					has_children = true
 					
 					if child.sfParent then
@@ -566,9 +566,9 @@ SF.Parent = {
 				}, meta)
 			end
 			
-			child.sfParent:init(parent, type, param)
+			child.sfParent:setParent(parent, type, param)
 		elseif child.sfParent then
-			child.sfParent:init()
+			child.sfParent:setParent()
 		end
 	end,
 }

--- a/lua/starfall/sflib.lua
+++ b/lua/starfall/sflib.lua
@@ -466,27 +466,91 @@ SF.BlockedList = {
 }
 setmetatable(SF.BlockedList, SF.BlockedList)
 
-
 SF.Parent = {
+	__call = function(meta, child, parent, type, param)
+		if parent then
+			if SF.ParentChainTooLong(parent, child) then SF.Throw("Parenting chain cannot exceed 16 or crash may occur", 3) end
+			
+			if not parent.sfParent then
+				parent.sfParent = setmetatable({
+					ent = parent,
+					children = {},
+				}, meta)
+			end
+			
+			if not child.sfParent then
+				child.sfParent = setmetatable({
+					ent = child,
+					children = {},
+				}, meta)
+			end
+			
+			child.sfParent:init(parent, type, param)
+		elseif child.sfParent then
+			child.sfParent:init()
+		end
+	end,
+	
 	__index = {
+		init = function(self, parent, type, param)
+			if self.parent and self.parent:IsValid() then
+				self:remove()
+				self.parent.sfParent.children[self.ent] = nil
+			end
+			
+			if parent then
+				self.param = param
+				self.parent = parent
+				self.set, self.remove = unpack(self.types[type])
+				parent.sfParent.children[self.ent] = self
+				
+				self:updateTransform()
+				self:set()
+			else
+				self.param = nil
+				self.parent = nil
+				self.set, self.remove = nil, nil
+			end
+		end,
+		
+		fix = function(self)
+			local has_children
+			for child, data in pairs(self.children) do
+				if child:IsValid() then
+					data:applyTransform()
+					data:set()
+					has_children = true
+					
+					if child.sfParent then
+						child.sfParent:fix()
+					end
+				else
+					self.children[child] = nil
+				end
+			end
+			if not has_children then
+				self.ent.sfParent = nil
+			end
+		end,
+		
 		updateTransform = function(self)
 			self.pos, self.ang = WorldToLocal(self.ent:GetPos(), self.ent:GetAngles(), self.parent:GetPos(), self.parent:GetAngles())
 		end,
-
+		
 		applyTransform = function(self)
 			local pos, ang = LocalToWorld(self.pos, self.ang, self.parent:GetPos(), self.parent:GetAngles())
 			self.ent:SetPos(pos)
 			self.ent:SetAngles(ang)
 		end,
 		
-		setParents = {
+		types = {
 			entity = {
 				function(self)
 					self.ent:SetParent(self.parent)
 				end,
 				function(self)
 					self.ent:SetParent()
-				end
+				end,
 			},
 			attachment = {
 				function(self)
@@ -495,7 +559,7 @@ SF.Parent = {
 				end,
 				function(self)
 					self.ent:SetParent()
-				end
+				end,
 			},
 			bone = {
 				function(self)
@@ -503,82 +567,21 @@ SF.Parent = {
 				end,
 				function(self)
 					self.ent:FollowBone(NULL, 0)
-				end
+				end,
 			}
-		},
-
-		setParent = function(self, parent, type, param)
-			if self.parent and self.parent:IsValid() then
-				self.parent.sf_parent.children[self.ent] = nil
-				self:unParentType()
-			end
-			if parent then
-				self.parent = parent
-				self.param = param
-				self.setParentType, self.unParentType = unpack(self.setParents[type])
-
-				local sf_parent = parent.sf_parent
-				if sf_parent then
-					sf_parent.children[self.ent] = self
-				end
-				self:updateTransform()
-				self:setParentType()
-			else
-				self.parent = nil
-				self.param = nil
-				self.setParentType = nil
-				self.unParentType = nil
-			end
-		end,
-
-		fix = function(self)
-			local empty = true
-			if self.parent and self.parent:IsValid() then
-				self:applyTransform()
-				self:setParentType()
-				empty = false
-			end
-			for child, data in pairs(self.children) do
-				if child:IsValid() then
-					data:applyTransform()
-					data:setParentType()
-					empty = false
-				else
-					self.children[child] = nil
-				end
-			end
-			if empty then
-				self.ent.sf_parent = nil
-			end
-		end,
-	},
-	__call = function(meta, parent, child, type, param)
-		if SF.ParentChainTooLong(parent, child) then SF.Throw("Parenting chain of entities can't exceed 16 or crash may occur", 3) end
-		if not parent.sf_parent then
-			parent.sf_parent = setmetatable({
-				ent = parent,
-				children = {}
-			}, meta)
-		end
-
-		local sf_parent = child.sf_parent
-		if not sf_parent then
-			sf_parent = setmetatable({
-				ent = child,
-				children = {}
-			}, meta)
-			child.sf_parent = sf_parent
-		end
-		sf_parent:setParent(parent, type, param)
-	end
+		}
+	}
 }
 setmetatable(SF.Parent, SF.Parent)
 
 if CLIENT then
-	-- Need to fix the children and parent of any entity retransmitted
-	hook.Add("NotifyShouldTransmit", "SF_HologramReparent", function(ent)
-		local sf_parent = ent.sf_parent
-		if sf_parent then sf_parent:fix() end
+	-- When parent is retransmitted, it loses it's children
+	hook.Add("NotifyShouldTransmit", "SF_HologramParentFix", function(ent)
+		local sfParent = ent.sfParent
+		if sfParent then
+			print("SF_HologramParentFix", sfParent.ent)
+			sfParent:fix()
+		end
 	end)
 end
 

--- a/lua/starfall/sflib.lua
+++ b/lua/starfall/sflib.lua
@@ -515,15 +515,15 @@ SF.Parent = {
 			if parent then
 				self.param = param
 				self.parent = parent
-				self.init, self.remove = unpack(self.types[type])
+				self.apply, self.remove = unpack(self.types[type])
 				parent.sfParent.children[self.ent] = self
 				
 				self:updateTransform()
-				self:init()
+				self:apply()
 			else
 				self.param = nil
 				self.parent = nil
-				self.init, self.remove = nil, nil
+				self.apply, self.remove = nil, nil
 			end
 		end,
 		
@@ -532,7 +532,7 @@ SF.Parent = {
 			for child, data in pairs(self.children) do
 				if child:IsValid() then
 					data:applyTransform()
-					data:init()
+					data:apply()
 					has_children = true
 					
 					if child.sfParent then

--- a/lua/starfall/sflib.lua
+++ b/lua/starfall/sflib.lua
@@ -569,6 +569,8 @@ SF.Parent = {
 			child.sfParent:setParent(parent, type, param)
 		elseif child.sfParent then
 			child.sfParent:setParent()
+		else
+			child:SetParent()
 		end
 	end,
 }


### PR DESCRIPTION
Fixes: #1336

- `SetParentAttachmentMaintainOffset` error is gone
- Fixed chain parenting (`sf_parent:fix()` wasn't recursive)
- Didn't bother with issue 5 and 6, mentioned in #1336, maybe I'll try to figure out what's going on, but not in this PR
- Renamed `sf_parent` to `sfParent`
- Many minor changes (I rewrote the thing, but flow and logic should be pretty similar)
- Known issue: `FollowBone` is messed up on serverside (GMod bug), I tried many different things, some of them sorta worked, but nothing solid, so I'm not doing anything to help with consistency for now. Maybe I'll figure out something in the future.

___

https://github.com/thegrb93/StarfallEx/blob/96ab9510cfc1b2601b0c654a15c08db7cd8ea218/lua/starfall/sflib.lua#L536-L540
This shouldn't be needed, parent is responsible for informing it's children to re-parent. Children do not trigger `NotifyShouldTransmit`

___

https://github.com/thegrb93/StarfallEx/blob/96ab9510cfc1b2601b0c654a15c08db7cd8ea218/lua/starfall/sflib.lua#L520-L521
This check shouldn't be needed, `init` will be called from `__call` after `parent` is assigned `sfParent`.
