### PR TITLE
Add ReadWriteType to public libs

### DIFF
--- a/lua/starfall/editor/sfderma.lua
+++ b/lua/starfall/editor/sfderma.lua
@@ -270,6 +270,7 @@ function PANEL:Setup(folder)
 		{"GifLoader", "https://raw.githubusercontent.com/thegrb93/MyStarfallScripts/master/libs/gifspritesheet.txt"},
 		{"HoloText", "https://raw.githubusercontent.com/Derpius/public-starfalls/master/libs/holotext/main.txt"},
 		{"HttpQueue", "https://raw.githubusercontent.com/ANormalTwig/PublicStarfalls/main/libraries/http_queueing.lua"},
+		{"ReadWriteType", "https://raw.githubusercontent.com/Jacbo1/Public-Starfall/main/ReadWriteType/readwritetype.lua"},
 		{"SafeNet", "https://raw.githubusercontent.com/Jacbo1/Public-Starfall/main/SafeNet/safeNet.lua"},
 		{"XInputNet", "https://raw.githubusercontent.com/thegrb93/MyStarfallScripts/master/libs/xinput.txt"},
 	} do


### PR DESCRIPTION
Allows reading and writing different datatypes, tables, and even varargs to and from files.  
Supports Angle, boolean, Color, double, float, int8, uint8, int16, uint16, int24, uint24, int32, uint32, Quaternion, string, table, varargs, Vector, VMatrix, and nil.  Also allows async reading and writing of tables and varargs.  
Github page for ReadWriteType is [here](https://github.com/Jacbo1/Public-Starfall/tree/main/ReadWriteType)