### PR TITLE
Support lua extension for default editor file

### DIFF
--- a/lua/starfall/editor/sfframe.lua
+++ b/lua/starfall/editor/sfframe.lua
@@ -83,6 +83,8 @@ Editor.EditorFileAutoReloadInterval = CreateClientConVar("sf_editor_file_auto_re
 function SF.DefaultCode()
 	if file.Exists("starfall/default.txt", "DATA") then
 		return file.Read("starfall/default.txt", "DATA")
+	elseif file.Exists("starfall/default.lua", "DATA") then
+		return file.Read("starfall/default.lua", "DATA")
 	else
 		local code = [=[--@name
 --@author


### PR DESCRIPTION
All other files can have the `lua` extension, but not the default one.