### PR TITLE
Remove file check timer on editor reload

### DIFF
--- a/lua/starfall/editor/editor.lua
+++ b/lua/starfall/editor/editor.lua
@@ -798,6 +798,7 @@ if CLIENT then
 		SF.Editor.initialized = false
 		SF.Editor.editor:Remove()
 		SF.Editor.editor = nil
+		timer.Remove("sf_editor_file_auto_reload")
 
 	end
 


### PR DESCRIPTION
Introduced in https://github.com/thegrb93/StarfallEx/pull/1376, the timer that checks for file changes isn't deleted when force reloading editor, causing the following error:

```
> sf_editor_reload 
Reloaded Control: StarfallFileTree
Reloaded Control: StarfallFileBrowser
Editor reloaded

[starfall] addons/starfall/lua/starfall/editor/sfframe.lua:1812: attempt to call method 'ReloadTabs' (a nil value)
  1. unknown - addons/starfall/lua/starfall/editor/sfframe.lua:1812

Timer Failed! [sf_editor_file_auto_reload][@addons/starfall/lua/starfall/editor/sfframe.lua (line 1811)]
[Name|4|STEAM_0:1:38746645] Lua Error:

[starfall] addons/starfall/lua/starfall/editor/sfframe.lua:1812: attempt to call method 'ReloadTabs' (a nil value)
  1. unknown - addons/starfall/lua/starfall/editor/sfframe.lua:1812
```