### PR TITLE
Add hook to prevent Effects from being created

### DIFF
--- a/lua/starfall/libs_sh/effect.lua
+++ b/lua/starfall/libs_sh/effect.lua
@@ -69,6 +69,7 @@ function effect_methods:play(eff)
 	plyEffectBurst:use(instance.player, 1)
 
 	if effect_blacklist[eff] then SF.Throw("Effect ("..eff..") is blacklisted", 2) end
+	if hook.Run( "Starfall_CanEffect", eff:lower(), instance ) == false then SF.Throw("Effect ("..eff..") has been blocked from running", 2) end
 
 	util.Effect(eff,unwrap(self))
 end

--- a/lua/starfall/libs_sh/effect.lua
+++ b/lua/starfall/libs_sh/effect.lua
@@ -68,8 +68,9 @@ function effect_methods:play(eff)
 	checkpermission(instance, nil, "effect.play")
 	plyEffectBurst:use(instance.player, 1)
 
+	eff = eff:lower()
 	if effect_blacklist[eff] then SF.Throw("Effect ("..eff..") is blacklisted", 2) end
-	if hook.Run( "Starfall_CanEffect", eff:lower(), instance ) == false then SF.Throw("Effect ("..eff..") has been blocked from running", 2) end
+	if hook.Run( "Starfall_CanEffect", eff, instance ) == false then SF.Throw("Effect ("..eff..") has been blocked from running", 2) end
 
 	util.Effect(eff,unwrap(self))
 end


### PR DESCRIPTION
I need to block players from using certain Effects with the Starfall Effect library.

I didn't test it, but I can't imagine it would misbehave.

Given that the file already felt similar to the Wiremod effectcore file, I tried to duplicate its behavior:
https://github.com/wiremod/wire/blob/master/lua/entities/gmod_wire_expression2/core/custom/effects.lua#L174
