### PR TITLE
Change loadstring; add getScript; change getScripts to also return functions

### DIFF
--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -762,11 +762,10 @@ function builtins_library.requiredir(path, loadpriority)
 end
 
 --- Returns an included script as a function.
--- Like Lua 5.1's loadfile, but does not support reading from standard input.
--- @param string path The file path to include. Make sure to --@include it
+-- @param string path The file path to include. Can be absolute or relative to calling file. Make sure to --@include it
 -- @return function? Compiled function corresponding to file, or nil if not found.
 -- @return string? Error message, or nil if found
-function builtins_library.loadfile(path)
+function builtins_library.getFunction(path)
 	checkluatype(path, TYPE_STRING)
 
 	local curdir = SF.GetExecutingPath() or ""
@@ -779,6 +778,16 @@ function builtins_library.loadfile(path)
 		return nil, "Can't find file '" .. path .. "' (did you forget to --@include it?)"
 	end
 	return func
+end
+
+--- Returns included scripts as functions. This does a table copy.
+-- @return table Table where keys are paths and values are functions
+function builtins_library.getFunctions()
+	local scripts = {}
+	for path, func in pairs(instance.scripts) do
+		scripts[path] = func
+	end
+	return scripts
 end
 
 --- Runs an included script, but does not cache the result.

--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -866,7 +866,7 @@ function builtins_library.loadstring(ld, source, mode, env)
 	if source == nil then
 		source = "=(load)"
 	else
-		checkluatype(ld, TYPE_STRING)
+		checkluatype(source, TYPE_STRING)
 	end
 	if not isstring(mode) then
 		mode, env = nil, mode

--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -702,7 +702,7 @@ function builtins_library.shareScripts(enable)
 end
 
 --- Runs an included script and caches the result.
--- This does not behave like vanilla Lua require. This behaves like dofile, except there is an invisible cache.
+-- The path must be an actual path, including the file extension and using slashes for directory separators instead of periods.
 -- @param string path The file path to include. Make sure to --@include it
 -- @return ... Return value(s) of the script
 function builtins_library.require(path)
@@ -718,7 +718,7 @@ function builtins_library.require(path)
 end
 
 --- Runs all included scripts in a directory and caches the results.
--- This does not behave like vanilla Lua require. This behaves like dofile, except there is an invisible cache.
+-- The path must be an actual path, including the file extension and using slashes for directory separators instead of periods.
 -- @param string path The directory to include. Make sure to --@includedir it
 -- @param table loadpriority Table of files that should be loaded before any others in the directory
 -- @return table Table of return values of the scripts

--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -761,6 +761,26 @@ function builtins_library.requiredir(path, loadpriority)
 	return returns
 end
 
+--- Returns an included script as a function.
+-- Like Lua 5.1's loadfile, but does not support reading from standard input.
+-- @param string path The file path to include. Make sure to --@include it
+-- @return function? Compiled function corresponding to file, or nil if not found.
+-- @return string? Error message, or nil if found
+function builtins_library.loadfile(path)
+	checkluatype(path, TYPE_STRING)
+
+	local curdir = SF.GetExecutingPath() or ""
+
+	path = SF.ChoosePath(path, curdir, function(testpath)
+		return instance.scripts[testpath]
+	end) or path
+	local func = instance.scripts[path]
+	if func == nil then
+		return nil, "Can't find file '" .. path .. "' (did you forget to --@include it?)"
+	end
+	return func
+end
+
 --- Runs an included script, but does not cache the result.
 -- Pretty much like standard Lua dofile()
 -- @param string path The file path to include. Make sure to --@include it

--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -845,33 +845,6 @@ local whitelistedEnvs = setmetatable({
 }, {__mode = 'k'})
 instance.whitelistedEnvs = whitelistedEnvs
 
--- Like GLua's CompileString, except with an environment parameter instead of a HandleError parameter and, of course, the resulting function is in your instance's environment by default.
--- @param string code String to compile
--- @param string? identifier Name of compiled function
--- @param table? env Environment of compiled function
--- @return function|string Compiled function, or error string if failed to compile
-function builtins_library.compileString(str, name, env)
-	checkluatype(str, TYPE_STRING)
-	if name == nil then
-		name = tostring(instance.env)
-	else
-		checkluatype(name, TYPE_STRING)
-	end
-	if env == nil then
-		env = instance.env
-	else
-		checkluatype(env, TYPE_TABLE)
-		whitelistedEnvs[env] = true
-	end
-	name = "SF:"..name
-	local func = SF.CompileString(str, name, false)
-	-- CompileString returns an error as a string, better check before setfenv
-	if isfunction(func) then
-		return setfenv(func, env)
-	end
-	return tostring(func)
-end
-
 --- Like Lua 5.2's load or LuaJIT's load/loadstring, except it has no mode parameter and, of course, the resulting function is in your instance's environment by default.
 -- For compatibility with older versions of Starfall, loadstring is NOT an alias of this function like it is in vanilla Lua 5.2/LuaJIT.
 -- @param string code String to compile

--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -845,14 +845,14 @@ local whitelistedEnvs = setmetatable({
 }, {__mode = 'k'})
 instance.whitelistedEnvs = whitelistedEnvs
 
---- Like Lua 5.2's load or LuaJIT's load/loadstring, except it has no mode parameter and, of course, the resulting function is in your instance's environment by default.
+--- Like Lua 5.2 or LuaJIT's load/loadstring, except it has no mode parameter and, of course, the resulting function is in your instance's environment by default.
 -- For compatibility with older versions of Starfall, loadstring is NOT an alias of this function like it is in vanilla Lua 5.2/LuaJIT.
 -- @param string code String to compile
 -- @param string? identifier Name of compiled function
 -- @param table? env Environment of compiled function
 -- @return function? Compiled function, or nil if failed to compile
 -- @return string? Error string, or nil if successfully compiled
-function builtins_library.load(ld, source, mode, env)
+function builtins_library.loadstring(ld, source, mode, env)
 	checkluatype(ld, TYPE_STRING)
 	if source == nil then
 		source = "=(load)"
@@ -875,7 +875,7 @@ function builtins_library.load(ld, source, mode, env)
 	end
 	return nil, tostring(retval)
 end
-builtins_library.loadstring = builtins_library.load
+builtins_library.load = builtins_library.loadstring
 
 --- Lua's setfenv
 -- Sets the environment of either the stack level or the function specified.

--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -871,10 +871,6 @@ function builtins_library.compileString(str, name, env)
 	end
 	return tostring(func)
 end
--- In Lua 5.2 and LuaJIT, loadstring is an alias of load. Unfortunately, SfEx
--- already had a function called loadstring which did not behave like load, so
--- doing that here would break compatibility.
-builtins_library.loadstring = builtins_library.compileString
 
 --- Like Lua 5.2's load or LuaJIT's load/loadstring, except it has no mode parameter and, of course, the resulting function is in your instance's environment by default.
 -- For compatibility with older versions of Starfall, loadstring is NOT an alias of this function like it is in vanilla Lua 5.2/LuaJIT.
@@ -906,6 +902,7 @@ function builtins_library.load(ld, source, mode, env)
 	end
 	return nil, tostring(retval)
 end
+builtins_library.loadstring = builtins_library.load
 
 --- Lua's setfenv
 -- Sets the environment of either the stack level or the function specified.

--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -702,7 +702,7 @@ function builtins_library.shareScripts(enable)
 end
 
 --- Runs an included script and caches the result.
--- Works pretty much like standard Lua require()
+-- This does not behave like vanilla Lua require. This behaves like dofile, except there is an invisible cache.
 -- @param string path The file path to include. Make sure to --@include it
 -- @return ... Return value(s) of the script
 function builtins_library.require(path)
@@ -717,8 +717,8 @@ function builtins_library.require(path)
 	return instance:require(path)
 end
 
---- Runs an included script and caches the result.
--- Works pretty much like standard Lua require()
+--- Runs all included scripts in a directory and caches the results.
+-- This does not behave like vanilla Lua require. This behaves like dofile, except there is an invisible cache.
 -- @param string path The directory to include. Make sure to --@includedir it
 -- @param table loadpriority Table of files that should be loaded before any others in the directory
 -- @return table Table of return values of the scripts
@@ -776,7 +776,7 @@ function builtins_library.dofile(path)
 	return (instance.scripts[path] or SF.Throw("Can't find file '" .. path .. "' (did you forget to --@include it?)", 2))()
 end
 
---- Runs an included directory, but does not cache the result.
+--- Runs all included scripts in directory, but does not cache the result.
 -- @param string path The directory to include. Make sure to --@includedir it
 -- @param table loadpriority Table of files that should be loaded before any others in the directory
 -- @return table Table of return values of the scripts
@@ -819,7 +819,7 @@ function builtins_library.dodir(path, loadpriority)
 	return returns
 end
 
--- Like GLua's CompileString, except with an environment parameter instead of a HandleError parameter and, of course, the resulting function is in your instance's environment.
+-- Like GLua's CompileString, except with an environment parameter instead of a HandleError parameter and, of course, the resulting function is in your instance's environment by default.
 -- @param string code String to compile
 -- @param string? identifier Name of compiled function
 -- @param table? env Environment of compiled function
@@ -850,6 +850,7 @@ end
 builtins_library.loadstring = builtins_library.compileString
 
 --- Like Lua 5.2's load or LuaJIT's load/loadstring, except it has no mode parameter and, of course, the resulting function is in your instance's environment by default.
+-- For compatibility with older versions of Starfall, loadstring is NOT an alias of this function like it is in vanilla Lua 5.2/LuaJIT.
 -- @param string code String to compile
 -- @param string? identifier Name of compiled function
 -- @param table? env Environment of compiled function

--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -848,7 +848,7 @@ function builtins_library.dodir(path, loadpriority)
 	return returns
 end
 
--- Used for compileString, load, setfenv, and getfenv.
+-- Used for loadstring, setfenv, and getfenv.
 local whitelistedEnvs = setmetatable({
 	[instance.env] = true,
 }, {__mode = 'k'})

--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -869,7 +869,7 @@ function builtins_library.compileString(str, name, env)
 	if isfunction(func) then
 		return setfenv(func, env)
 	end
-	return func
+	return tostring(func)
 end
 -- In Lua 5.2 and LuaJIT, loadstring is an alias of load. Unfortunately, SfEx
 -- already had a function called loadstring which did not behave like load, so
@@ -904,7 +904,7 @@ function builtins_library.load(ld, source, mode, env)
 		whitelistedEnvs[env] = true
 		return setfenv(retval, env)
 	end
-	return nil, retval
+	return nil, tostring(retval)
 end
 
 --- Lua's setfenv


### PR DESCRIPTION
- ~~Added `compileString`.~~
    - ~~Has an environment parameter instead of a "HandleError" parameter as that is much more useful, and for compatibility with [TSCM's Starfall](https://teamscm.co.uk/thread-7.html) (not that it matters given how much TSCM's Starfall differs from StarfallEx).~~
- ~~Added `load`. Behaves like [Lua 5.2](https://www.lua.org/manual/5.2/manual.html#pdf-load)/[LuaJIT's](https://luajit.org/extensions.html#lua52) `load`.~~ Changed `loadstring` to behave like Lua 5.2/LuaJIT `load`.
    - Doesn't support using a function for first parameter, but it's not like anyone uses that.
    - If identifier unspecified, defaults to `=(load)` instead of `tostring`-ing the environment.
    - Does not require but will handle a mode parameter, but will just ignore it.
- ~~`loadstring` aliased to `compileString` for compatibility with older versions of Starfall.~~ `loadstring` aliased to `load` like Lua 5.2/LuaJIT.
    - Aliasing it to `load` like Lua 5.2 and LuaJIT do wouldn't break any of *my* chips, but I'm unsure how many other users will have had the same foresight.
- ~~Added `loadfile`. Behaves like [Lua 5.1's `loadfile`](https://www.lua.org/manual/5.1/manual.html#pdf-loadfile).~~ ~~Added `getFunction`.~~ Added `getScript`. A better alternative to something like `loadstring(getScripts()[path], path)`.
- ~~Added `getFunctions`. Like `getScripts`, but returns functions (`instance.scripts`).~~
- `getScripts` now also returns functions.
    - Does not return functions if another chip is specified.

<details>
<summary>Security considerations</summary>

- `setfenv`, unlike `debug.setfenv`, will throw if the first argument is anything but a function or a number, or if the second argument is anything but a table.
    - The code path that calls `setfenv` is only reachable if the value that will be the first argument is a function.
    - I cannot think of any way it could fail and still return the function.
    - A chip cannot set the environment of the function to any table they don't already have.
- I did not forget to whitelist the environment, but even if I had forgotten, that wouldn't be a security issue.
- I `tostring` the return value if it is not a function, so it will not cause a security issue even in the very unlikely event an unsafe non-string type is returned.
- A chip can only create new functions this way, not already existing functions, so there is no way it could be used to set the environment of external functions.
- The new code is not significantly more complex than the old code.
- A test was written and the code passes.
- `getScripts` does not return functions if another chip is specified.
</details>

<details>
<summary>Test scripts</summary>

```lua
if player() ~= owner() then
    return
end
local code_bad = '$$$'
local code = 'print("Hello, world!")'
local env = {}
local func, err, retval
func, err = loadstring(code_bad)
assert(func == nil)
assert(err == 'SF:=(load):1: unexpected symbol near \'$\'')
func, err = loadstring(code)
assert(isfunction(func))
assert(err == nil)
assert(debug.getinfo(func, 'S').source == '@SF:=(load)')
assert(getfenv(func) == _G)
func, err = loadstring(code, '1')
assert(isfunction(func))
assert(err == nil)
assert(debug.getinfo(func, 'S').source == '@SF:1')
assert(getfenv(func) == _G)
func, err = loadstring(code, '2', env)
assert(isfunction(func))
assert(err == nil)
assert(debug.getinfo(func, 'S').source == '@SF:2')
assert(getfenv(func) == env)
func, err = loadstring(code, '3', 't')
assert(isfunction(func))
assert(err == nil)
assert(debug.getinfo(func, 'S').source == '@SF:3')
assert(getfenv(func) == _G)
func, err = loadstring(code, '4', 't', env)
assert(isfunction(func))
assert(err == nil)
assert(debug.getinfo(func, 'S').source == '@SF:4')
assert(getfenv(func) == env)
assert(load == loadstring)
assert(pcall(loadstring, nil) == false)
assert(pcall(loadstring, code, false) == false)
assert(pcall(loadstring, code, {}) == false)
assert(pcall(loadstring, code, '5', false) == false)
assert(pcall(loadstring, code, '6', 't', false) == false)
assert(pcall(loadstring, code, '7', 't', '') == false)
print("ok")
```
```lua
--@include sfex_a882fea_included.lua
local path = 'sfex_a882fea_included.lua'
local src, func = getScript('$$$')
assert(src == nil)
assert(func == nil)
src, func = getScript(path)
assert(isstring(src))
assert(isfunction(func))
local t, j = {nil, 2, nil, 4, nil}, 5
local T = {func(unpack(t, 1, j))}
for i=1, j do
    assert(t[i] == T[i])
end
src, func = getScripts()
printTable(src)
printTable(func)
print("ok")
```
`sfex_a882fea_included.lua`:
```lua
return ...
```
`sfex_4ad1c31a_attacker.lua`:
```lua
local o = entity(78)
local success, srcs, funcs = pcall(getScripts, o)
print(success)
if success then
    print(srcs)
    printTable(srcs)
    print(funcs)
    if funcs then
        printTable(funcs)
    end
end
```
`sfex_4ad1c31a_victim.lua`:
```lua
-- FAIL
shareScripts(true)
print(chip():entIndex())
```
`sfex_4ad1c31a_sanity.lua`:
```lua
local SF = {
    Throw = function(msg, level)
        level = (level or 1)+1
        error(msg, level)
    end,
}
local instance = {
    player = entity(0),
}
local ent = {
    Starfall = true,
    instance = {
        shareScripts = false,
        player = owner(),
    },
}
local oinstance = ent.instance
if not ent.Starfall or not oinstance then
    SF.Throw("Invalid starfall chip", 2)
    return
elseif not oinstance.shareScripts and oinstance.player ~= instance.player then
    SF.Throw("Not allowed", 2)
    return
end
print("ok")
```
</details>
