### PR TITLE
Normalize code before comparison (#1348)

### DIFF
--- a/lua/starfall/editor/editor.lua
+++ b/lua/starfall/editor/editor.lua
@@ -130,6 +130,13 @@ if CLIENT then
 		return path
 	end
 
+	--- Converts given text to LF and tabs to spaces.
+	-- Every code which goes into the editor is normalized first.
+	-- Note: remember to normalize every input file when comparing it to already open files to avoid inconsistencies.
+	function SF.Editor.normalizeCode(code)
+		return string.gsub(code, "[\r\t]", {["\r"]="", ["\t"]="    "})
+	end
+
 	function SF.Editor.renameFile(oldFile, newFile)
 		if file.Exists(newFile, "DATA") then
 			SF.AddNotify(LocalPlayer(), "Failed to rename. File already exists there.", "ERROR", 7, "ERROR1")

--- a/lua/starfall/editor/sfframe.lua
+++ b/lua/starfall/editor/sfframe.lua
@@ -1440,7 +1440,7 @@ function Editor:ChosenFile(Line, code)
 	if not code then
 		code = Line and file.Read(Line)
 		if code then
-			code = string.gsub(code, "[\r\t]", {["\r"]="", ["\t"]="    "})
+			code = SF.Editor.normalizeCode(code)
 		end
 	end
 	self:GetCurrentTabContent().savedCode = code
@@ -1542,8 +1542,9 @@ function Editor:Open(Line, code, forcenewtab, checkFileExists)
 	self:SetV(true)
 	if code then
 		if not forcenewtab then
+			local normalizedCode = SF.Editor.normalizeCode(code)
 			for i = 1, self:GetNumTabs() do
-				if self:GetTabContent(i):GetCode() == code then
+				if self:GetTabContent(i):GetCode() == normalizedCode then
 					self:SetActiveTab(i)
 					return
 				end

--- a/lua/starfall/editor/tabhandlers/tab_wire.lua
+++ b/lua/starfall/editor/tabhandlers/tab_wire.lua
@@ -845,7 +845,7 @@ function PANEL:OnMouseReleased(code)
 end
 
 function PANEL:SetCode(text)
-	text = string_gsub(text, "[\r\t]", {["\r"]="", ["\t"]="    "})
+	text = SF.Editor.normalizeCode(text)
 	if text == self:GetCode() then return end
 	self.Rows = {}
 	self.RowTexts = {}


### PR DESCRIPTION
Fixes https://github.com/thegrb93/StarfallEx/issues/1348 by normalizing code when a search for an already open tab is performed. This fixes a rare case where files from public libs containing tab or CRLF characters would open multiple tabs if clicked on multiple times. I guess most people wouldn't even notice this bug, but I need it fixed for a thing I'm working on.
Besides the fix, I extracted this code normalization into a separate function to avoid repeated code and left a note for other editor devs to remember to normalize the input before doing something with it.