### PR TITLE
Add concurrent HTTP request support

### DIFF
--- a/lua/starfall/libs_sh/http.lua
+++ b/lua/starfall/libs_sh/http.lua
@@ -41,18 +41,20 @@ local function runCallback(callback)
 		end
 	end
 end
+local function canRequest(player)
+	confirmPlayerHasRequests(player)
+	return requests[player] < http_max_active:GetInt()
+end
 
 --- Checks if a new http request can be started
 -- @return boolean If an HTTP get/post request can be made
 function http_library.canRequest()
-	confirmPlayerHasRequests(instance.player)
-	return requests[instance.player] < http_max_active:GetInt()
+	return canRequest(instance.player)
 end
 --- Gets how many get/post operations are currently in progress
 -- @return number The current amount of active HTTP get/post requests
 function http_library.getActiveRequests()
-	confirmPlayerHasRequests(instance.player)
-	return requests[instance.player]
+	return requests[instance.player] or 0
 end
 --- Gets how many get/post operations can be in progress at the same time
 -- @return number Maximum amount of concurrent active HTTP get/post requests 
@@ -80,7 +82,7 @@ function http_library.get(url, callbackSuccess, callbackFail, headers)
 		end
 	end
 
-	if not http_library.canRequest() then SF.Throw(string.format("You have hit the maximum amount of concurrent HTTP requests (%d)", http_max_active:GetInt()), 2) end
+	if not canRequest(instance.player) then SF.Throw(string.format("You have hit the maximum amount of concurrent HTTP requests (%d)", http_max_active:GetInt()), 2) end
 	addToPlayerRequests(instance.player, 1)
 
 	if CLIENT then SF.HTTPNotify(instance.player, url) end
@@ -145,7 +147,7 @@ function http_library.post(url, payload, callbackSuccess, callbackFail, headers)
 	end
 	request.failed = runCallback(callbackFail)
 
-	if not http_library.canRequest() then SF.Throw(string.format("You have hit the maximum amount of concurrent HTTP requests (%d)", http_max_active:GetInt()), 2) end
+	if not canRequest(instance.player) then SF.Throw(string.format("You have hit the maximum amount of concurrent HTTP requests (%d)", http_max_active:GetInt()), 2) end
 	addToPlayerRequests(instance.player, 1)
 
 	if CLIENT then SF.HTTPNotify(instance.player, url) end

--- a/lua/starfall/libs_sh/http.lua
+++ b/lua/starfall/libs_sh/http.lua
@@ -48,10 +48,10 @@ local function runCallback(callback)
 end
 
 --- Checks if a new http request can be started
+-- @class function
 -- @return boolean If an HTTP get/post request can be made
-function http_library.canRequest()
-	return canRequest()
-end
+http_library.canRequest = canRequest
+
 --- Gets how many get/post operations are currently in progress
 -- @return number The current amount of active HTTP get/post requests
 function http_library.getActiveRequests()

--- a/lua/starfall/libs_sh/http.lua
+++ b/lua/starfall/libs_sh/http.lua
@@ -62,6 +62,10 @@ function http_library.getMaximumRequests()
 	return http_max_active:GetInt()
 end
 
+local function tooManyConcurrentRequestsError()
+	SF.Throw("You have hit the maximum amount of concurrent HTTP requests (" .. http_max_active:GetInt() .. ")", 2)
+end
+
 --- Runs a new http GET request
 -- @param string url Http target url
 -- @param function callbackSuccess The function to be called on request success, taking the arguments body (string), length (number), headers (table) and code (number)
@@ -82,7 +86,7 @@ function http_library.get(url, callbackSuccess, callbackFail, headers)
 		end
 	end
 
-	if not canRequest(instance.player) then SF.Throw(string.format("You have hit the maximum amount of concurrent HTTP requests (%d)", http_max_active:GetInt()), 2) end
+	if not canRequest(instance.player) then tooManyConcurrentRequestsError() end
 	addToPlayerRequests(instance.player, 1)
 
 	if CLIENT then SF.HTTPNotify(instance.player, url) end
@@ -147,7 +151,7 @@ function http_library.post(url, payload, callbackSuccess, callbackFail, headers)
 	end
 	request.failed = runCallback(callbackFail)
 
-	if not canRequest(instance.player) then SF.Throw(string.format("You have hit the maximum amount of concurrent HTTP requests (%d)", http_max_active:GetInt()), 2) end
+	if not canRequest(instance.player) then tooManyConcurrentRequestsError() end
 	addToPlayerRequests(instance.player, 1)
 
 	if CLIENT then SF.HTTPNotify(instance.player, url) end

--- a/lua/starfall/libs_sh/http.lua
+++ b/lua/starfall/libs_sh/http.lua
@@ -35,8 +35,8 @@ end
 -- Runs the appropriate callback after a http request
 local function runCallback(callback)
 	return function(...)
+		addToPlayerRequests(instance.player, -1)
 		if callback then
-			addToPlayerRequests(instance.player, -1)
 			instance:runFunction(callback, ...)
 		end
 	end

--- a/lua/starfall/libs_sh/http.lua
+++ b/lua/starfall/libs_sh/http.lua
@@ -3,8 +3,8 @@ local checkluatype = SF.CheckLuaType
 local registerprivilege = SF.Permissions.registerPrivilege
 
 
-local http_interval = CreateConVar("sf_http_interval", "0.5", { FCVAR_ARCHIVE, FCVAR_REPLICATED }, "Interval in seconds in which one http request can be made")
-local http_max_active = CreateConVar("sf_http_max_active", "3", { FCVAR_ARCHIVE, FCVAR_REPLICATED }, "The maximum amount of active http requests at the same time")
+--local http_interval = CreateConVar("sf_http_interval", "0.5", { FCVAR_ARCHIVE, FCVAR_REPLICATED }, "Interval in seconds in which one http request can be made")
+local http_max_active = CreateConVar("sf_http_max_active", "3", { FCVAR_ARCHIVE }, "The maximum amount of active http requests at the same time")
 
 local permission_level = SERVER and 1 or 3
 registerprivilege("http.get", "HTTP Get method", "Allows the user to request html data", { client = {}, urlwhitelist = { default = permission_level } })

--- a/lua/starfall/libs_sh/http.lua
+++ b/lua/starfall/libs_sh/http.lua
@@ -2,8 +2,6 @@
 local checkluatype = SF.CheckLuaType
 local registerprivilege = SF.Permissions.registerPrivilege
 
-
---local http_interval = CreateConVar("sf_http_interval", "0.5", { FCVAR_ARCHIVE, FCVAR_REPLICATED }, "Interval in seconds in which one http request can be made")
 local http_max_active = CreateConVar("sf_http_max_active", "3", { FCVAR_ARCHIVE }, "The maximum amount of active http requests at the same time")
 
 local permission_level = SERVER and 1 or 3


### PR DESCRIPTION
Adds the ability to have concurrent HTTP requests. I assume that this functionality was intended to be implemented at some point (there's a convar named "sf_http_max_active" which was going unused until now).

Also adds http.getActiveRequests and http.getMaximumRequests.

![MaximumRequests](https://user-images.githubusercontent.com/106459595/232866280-72343508-2333-4824-8d75-22e906ee42a2.png)
