### PR TITLE
Fix text depth rendering in Cam3D2D example

### DIFF
--- a/lua/starfall/examples/cam3d2d.lua
+++ b/lua/starfall/examples/cam3d2d.lua
@@ -2,7 +2,6 @@
 --@author Name
 --@client
 
-local iterations = 14
 local scale = 0.1
 local font = render.createFont("Roboto", 256, 400, true)
 
@@ -12,21 +11,23 @@ local font = render.createFont("Roboto", 256, 400, true)
 -- m:setTranslation(Vector(0, 0, 0))
 -- m:setScale(Vector(scale, -scale))
 
-hook.add("PostDrawOpaqueRenderables", "", function()
+hook.add("PreDrawTranslucentRenderables", "", function()
     local m = chip():getMatrix()
     m:translate(Vector(0, 0, 45))
     m:setAngles((eyePos() - m:getTranslation()):getAngle() + Angle(90, 0, 0))
     m:rotate(Angle(0, 90, 0))
     m:setScale(Vector(scale, -scale))
     
-    for i = 1, iterations do
-        render.pushMatrix(m)
-            render.setColor(Color(245, 177, 29) / (iterations-i))
-            render.setFont(font)
-            render.drawSimpleText(0, 0, "FANCY", 1, 1)
-        render.popMatrix()
-        m:translate(Vector(1, -1))
-    end
+    render.pushMatrix(m)
+        render.setColor(Color(255, 191, 20, 155))
+        render.drawRect(-512, -128, 1024, 256)
+
+        -- Override depth for text rendering, otherwise it's gonna draw on top of the world
+        render.enableDepth(true)
+        render.setColor(Color(10, 167, 238))
+        render.setFont(font)
+        render.drawSimpleText(0, 0, "StarfallEx", 1, 1)
+    render.popMatrix()
 end)
 
 if player() == owner() then


### PR DESCRIPTION
Fixes the text drawing on top of the font. Also simplified the example a bit and changed the hook to a better one.