### PR TITLE
Add revolt.chat to the URL whitelist

### DIFF
--- a/lua/starfall/permissions/providers_sh/url_whitelist.lua
+++ b/lua/starfall/permissions/providers_sh/url_whitelist.lua
@@ -247,3 +247,12 @@ pattern [[(%w+)%.keybase.pub/(.+)]]
 -- Examples:
 -- https://tts.cyzon.us/tts?text=test
 pattern [[tts.cyzon.us/(.+)]]
+
+-- Revolt
+--- Examples:
+---  https://static.revolt.chat/emoji/mutant/1f440.svg?rev=3
+---  https://autumn.revolt.chat/emojis/01G7J9RTHKEPJM8DM19TX35M8N
+---  https://autumn.revolt.chat/attachments/mmCR_bFMLEfBAE8mweH2u4o9_x6DiDtU9JXoSbdvZE/live-bocchi-reaction.gif
+
+simple [[static.revolt.chat]]
+simple [[autumn.revolt.chat]]


### PR DESCRIPTION
Revolt is a open source chat platform, similar to Discord. This PR adds the media and emoji URLs to the whitelist (`static.revolt.chat` and `autumn.revolt.chat`).