### PR TITLE
Don't block mouse/joystick when chat is open and the input.chat perm is disabled

### DIFF
--- a/lua/starfall/libs_sh/input.lua
+++ b/lua/starfall/libs_sh/input.lua
@@ -92,10 +92,11 @@ hook.Add("FinishChat","SF_StartChat",function() isChatOpen=false end)
 
 
 local function CheckButtonPerms(instance, ply, button)
-	if (IsFirstTimePredicted() or game.SinglePlayer()) and haspermission(instance, nil, "input") and (not isChatOpen or haspermission(instance, nil, "input.chat")) then
-		return true, { button }
-	end
-	return false
+	if not IsFirstTimePredicted() and not game.SinglePlayer() then return false end
+	if not haspermission(instance, nil, "input") then return false end
+	if isChatOpen and not haspermission(instance, nil, "input.chat") then return false end
+
+	return true, { button }
 end
 
 --- Called when a button is pressed

--- a/lua/starfall/libs_sh/input.lua
+++ b/lua/starfall/libs_sh/input.lua
@@ -94,7 +94,11 @@ hook.Add("FinishChat","SF_StartChat",function() isChatOpen=false end)
 local function CheckButtonPerms(instance, ply, button)
 	if not IsFirstTimePredicted() and not game.SinglePlayer() then return false end
 	if not haspermission(instance, nil, "input") then return false end
-	if isChatOpen and not haspermission(instance, nil, "input.chat") then return false end
+	if isChatOpen and not haspermission(instance, nil, "input.chat") then
+		local notMouseButton = button < MOUSE_FIRST and button > MOUSE_LAST
+		local notJoystick = button < JOYSTICK_FIRST and button > JOYSTICK_LAST
+		if notMouseButton and notJoystick then return false end -- Mouse and joystick are allowed, they don't put text into the chat
+	end
 
 	return true, { button }
 end


### PR DESCRIPTION
Fixes an issue with a29daca which causes it to block mouse/joystick inputs despite them not altering the chat box's text.