### PR TITLE
Fix HTTP configuration issue

### DIFF
--- a/lua/starfall/libs_sh/http.lua
+++ b/lua/starfall/libs_sh/http.lua
@@ -6,8 +6,9 @@ local registerprivilege = SF.Permissions.registerPrivilege
 local http_interval = CreateConVar("sf_http_interval", "0.5", { FCVAR_ARCHIVE, FCVAR_REPLICATED }, "Interval in seconds in which one http request can be made")
 local http_max_active = CreateConVar("sf_http_max_active", "3", { FCVAR_ARCHIVE, FCVAR_REPLICATED }, "The maximum amount of active http requests at the same time")
 
-registerprivilege("http.get", "HTTP Get method", "Allows the user to request html data", { client = {}, urlwhitelist = { default = 1 } })
-registerprivilege("http.post", "HTTP Post method", "Allows the user to post html data", { client = { default = 1 }, urlwhitelist = { default = 1 } })
+local permission_level = SERVER and 1 or 3
+registerprivilege("http.get", "HTTP Get method", "Allows the user to request html data", { client = {}, urlwhitelist = { default = permission_level } })
+registerprivilege("http.post", "HTTP Post method", "Allows the user to post html data", { client = { default = 1 }, urlwhitelist = { default = permission_level } })
 
 local requests = SF.EntityTable("playerHTTPRequests")
 

--- a/lua/starfall/libs_sh/http.lua
+++ b/lua/starfall/libs_sh/http.lua
@@ -6,8 +6,8 @@ local registerprivilege = SF.Permissions.registerPrivilege
 local http_interval = CreateConVar("sf_http_interval", "0.5", { FCVAR_ARCHIVE, FCVAR_REPLICATED }, "Interval in seconds in which one http request can be made")
 local http_max_active = CreateConVar("sf_http_max_active", "3", { FCVAR_ARCHIVE, FCVAR_REPLICATED }, "The maximum amount of active http requests at the same time")
 
-registerprivilege("http.get", "HTTP Get method", "Allows the user to request html data", { client = {}, urlwhitelist = { default = 2 } })
-registerprivilege("http.post", "HTTP Post method", "Allows the user to post html data", { client = { default = 1 }, urlwhitelist = { default = 2 } })
+registerprivilege("http.get", "HTTP Get method", "Allows the user to request html data", { client = {}, urlwhitelist = { default = 1 } })
+registerprivilege("http.post", "HTTP Post method", "Allows the user to post html data", { client = { default = 1 }, urlwhitelist = { default = 1 } })
 
 local requests = SF.EntityTable("playerHTTPRequests")
 

--- a/lua/starfall/permissions/core.lua
+++ b/lua/starfall/permissions/core.lua
@@ -141,14 +141,13 @@ function P.buildPermissionCheck(privilegeid)
 end
 
 local invalidators = {
-	[1668844800] = { -- November 19th, 2022
+	[1669008186] = { -- Nov 21, 2022
 		message = "HTTP's URL whitelisting was misconfigured, and set by default to Disabled",
 		realm = CLIENT,
 		invalidate = {"http.get", "http.post"},
 		check = function(settings_table)
-			local getcheck = settings_table["http.get"] ~= nil and settings_table["http.get"]["urlwhitelist"] == 2 or false
-			local postcheck = settings_table["http.post"] ~= nil and settings_table["http.post"]["urlwhitelist"] == 2 or false
-			return getcheck or postcheck
+			return (settings_table["http.get"] ~= nil and settings_table["http.get"]["urlwhitelist"] == 2) or
+					(settings_table["http.post"] ~= nil and settings_table["http.post"]["urlwhitelist"] == 2)
 		end
 	}
 }
@@ -157,28 +156,20 @@ local printC = function(...) (SERVER and MsgC or chat.AddText)(Color(255, 255, 2
 
 -- Load the permission settings for each provider
 function P.loadPermissionOptions()
-	local file_time = file.Time(P.filename, "DATA")
-	local replacements = {}
-
+	local saveSettings = not file.Exists(P.filename, "DATA")
 	local settings = util.JSONToTable(file.Read(P.filename) or "") or {}
-	for issue_time, issue in pairs(invalidators) do
-		if file_time < issue_time and issue.realm then
-			if issue.check == nil or issue.check(settings) then 
-				printC("Your configuration has been modified due to a misconfiguration.")
-				printC("Reason: " .. issue.message)
-				printC("Changes: " .. table.concat(issue.invalidate, ", "))
-				for _, v in ipairs(issue.invalidate) do
-					replacements[v] = true
-				end
+	local settingsTime = file.Time(P.filename, "DATA") or math.huge
+
+	for issueTime, issue in pairs(invalidators) do
+		if settingsTime < issueTime and issue.realm and (issue.check == nil or issue.check(settings)) then 
+			printC("Your configuration has been modified due to a misconfiguration.")
+			printC("Reason: " .. issue.message)
+			printC("Changes: " .. table.concat(issue.invalidate, ", "))
+			for _, v in ipairs(issue.invalidate) do
+				saveSettings = true
+				settings[v] = nil
 			end
 		end
-	end
-
-	if table.Count(replacements) > 0 then
-		for invalidate, _ in pairs(replacements) do
-			settings[invalidate] = nil
-		end
-		file.Write(P.filename, util.TableToJSON(settings))
 	end
 	
 	for privilegeid, privilege in pairs(P.privileges) do
@@ -204,6 +195,10 @@ function P.loadPermissionOptions()
 			end
 		end
 		P.buildPermissionCheck(privilegeid)
+	end
+
+	if saveSettings then
+		P.savePermissions()
 	end
 end
 


### PR DESCRIPTION
HTTP's urlwhitelist permissions are bugged and set to "2", which is "Disabled", meaning that the URL whitelist is disabled for get/post functions. My best guess is that it was assumed this would be Disabled for owner, but it was actually setting it to Disable for all. This should change this to Enabled instead of Disabled for owner, but a change from 1 to 3 could change that to its intended value if I'm correct about my hypothesis. Thanks to @Xandertron for figuring this issue out.

I have not tested these changes, so someone may want to make sure I did this right, although I don't know how I could have really messed this up. (Xander did test the issue on several big servers, the only one failing was CFC due to them using their own URL filtering)

This is a rather critical issue; can be used for stuff like IP grabbers pretty easily, and my other friend @CheezusChrust has seen Starfall dupes in the wild that show peoples cities and states with the ease of spawning an E2 ops/us board.

I should note that this was brought up privately by Xandertron; but was ignored by thegrb93, hence me creating this PR. This also won't fix the issue that any new player since this issue was introduced will have this written to their sf_perms.txt, which needs to be fixed as well. 