### PR TITLE
Add game.maxAmmoCount()

### DIFF
--- a/lua/starfall/libs_sh/game.lua
+++ b/lua/starfall/libs_sh/game.lua
@@ -84,9 +84,9 @@ function game_library.getAmmoData(id)
 	return game.GetAmmoData(id)
 end
 
---- Returns the real maximum amount of ammo of given ammo ID, regardless of the setting of gmod_maxammo convar.
+--- Returns the real maximum amount of ammo of given ammo ID, regardless of the setting of gmod_maxammo convar
 -- @param number id See https://wiki.facepunch.com/gmod/Default_Ammo_Types
--- @return The maximum amount of reserve ammo a player can hold of this ammo type.
+-- @return The maximum amount of reserve ammo a player can hold of this ammo type
 function game_library.getAmmoMax(id)
 	return game.GetAmmoMax(id)
 end

--- a/lua/starfall/libs_sh/game.lua
+++ b/lua/starfall/libs_sh/game.lua
@@ -90,7 +90,7 @@ end
 function game_library.getAmmoMax(id)
 	return game.GetAmmoMax(id)
 end
-	
+
 --- Returns the worldspawn entity
 -- @return Entity Worldspawn
 function game_library.getWorld()

--- a/lua/starfall/libs_sh/game.lua
+++ b/lua/starfall/libs_sh/game.lua
@@ -84,6 +84,13 @@ function game_library.getAmmoData(id)
 	return game.GetAmmoData(id)
 end
 
+--- Returns the real maximum amount of ammo of given ammo ID, regardless of the setting of gmod_maxammo convar.
+-- @param number id See https://wiki.facepunch.com/gmod/Default_Ammo_Types
+-- @return The maximum amount of reserve ammo a player can hold of this ammo type.
+function game_library.getAmmoMax(id)
+	return game.GetAmmoMax(id)
+end
+	
 --- Returns the worldspawn entity
 -- @return Entity Worldspawn
 function game_library.getWorld()

--- a/lua/starfall/libs_sh/game.lua
+++ b/lua/starfall/libs_sh/game.lua
@@ -86,7 +86,7 @@ end
 
 --- Returns the real maximum amount of ammo of given ammo ID, regardless of the setting of gmod_maxammo convar
 -- @param number id See https://wiki.facepunch.com/gmod/Default_Ammo_Types
--- @return The maximum amount of reserve ammo a player can hold of this ammo type
+-- @return number The maximum amount of reserve ammo a player can hold of this ammo type
 function game_library.getAmmoMax(id)
 	return game.GetAmmoMax(id)
 end


### PR DESCRIPTION
Additions:
- Wrapped game.GetAmmoMax() to be usable in starfall (game.getAmmoMax() in SF)

This is to avoid the headache of `game.getAmmoData(wep:getPrimaryAmmoType()).maxcarry` and then manually processing whether the output was a number or a string convar pointer (and potentially even doing more calls if it is a string JUST to find out a simple number)