### PR TITLE
Allow EntityFireBullets hook to set a bullet callback

### DIFF
--- a/lua/starfall/libs_sh/hook.lua
+++ b/lua/starfall/libs_sh/hook.lua
@@ -461,7 +461,9 @@ add("EntityFireBullets", nil, function(instance, ent, data)
 	return true, { instance.WrapObject(ent), SF.StructWrapper(instance, data, "Bullet") }
 end, function(instance, ret, ent, data)
 	if ret[1] and isfunction(ret[2]) then
+		local prevCallback = data.Callback
 		data.Callback = function(attacker, tr, dmginfo)
+			if isfunction(prevCallback) then prevCallback(attacker, tr, dmginfo) end
 			ret[2](instance.WrapObject(attacker), SF.StructWrapper(instance, tr, "TraceResult"))
 		end
 		return true

--- a/lua/starfall/libs_sh/hook.lua
+++ b/lua/starfall/libs_sh/hook.lua
@@ -461,9 +461,7 @@ add("EntityFireBullets", nil, function(instance, ent, data)
 	return true, { instance.WrapObject(ent), SF.StructWrapper(instance, data, "Bullet") }
 end, function(instance, ret, ent, data)
 	if ret[1] and isfunction(ret[2]) then
-		local prevCallback = data.Callback
 		data.Callback = function(attacker, tr, dmginfo)
-			if isfunction(prevCallback) then prevCallback(attacker, tr, dmginfo) end
 			instance:runFunction(ret[2], instance.WrapObject(attacker), SF.StructWrapper(instance, tr, "TraceResult"))
 		end
 		return true

--- a/lua/starfall/libs_sh/hook.lua
+++ b/lua/starfall/libs_sh/hook.lua
@@ -464,11 +464,11 @@ end, function(instance, ret, ent, data)
 		local prevCallback = data.Callback
 		data.Callback = function(attacker, tr, dmginfo)
 			if isfunction(prevCallback) then prevCallback(attacker, tr, dmginfo) end
-			ret[2](instance.WrapObject(attacker), SF.StructWrapper(instance, tr, "TraceResult"))
+			instance:runFunction(ret[2], instance.WrapObject(attacker), SF.StructWrapper(instance, tr, "TraceResult"))
 		end
 		return true
 	end
-end)
+end, true)
 
 --- Called whenever a sound has been played. This will not be called clientside if the server played the sound without the client also calling Entity:EmitSound.
 -- @name EntityEmitSound

--- a/lua/starfall/libs_sh/hook.lua
+++ b/lua/starfall/libs_sh/hook.lua
@@ -456,8 +456,16 @@ add("PropBreak")
 -- @shared
 -- @param Entity ent The entity that fired the bullet
 -- @param table data The bullet data. See http://wiki.facepunch.com/gmod/Structures/Bullet
+-- @return function? Optional callback to called as if it were the Bullet structure's Callback. Called before the bullet deals damage with attacker, traceResult.
 add("EntityFireBullets", nil, function(instance, ent, data)
 	return true, { instance.WrapObject(ent), SF.StructWrapper(instance, data, "Bullet") }
+end, function(instance, ret, ent, data)
+	if ret[1] and isfunction(ret[2]) then
+		data.Callback = function(attacker, tr, dmginfo)
+			ret[2](instance.WrapObject(attacker), SF.StructWrapper(instance, tr, "TraceResult"))
+		end
+		return true
+	end
 end)
 
 --- Called whenever a sound has been played. This will not be called clientside if the server played the sound without the client also calling Entity:EmitSound.


### PR DESCRIPTION
Allows for the `EntityFireBullets` hook to optionally return a function that will be called as if it were the `Bullet.Callback`. When the bullet gets fired, the callback will be called with the wrapped `attacker` and `traceResult`, `dmgInfo` (CTakeDamageInfo) has been omitted.

This solves the issue of it not being possible to get exactly where a bullet impacts as the `EntityFireBullets` does not have all the needed information to compute the bullet trace, as it contains the general spread of the weapon being fired, not the actual, specific, random spread that has been chosen for the currently being fired bullet. Would also be more efficint that re-tracing an already traced trajectory.