### PR TITLE
Fix hologram retaining parent's velocity after unparenting

### DIFF
--- a/lua/starfall/libs_sh/holograms.lua
+++ b/lua/starfall/libs_sh/holograms.lua
@@ -214,6 +214,7 @@ if SERVER then
 		checkpermission(instance, holo, "hologram.setRenderProperty")
 
 		holo:SetLocalVelocity(vel)
+		holo.targetLocalVelocity = vel ~= vector_origin and vel or nil
 	end
 
 	--- Sets the hologram's angular velocity.

--- a/lua/starfall/sflib.lua
+++ b/lua/starfall/sflib.lua
@@ -485,7 +485,9 @@ SF.Parent = {
 					self.ent:SetParent(self.parent)
 				end,
 				function(self)
-					self.ent:SetParent()
+					local ent = self.ent
+					ent:SetParent()
+					ent:SetLocalVelocity(ent.targetLocalVelocity or vector_origin)
 				end
 			},
 			attachment = {
@@ -502,7 +504,9 @@ SF.Parent = {
 					self.ent:FollowBone(self.parent, self.param)
 				end,
 				function(self)
-					self.ent:FollowBone(NULL, 0)
+					local ent = self.ent
+					ent:FollowBone(NULL, 0)
+					ent:SetLocalVelocity(ent.targetLocalVelocity or vector_origin)
 				end
 			}
 		},


### PR DESCRIPTION
Entities with `MOVETYPE_NOCLIP` seem to retain parent's velocity ([`Entity.GetAbsVelocity`](https://wiki.facepunch.com/gmod/Entity:GetAbsVelocity)) when unparented.
Reproducing:
```lua
--@server

local holo = holograms.create(chip():getPos(), chip():getAngles(), "models/holograms/cube.mdl")
holo:setParent(owner())

concmd("+forward")
timer.simple(0.2, function()
    holo:setParent(nil)
    holo:setPos(chip():getPos()) -- optional
    concmd("-forward")
end)
```
This happens mostly on players (and bots), but I was also able to force it on normal props.

While the fix works, I'm still not quite sure about the exact cause, so accept at your own risk.