### PR TITLE
Update example render_view.lua to be more consistent with #1419.

### DIFF
--- a/lua/starfall/examples/render_view.lua
+++ b/lua/starfall/examples/render_view.lua
@@ -28,10 +28,10 @@ hook.add("renderscene", "render_view", function()
         local clipNormal = screenEnt:getUp()
         render.pushCustomClipPlane(clipNormal, (screenEnt:getPos() + clipNormal):dot(clipNormal))
         
-        local localOrigin = screenEnt:worldToLocal(eyePos())
+        local localOrigin = screenEnt:worldToLocal(render.getOrigin())
         local reflectedOrigin = screenEnt:localToWorld(localOrigin * Vector(1, 1, -1))  
         
-        local localAng = screenEnt:worldToLocalAngles(eyeAngles())
+        local localAng = screenEnt:worldToLocalAngles(render.getAngles())
         local reflectedAngle = screenEnt:localToWorldAngles(Angle(-localAng.p, localAng.y, -localAng.r + 180))
         
         render.renderView({


### PR DESCRIPTION
Since example used `eyePos()` and `eyeAngles()`, it didn't work properly with third person view. I changed it to use more proper functions `render.getOrigin()` and `render.getAngles()` added in #1419.