### PR TITLE
Cache "nil" permission requests per instance

### DIFF
--- a/lua/starfall/permissions/core.lua
+++ b/lua/starfall/permissions/core.lua
@@ -112,14 +112,13 @@ function P.registerPrivilege(id, name, description, providerconfig)
 end
 
 function P.check(instance, target, key)
-	local nilTarget = target == nil
-	if nilTarget then
-		local permCache = instance.permissionCache
-		if not permCache then
-			instance.permissionCache = {}
-			permCache = instance.permissionCache
-		end
+	local permCache = instance.permissionCache
+	if not permCache then
+		instance.permissionCache = {}
+		permCache = instance.permissionCache
+	end
 
+	if target == nil then
 		local cached = permCache[key]
 		if cached then return cached end
 	end
@@ -127,7 +126,7 @@ function P.check(instance, target, key)
 	local ok, reason = P.privileges[key].check(instance, target)
 	if not ok then SF.Throw("Permission " .. key .. ": " .. reason, 3) end
 
-	if nilTarget then
+	if target == nil then
 		permCache[key] = true
 	end
 end

--- a/lua/starfall/permissions/core.lua
+++ b/lua/starfall/permissions/core.lua
@@ -111,9 +111,20 @@ function P.registerPrivilege(id, name, description, providerconfig)
 	P.privileges[id] = Privilege(id, name, description, providerconfig)
 end
 
+local permNCache = {}
+
 function P.check(instance, target, key)
+	if target == nil then
+		local cached = permNCache[key]
+		if cached then return cached end
+	end
+
 	local ok, reason = P.privileges[key].check(instance, target)
 	if not ok then SF.Throw("Permission " .. key .. ": " .. reason, 3) end
+
+	if target == nil then
+		permNCache[key] = true
+	end
 end
 
 function P.hasAccess(instance, target, key)
@@ -121,6 +132,8 @@ function P.hasAccess(instance, target, key)
 end
 
 function P.refreshSettingsCache()
+	permNCache = {}
+
 	for providerid, provider in pairs(P.providers) do
 		local settings = {}
 		for privilegeid, privilege in pairs(P.privileges) do

--- a/lua/starfall/permissions/core.lua
+++ b/lua/starfall/permissions/core.lua
@@ -112,13 +112,14 @@ function P.registerPrivilege(id, name, description, providerconfig)
 end
 
 function P.check(instance, target, key)
-	local permCache = instance.permissionCache
-	if not permCache then
-		instance.permissionCache = {}
-		permCache = instance.permissionCache
-	end
+	local nilTarget = target == nil
+	if nilTarget then
+		local permCache = instance.permissionCache
+		if not permCache then
+			instance.permissionCache = {}
+			permCache = instance.permissionCache
+		end
 
-	if target == nil then
 		local cached = permCache[key]
 		if cached then return cached end
 	end
@@ -126,7 +127,7 @@ function P.check(instance, target, key)
 	local ok, reason = P.privileges[key].check(instance, target)
 	if not ok then SF.Throw("Permission " .. key .. ": " .. reason, 3) end
 
-	if target == nil then
+	if nilTarget then
 		permCache[key] = true
 	end
 end

--- a/lua/starfall/permissions/core.lua
+++ b/lua/starfall/permissions/core.lua
@@ -111,11 +111,15 @@ function P.registerPrivilege(id, name, description, providerconfig)
 	P.privileges[id] = Privilege(id, name, description, providerconfig)
 end
 
-local permNCache = {}
-
 function P.check(instance, target, key)
+	local permCache = instance.permissionCache
+	if not permCache then
+		instance.permissionCache = {}
+		permCache = instance.permissionCache
+	end
+
 	if target == nil then
-		local cached = permNCache[key]
+		local cached = permCache[key]
 		if cached then return cached end
 	end
 
@@ -123,7 +127,7 @@ function P.check(instance, target, key)
 	if not ok then SF.Throw("Permission " .. key .. ": " .. reason, 3) end
 
 	if target == nil then
-		permNCache[key] = true
+		permCache[key] = true
 	end
 end
 
@@ -132,8 +136,6 @@ function P.hasAccess(instance, target, key)
 end
 
 function P.refreshSettingsCache()
-	permNCache = {}
-
 	for providerid, provider in pairs(P.providers) do
 		local settings = {}
 		for privilegeid, privilege in pairs(P.privileges) do


### PR DESCRIPTION
After testing around and seeing if i could improve performance on trace.line i saw that permission requests take up a significant amount of time. After further inspection i noticed that some checks like the trace permission check run each time while there's no need for it.
So i decided to use a cache to improve the speed of perm checks.

Testing using this code:
![image](https://github.com/thegrb93/StarfallEx/assets/69946827/3751266e-d2b9-48ca-a75f-1ab36e8af427)

Before:
![image](https://github.com/thegrb93/StarfallEx/assets/69946827/9cc027f6-bbc5-4861-84c0-5686b25edc9c)

After:
![image](https://github.com/thegrb93/StarfallEx/assets/69946827/4eb63414-abbe-4a14-a446-d730f1227027)

As can be seen, proportionally it takes up significantly less time with the cache in place