### PR TITLE
Add render.suppressEngineLighting()

### DIFF
--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -471,6 +471,7 @@ function instance:cleanupRender()
 	render.SetLightingMode(0)
 	render.ResetModelLighting(1, 1, 1)
 	render.DepthRange(0, 1)
+	render.SuppressEngineLighting(false)
 	pp.colour:SetTexture("$fbtexture", tex_screenEffect)
 	pp.downsample:SetTexture("$fbtexture", tex_screenEffect)
 	for i = #matrix_stack, 1, -1 do
@@ -543,6 +544,12 @@ function render_library.clearStencil()
 	render.ClearStencil()
 end
 
+function render_library.suppressEngineLighting(enable)
+	enable = (enable == true)
+	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
+	render.SuppressEngineLighting(enable)
+end
+	
 --- Sets up the ambient lighting for any upcoming render operation. Ambient lighting can be seen as a cube enclosing the object to be drawn, each of its faces representing a directional light source that shines towards the object.
 -- @param number lightDirection The light source to edit, builtins.BOX enumeration.
 -- @param number r The red component of the light color.

--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -544,6 +544,8 @@ function render_library.clearStencil()
 	render.ClearStencil()
 end
 
+--- Suppresses or enables any engine lighting for any upcoming render operation.
+-- @param boolean suppress True to suppress false to enable.
 function render_library.suppressEngineLighting(enable)
 	enable = (enable == true)
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end

--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -532,7 +532,6 @@ end
 --- Sets whether stencil tests are carried out for each rendered pixel. Only pixels passing the stencil test are written to the render target.
 -- @param boolean enable True to enable, false to disable
 function render_library.setStencilEnable(enable)
-	enable = (enable == true) -- Make sure it's a boolean
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	if renderdata.noStencil and not renderdata.usingRT then SF.Throw("Stencil operations must be used inside RenderTarget or HUD") end
 	render.SetStencilEnable(enable)
@@ -547,7 +546,6 @@ end
 --- Suppresses or enables any engine lighting for any upcoming render operation.
 -- @param boolean suppress True to suppress false to enable.
 function render_library.suppressEngineLighting(enable)
-	enable = (enable == true)
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	render.SuppressEngineLighting(enable)
 end


### PR DESCRIPTION
Required for things like render.setModelLighting and render.resetModelLighting as those + the draw function need to be wrapped in SuppressEngineLighting to work.