### PR TITLE
Add PreDrawSkyBox hook & PostDrawSkyBox hook

### DIFF
--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -323,6 +323,16 @@ end, function(instance)
 	return true
 end)
 
+--- Called before the 3D skybox is drawn. This will not be called for maps with no 3D skybox, or when the 3d skybox is disabled
+-- @name predrawskybox
+-- @class hook
+-- @client
+-- @return boolean Return true to not predraw the skybox both 2d and 3d
+SF.hookAdd("PreDrawSkyBox", nil, hudPrepareSafeArgs,
+function(instance, args)
+    if args[1] and args[2]==true then return true end
+end)
+
 --- Called when the engine wants to calculate the player's view. Only works if connected to Starfall HUD
 -- @name calcview
 -- @class hook

--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -333,6 +333,12 @@ function(instance, args)
     if args[1] and args[2]==true then return true end
 end)
 
+--- Called after the 3D skybox is drawn. This will not be called if PreDrawSkyBox has prevented rendering of the skybox
+-- @name postdrawskybox
+-- @class hook
+-- @client
+SF.hookAdd("PostDrawSkyBox", nil, hudPrepareSafeArgs, cleanupRender)
+
 --- Called when the engine wants to calculate the player's view. Only works if connected to Starfall HUD
 -- @name calcview
 -- @class hook

--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -328,8 +328,8 @@ end)
 -- @class hook
 -- @client
 -- @return boolean Return true to not predraw the skybox both 2d and 3d
-SF.hookAdd("PreDrawSkyBox", nil, hudPrepareSafeArgs,
-function(instance, args)
+SF.hookAdd("PreDrawSkyBox", nil, hudPrepareSafeArgs, function(instance, args)
+	instance:cleanupRender()
     if args[1] and args[2]==true then return true end
 end)
 


### PR DESCRIPTION
Tested PreDrawSkyBox in-game, functions as intended, skybox no longer draws when returned true, and draws when returned false. Tested PostDrawSkyBox in-game, also functions as intended, calls when skybox is drawn, unless PreDrawSkyBox prevents the drawing of the skybox.