### PR TITLE
Allow using setEyeAngles on self

### DIFF
--- a/lua/starfall/libs_sh/players.lua
+++ b/lua/starfall/libs_sh/players.lua
@@ -550,9 +550,9 @@ if SERVER then
 	function player_methods:setEyeAngles(ang)
 		local ent = getent(self)
 		local ang = aunwrap(ang)
-
-		checkpermission(instance, ent, "entities.setEyeAngles")
-
+		if instance.player != ent then
+			checkpermission(instance, ent, "entities.setEyeAngles")
+		end
 		ent:SetEyeAngles(ang)
 	end
 


### PR DESCRIPTION
Fix for being unable to modify own eye angles due to world entity owning players via CPPI.