### PR TITLE
Check main script was compiled / Error message for including across realms

### DIFF
--- a/lua/starfall/instance.lua
+++ b/lua/starfall/instance.lua
@@ -599,10 +599,12 @@ function SF.Instance:initialize()
 	self:RunHook("initialize")
 
 	local func = self.scripts[self.mainfile]
-	local tbl = self:run(func)
-	if not tbl[1] then
-		self:Error(tbl[2])
-		return false, tbl[2]
+	if func then
+		local tbl = self:run(func)
+		if not tbl[1] then
+			self:Error(tbl[2])
+			return false, tbl[2]
+		end
 	end
 
 	return true

--- a/lua/starfall/instance.lua
+++ b/lua/starfall/instance.lua
@@ -63,6 +63,20 @@ function SF.Instance.Compile(code, mainfile, player, entity)
 		end
 	end
 
+	local includes = instance.ppdata.includes
+	if includes then
+		local serverorclient = instance.ppdata.serverorclient
+		if serverorclient then
+			for filename, files in pairs(includes) do
+				for _, t in ipairs(files) do
+					if serverorclient[t] and serverorclient[filename] ~= serverorclient[t] then
+						return false, { message = "Can't include a file that doesn't exist in the same realm!", traceback = "" }
+					end
+				end
+			end
+		end
+	end
+
 	if player:IsWorld() then
 		player = SF.Superuser
 	elseif instance.ppdata.superuser and instance.ppdata.superuser[mainfile] then

--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -1246,3 +1246,7 @@ end
 --- Lets the chip run with no restrictions and the chip owner becomes SF.Superuser. Can only be used in the main file. --@superuser
 -- @name superuser
 -- @class directive
+
+--- Set the current file to only be sent to the owner. --@owneronly
+-- @name owneronly
+-- @class directive


### PR DESCRIPTION
Minor additions due to the changes in the owneronly pull req which stops files across realms from needlessly compiling.

Fix SF not checking main script is compiled before attempting to run it.
Add error message when trying to include files that only exist in the opposite realm.