### PR TITLE
Make printTable not print the initial table twice

### DIFF
--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -562,7 +562,7 @@ if SERVER then
 	-- @param table tbl Table to print
 	function builtins_library.printTable(tbl)
 		checkluatype(tbl, TYPE_TABLE)
-		printTableX(tbl, 0, { tbl = true })
+		printTableX(tbl, 0, { [tbl] = true })
 	end
 
 	--- Execute a console command


### PR DESCRIPTION
I don't know how I didn't notice this when I was adding StructWrapper support to `printTable` but the third argument it passes doesn't actually add the initial table to the `alreadyprinted` table and just sets the string key `tbl` to `true` instead of the actual table object.

As far as I can tell with git blame, this last worked 10 years ago lmao.