### PR TITLE
Make pcall and xpcall return values not stop at nil

### DIFF
--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -957,6 +957,10 @@ local uncatchable = {
 	["stack overflow"] = true
 }
 
+local function get_retvals_vararg(...)
+	return {...}, select('#', ...)
+end
+
 --- Lua's pcall with SF throw implementation
 -- Calls a function and catches an error that can be thrown while the execution of the call.
 -- @param function func Function to be executed and of which the errors should be caught of
@@ -964,10 +968,10 @@ local uncatchable = {
 -- @return boolean If the function had no errors occur within it.
 -- @return ... If an error occurred, this will be a string containing the error message. Otherwise, this will be the return values of the function passed in.
 function builtins_library.pcall(func, ...)
-	local vret = { pcall(func, ...) }
+	local vret, j = get_retvals_vararg(pcall(func, ...))
 	local ok, err = vret[1], vret[2]
 
-	if ok then return unpack(vret) end
+	if ok then return unpack(vret, 1, j) end
 
 	if dgetmeta(err)==SF.Errormeta then
 		if err.userdata~=nil then
@@ -995,10 +999,10 @@ end
 -- @return boolean Status of the execution; true for success, false for failure.
 -- @return ... The returns of the first function if execution succeeded, otherwise the return values of the error callback.
 function builtins_library.xpcall(func, callback, ...)
-	local vret = { xpcall(func, xpcall_Callback, ...) }
+	local vret, j = get_retvals_vararg(xpcall(func, xpcall_Callback, ...))
 	local ok, errData = vret[1], vret[2]
 
-	if ok then return unpack(vret) end
+	if ok then return unpack(vret, 1, j) end
 
 	local err, traceback = errData[1], errData[2]
 	if dgetmeta(err)==SF.Errormeta then


### PR DESCRIPTION
Currently, StarfallEx's `pcall` and `xpcall`'s return values stop at the first nil value, but vanilla `pcall` and `xpcall` do not behave this way. My pull request changes StarfallEx's behavior to match the expected behavior.
```lua
if player() ~= owner() then
    return
end
local B = 1
local function func()
    return nil, B, nil
end
local function test(success, ...)
    local a, b, c = ...
    assert(success, a)
    assert(select('#', ...) == 3)
    assert(b == B)
    print("ok")
end
test(pcall(func))
```