### PR TITLE
Fix TempFileCache:CheckSize calling nil method

### DIFF
--- a/lua/starfall/libs_cl/file.lua
+++ b/lua/starfall/libs_cl/file.lua
@@ -104,7 +104,7 @@ do
 			end
 		end
 		if check.totalsize >= cv_temp_maxsize:GetFloat()*1e6 then
-			self:Clean(check)
+			self:CleanAll(check)
 			if check.totalsize >= cv_temp_maxsize:GetFloat()*1e6 then
 				return false, "The temp file cache has reached its limit!"
 			end


### PR DESCRIPTION
tiny fix for the following error:
```
Callback errored with: addons/starfallex-master/lua/starfall/libs_cl/file.lua:107: attempt to call method 'Clean' (a nil value)
stack traceback:
    addons/starfallex-master/lua/starfall/libs_cl/file.lua:107: in function 'CheckSize'
    addons/starfallex-master/lua/starfall/libs_cl/file.lua:58: in function 'Write'
    addons/starfallex-master/lua/starfall/libs_cl/file.lua:268: in function 'writeTemp'
```