### PR TITLE
Made eyePos, eyeAngles, eyeVector return real local values instead of server agreed ones

### DIFF
--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -511,6 +511,20 @@ end
 
 
 -- ------------------------------------------------------------------ --
+--- Returns the origin of the current render context as calculated by calcview.
+function render_library.getOrigin()
+	return vwrap(EyePos())
+end
+
+--- Returns the angles of the current render context as calculated by calcview.
+function render_library.getAngles()
+	return vwrap(EyeAngles())
+end
+
+--- Returns the normal vector of the current render context as calculated by calcview, similar to render.getAngles.
+function render_library.getEye()
+	return vwrap(EyeVector())
+end
 
 --- Sets whether stencil tests are carried out for each rendered pixel. Only pixels passing the stencil test are written to the render target.
 -- @param boolean enable True to enable, false to disable

--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -518,7 +518,7 @@ end
 
 --- Returns the angles of the current render context as calculated by calcview.
 function render_library.getAngles()
-	return vwrap(EyeAngles())
+	return awrap(EyeAngles())
 end
 
 --- Returns the normal vector of the current render context as calculated by calcview, similar to render.getAngles.

--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -665,21 +665,21 @@ else
 	-- @client
 	-- @return Angle The local player's camera angles
 	function builtins_library.eyeAngles()
-		return awrap(LocalPlayer():EyeAngles())
+		return awrap(EyeAngles())
 	end
 
 	--- Returns the local player's camera position
 	-- @client
 	-- @return Vector The local player's camera position
 	function builtins_library.eyePos()
-		return vwrap(LocalPlayer():EyePos())
+		return vwrap(EyePos())
 	end
 
 	--- Returns the local player's camera forward vector
 	-- @client
 	-- @return Vector The local player's camera forward vector
 	function builtins_library.eyeVector()
-		return vwrap(LocalPlayer():GetAimVector())
+		return vwrap(EyeVector())
 	end
 end
 

--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -665,21 +665,21 @@ else
 	-- @client
 	-- @return Angle The local player's camera angles
 	function builtins_library.eyeAngles()
-		return awrap(EyeAngles())
+		return awrap(LocalPlayer():EyeAngles())
 	end
 
 	--- Returns the local player's camera position
 	-- @client
 	-- @return Vector The local player's camera position
 	function builtins_library.eyePos()
-		return vwrap(EyePos())
+		return vwrap(LocalPlayer():EyePos())
 	end
 
 	--- Returns the local player's camera forward vector
 	-- @client
 	-- @return Vector The local player's camera forward vector
 	function builtins_library.eyeVector()
-		return vwrap(EyeVector())
+		return vwrap(LocalPlayer():GetAimVector())
 	end
 end
 


### PR DESCRIPTION
Thirdperson addons break hud rendering
![image](https://user-images.githubusercontent.com/23390269/213929493-f7165391-4e2d-49d8-a72e-5373a9b69b71.png)
```lua
EyePos() =/= LocalPlayer():EyePos()
EyeAngles() =/= LocalPlayer():EyeAngles()
EyeVector() =/= LocalPlayer():GetAimVector()
```

I think it has to be the same as in GLua, or we should provide new methods like
```lua
localEyePos(), localEyeAngles(), localEyeVector()
```