### PR TITLE
Editor file auto-reload on upload

### DIFF
--- a/lua/entities/starfall_processor/shared.lua
+++ b/lua/entities/starfall_processor/shared.lua
@@ -148,6 +148,13 @@ function ENT:SetupFiles(sfdata)
 	end
 end
 
+---Does this chip depend on the script with name `filename`
+---@param filename string This is a name like `script1.txt`
+---@return boolean depends Does it depend on `filename`
+function ENT:DependsOnFile(filename)
+	return self.sfdata.files[filename] ~= nil
+end
+
 function ENT:GetGateName()
 	return self.name
 end
@@ -213,6 +220,17 @@ local function MenuOpen( ContextMenu, Option, Entity, Trace )
 	SubMenu:AddOption("Open Global Permissions", function ()
 		SF.Editor.openPermissionsPopup()
 	end)
+
+	if ent:GetReuploadOnReload() then
+		SubMenu:AddOption("Disable reupload on reload", function ()
+			ent:SetReuploadOnReload(false)
+		end)
+	else
+		SubMenu:AddOption("Enable reupload on reload", function ()
+			ent:SetReuploadOnReload(true)
+		end)
+	end
+
 	local instance = ent.instance
 	if instance and instance.player ~= SF.Superuser and (instance.permissionRequest and instance.permissionRequest.overrides and table.Count(instance.permissionRequest.overrides) > 0
 				or instance.permissionOverrides and table.Count(instance.permissionOverrides) > 0) then

--- a/lua/starfall/editor/editor.lua
+++ b/lua/starfall/editor/editor.lua
@@ -161,6 +161,9 @@ if CLIENT then
 			local tab = SF.Editor.editor:GetTabContent(i)
 			local path = tab.chosenfile
 			if path and tab.GetCode then
+				if SF.Editor.editor:SettingShouldReloadBeforeUpload() then
+					SF.Editor.editor:ReloadFile(path)
+				end
 				files[path:match("starfall/(.+)") or path] = tab:GetCode()
 			end
 		end

--- a/lua/starfall/editor/editor.lua
+++ b/lua/starfall/editor/editor.lua
@@ -161,8 +161,8 @@ if CLIENT then
 			local tab = SF.Editor.editor:GetTabContent(i)
 			local path = tab.chosenfile
 			if path and tab.GetCode then
-				if SF.Editor.editor:SettingShouldReloadBeforeUpload() then
-					SF.Editor.editor:ReloadFile(path)
+				if SF.Editor.editor:ShouldReloadBeforeUpload() then
+					SF.Editor.editor:ReloadTabs(false)
 				end
 				files[path:match("starfall/(.+)") or path] = tab:GetCode()
 			end

--- a/lua/starfall/editor/sfframe.lua
+++ b/lua/starfall/editor/sfframe.lua
@@ -175,8 +175,8 @@ function Editor:Init()
 	-- Controls the auto reload functionality
 	self.autoReloadEnabled = Editor.EditorFileAutoReload:GetBool()
 	self.autoReloadInterval = Editor.EditorFileAutoReloadInterval:GetFloat()
-	cvars.AddChangeCallback(Editor.EditorFileAutoReload:GetName(), function(_, _, newValue) self:setFileAutoReload(newValue) end)
-	cvars.AddChangeCallback(Editor.EditorFileAutoReloadInterval:GetName(), function(_, _, newValue) self:setFileAutoReloadInterval(newValue) end)
+	cvars.AddChangeCallback(Editor.EditorFileAutoReload:GetName(), function() self:setFileAutoReload(Editor.EditorFileAutoReload:GetBool()) end)
+	cvars.AddChangeCallback(Editor.EditorFileAutoReloadInterval:GetName(), function() self:setFileAutoReloadInterval(Editor.EditorFileAutoReloadInterval:GetFloat()) end)
 
 
 	-- Load border colors, position, & size

--- a/lua/starfall/editor/sfframe.lua
+++ b/lua/starfall/editor/sfframe.lua
@@ -1643,7 +1643,10 @@ function Editor:LoadFile(Line, forcenewtab)
 			for i = 1, self:GetNumTabs() do
 				if self:GetTabContent(i).chosenfile == Line then
 					self:SetActiveTab(i)
-					if forcenewtab ~= nil then self:SetCode(str) end
+					if forcenewtab ~= nil then
+						self:SetCode(str)
+						self:GetCurrentTabContent().savedCode = SF.Editor.normalizeCode(str)
+					end
 					return
 				end
 			end

--- a/lua/starfall/editor/sfframe.lua
+++ b/lua/starfall/editor/sfframe.lua
@@ -1735,14 +1735,14 @@ function Editor:ReloadTab(tabIndex, interactive)
 
 	-- This `autoReloadLastModified` variable is only assigned and read here, other places in the code should not use
 	-- it since they can just call one of the editor's functions.
-	if tabContent.autoReloadLastModified ~= nil and tabContent.autoReloadLastModified >= fileLastModified then
+	if tabContent.autoReloadLastModified ~= nil and tabContent.autoReloadLastModified >= fileLastModified and tabContent:IsSaved() then
 		return
 	end
-	tabContent.autoReloadLastModified = fileLastModified
 
 	local executeReload = function()
 		tabContent:SetCode(fileContent)
 		tabContent.savedCode = SF.Editor.normalizeCode(fileContent)
+		tabContent.autoReloadLastModified = fileLastModified
 		self:UpdateTabText(tab)
 		if tabIndex == activeTabIndex then
 			self:Validate()

--- a/lua/starfall/editor/sfframe.lua
+++ b/lua/starfall/editor/sfframe.lua
@@ -77,6 +77,7 @@ Editor.OpenOldTabsVar = CreateClientConVar("sf_editor_openoldtabs", "1", true, f
 Editor.WorldClickerVar = CreateClientConVar("sf_editor_worldclicker", "0", true, false)
 Editor.LayoutVar = CreateClientConVar("sf_editor_layout", "0", true, false)
 Editor.StartHelperUndocked = CreateClientConVar("sf_helper_startundocked", "0", true, false)
+Editor.ReloadBeforeUpload = CreateClientConVar("sf_reload_before_upload", "0", true, false)
 
 function SF.DefaultCode()
 	if file.Exists("starfall/default.txt", "DATA") then
@@ -1105,6 +1106,11 @@ function Editor:GetSettings()
 	UndockHelper:SetText("Undock helper on open")
 	UndockHelper:SizeToContents()
 
+	local ReloadBeforeUpload = vgui.Create("DCheckBoxLabel")
+	dlist:AddItem(ReloadBeforeUpload)
+	ReloadBeforeUpload:SetConVar("sf_reload_before_upload")
+	ReloadBeforeUpload:SetText("Reload files before uploading")
+	ReloadBeforeUpload:SizeToContents()
 
 	AddCategory(dlist, "Editor", "icon16/application_side_tree.png", "Options for the editor itself.")
 
@@ -1682,6 +1688,12 @@ function Editor:LoadFile(Line, forcenewtab)
 		self:UpdateTabText(tab)
 		self.C.TabHolder:InvalidateLayout()
 	end
+end
+
+--- Returns the value of the settings `ReloadBeforeUpload` of the editor.
+---@return boolean
+function Editor:SettingShouldReloadBeforeUpload()
+    return self.ReloadBeforeUpload:GetBool()
 end
 
 ---Reloads the tab associated to the file at `filepath`, if there is one.

--- a/lua/starfall/editor/sfframe.lua
+++ b/lua/starfall/editor/sfframe.lua
@@ -1732,6 +1732,7 @@ function Editor:ReloadTab(tabIndex, interactive)
 		return
 	end
 	local fileLastModified = file.Time(filepath, "DATA")
+	local mainfile = string.match(filepath, "starfall/(.*)")
 
 	-- This `autoReloadLastModified` variable is only assigned and read here, other places in the code should not use
 	-- it since they can just call one of the editor's functions.
@@ -1747,6 +1748,7 @@ function Editor:ReloadTab(tabIndex, interactive)
 		if tabIndex == activeTabIndex then
 			self:Validate()
 		end
+		hook.Run("StarfallEditorFileReload", mainfile)
 	end
 
 	if tabContent:IsSaved() then

--- a/lua/starfall/editor/sfframe.lua
+++ b/lua/starfall/editor/sfframe.lua
@@ -1726,13 +1726,8 @@ function Editor:ReloadTab(tabIndex, interactive)
 		return
 	end
 
-	local fileContent = file.Read(filepath)
-	if fileContent == nil then
-		ErrorNoHalt("Error while reloading, failed to read file: ", filepath)
-		return
-	end
 	local fileLastModified = file.Time(filepath, "DATA")
-	local mainfile = string.match(filepath, "starfall/(.*)")
+	if fileLastModified == 0 then return end
 
 	-- This `autoReloadLastModified` variable is only assigned and read here, other places in the code should not use
 	-- it since they can just call one of the editor's functions.
@@ -1741,6 +1736,12 @@ function Editor:ReloadTab(tabIndex, interactive)
 	end
 
 	local executeReload = function()
+		local fileContent = file.Read(filepath)
+		if fileContent == nil then
+			ErrorNoHalt("Error while reloading, failed to read file: ", filepath)
+			return
+		end
+
 		tabContent:SetCode(fileContent)
 		tabContent.savedCode = SF.Editor.normalizeCode(fileContent)
 		tabContent.autoReloadLastModified = fileLastModified
@@ -1748,6 +1749,8 @@ function Editor:ReloadTab(tabIndex, interactive)
 		if tabIndex == activeTabIndex then
 			self:Validate()
 		end
+
+		local mainfile = string.match(filepath, "starfall/(.*)")
 		hook.Run("StarfallEditorFileReload", mainfile)
 	end
 

--- a/lua/starfall/editor/sfframe.lua
+++ b/lua/starfall/editor/sfframe.lua
@@ -493,7 +493,7 @@ function Editor:GetActiveTabIndex()
 	return -1
 end
 
---- Gets the index of the tab with the file at `filepath` opened
+---Gets the index of the tab with the file at `filepath` opened
 ---@param filepath string The filepath of the tab to find
 ---@return number index # The index of the tab, if found
 ---@return boolean found # Boolean indicating if we found the tab
@@ -1536,10 +1536,10 @@ function Editor:GetTabContent(n)
 	end
 end
 
---- Returns the associated `DTab` for the tab at index `n`
+---Returns the associated `DTab` for the tab at index `n`
 ---@param n number Tab index
 ---@return DTab # DTab of the associated tab
---- https://wiki.facepunch.com/gmod/DPropertySheet:GetItems
+---https://wiki.facepunch.com/gmod/DPropertySheet:GetItems
 function Editor:GetTab(n)
 	if self.C.TabHolder.Items[n] then
 		return self.C.TabHolder.Items[n].Tab
@@ -1690,7 +1690,7 @@ function Editor:LoadFile(Line, forcenewtab)
 	end
 end
 
---- Returns the value of the settings `ReloadBeforeUpload` of the editor.
+---Returns the value of the settings `ReloadBeforeUpload` of the editor.
 ---@return boolean
 function Editor:SettingShouldReloadBeforeUpload()
     return self.ReloadBeforeUpload:GetBool()

--- a/lua/starfall/editor/sfframe.lua
+++ b/lua/starfall/editor/sfframe.lua
@@ -1771,7 +1771,7 @@ function Editor:ReloadTab(tabIndex, interactive)
 end
 
 ---Reloads the tab associated to the file at `filepath`, if there is one.
----@param string filepath The filepath of the file to reload
+---@param filepath string The filepath of the file to reload
 ---@param interactive boolean See `Editor:ReloadTab`
 function Editor:ReloadFile(filepath, interactive)
 	local tabIndex, tabFound = self:GetTabIndexByFilePath(filepath)


### PR DESCRIPTION
This PR adds an option that, if enabled, will read script files from disk before spawning a starfall chip. This makes it easier to use an external editor side-by-side with Garry's Mod.
The option can be toggled with a checkbox in the editor settings. This option is disabled by default so that if nothing is done then everything should continue to work as usual.
There is also a confirmation prompt that show's up when clicking the`Refresh file` button if this button is clicked while there are unsaved changes.