### PR TITLE
Add SOLID and FSOLID related getter methods and enums

### DIFF
--- a/lua/starfall/libs_sh/entities.lua
+++ b/lua/starfall/libs_sh/entities.lua
@@ -643,6 +643,24 @@ function ents_methods:getCollisionGroup()
 	return getent(self):GetCollisionGroup()
 end
 
+--- Gets the solid enum of the entity
+-- @return number The solid enum of the entity. https://wiki.facepunch.com/gmod/Enums/SOLID
+function ents_methods:getSolid()
+	return getent(self):GetSolid()
+end
+
+--- Gets the solid flag enum of the entity
+-- @return number The solid flag enum of the entity. https://wiki.facepunch.com/gmod/Enums/FSOLID
+function ents_methods:getSolidFlags()
+	return getent(self):GetSolidFlags()
+end
+
+--- Gets whether an entity is solid or not
+-- @return boolean whether an entity is solid or not
+function ents_methods:isSolid()
+	return getent(self):IsSolid()
+end
+
 --- Gets the movetype enum of the entity
 -- @return number The movetype enum of the entity. https://wiki.facepunch.com/gmod/Enums/MOVETYPE
 function ents_methods:getMoveType()

--- a/lua/starfall/libs_sh/enum.lua
+++ b/lua/starfall/libs_sh/enum.lua
@@ -611,6 +611,55 @@ env.COLLISION_GROUP = {
 	["WORLD"] = COLLISION_GROUP_WORLD
 }
 
+
+--- ENUMs of solid for use with entity:getSolid
+-- @name builtins_library.SOLID
+-- @class table
+-- @field NONE
+-- @field BSP
+-- @field BBOX
+-- @field OBB
+-- @field OBB_YAW
+-- @field CUSTOM
+-- @field VPHYSICS
+
+env.SOLID = {
+	["NONE"] = SOLID_NONE,
+	["BSP"] = SOLID_BSP,
+	["BBOX"] = SOLID_BBOX,
+	["OBB"] = SOLID_OBB,
+	["OBB_YAW"] = SOLID_OBB_YAW,
+	["CUSTOM"] = SOLID_CUSTOM,
+	["VPHYSICS"] = SOLID_VPHYSICS
+}
+
+--- ENUMs of solid flags for use with entity:getSolidFlags
+-- @name builtins_library.FSOLID
+-- @class table
+-- @field FSOLID_CUSTOMRAYTEST
+-- @field FSOLID_CUSTOMBOXTEST
+-- @field FSOLID_NOT_SOLID
+-- @field FSOLID_TRIGGER
+-- @field FSOLID_NOT_STANDABLE
+-- @field FSOLID_VOLUME_CONTENTS
+-- @field FSOLID_FORCE_WORLD_ALIGNED
+-- @field FSOLID_USE_TRIGGER_BOUNDS
+-- @field FSOLID_ROOT_PARENT_ALIGNED
+-- @field FSOLID_TRIGGER_TOUCH_DEBRIS
+
+env.FSOLID = {
+	["CUSTOMRAYTEST"] = FSOLID_CUSTOMRAYTEST or 1,
+	["CUSTOMBOXTEST"] = FSOLID_CUSTOMBOXTEST or 2,
+	["NOT_SOLID"] = FSOLID_NOT_SOLID or 4,
+	["TRIGGER"] = FSOLID_TRIGGER or 8,
+	["NOT_STANDABLE"] = FSOLID_NOT_STANDABLE or 16,
+	["VOLUME_CONTENTS"] = FSOLID_VOLUME_CONTENTS or 32,
+	["FORCE_WORLD_ALIGNED"] = FSOLID_FORCE_WORLD_ALIGNED or 64,
+	["USE_TRIGGER_BOUNDS"] = FSOLID_USE_TRIGGER_BOUNDS or 128,
+	["ROOT_PARENT_ALIGNED"] = FSOLID_ROOT_PARENT_ALIGNED or 256,
+	["TRIGGER_TOUCH_DEBRIS"] = FSOLID_TRIGGER_TOUCH_DEBRIS or 512
+}
+
 --- ENUMs of mesh types. To be used with mesh.generate.
 -- @name builtins_library.MATERIAL
 -- @class table


### PR DESCRIPTION
This pull request adds the SOLID and FSOLID enums, as well as getter methods to interact with them:

isSolid - Returns whether the entity is solid or not. I think it can help determine if a prop has had propnotsolid used on it (E2 function). (This does not use the SOLID enums). It uses this function internally: https://wiki.facepunch.com/gmod/Entity:IsSolid

getSolid - Returns the solid type enum of an entity. It uses this function internally: https://wiki.facepunch.com/gmod/Entity:GetSolid

getSolidFlags - Returns the solid flags type enum of an entity. It uses this function internally: https://wiki.facepunch.com/gmod/Entity:GetSolidFlags

The SOLID and FSOLID enums have been added and their meanings can be found here:
https://wiki.facepunch.com/gmod/Enums/SOLID
https://wiki.facepunch.com/gmod/Enums/FSOLID