### PR TITLE
Reload permissions after reloading a library. Fixes: #1561

### DIFF
--- a/lua/starfall/sflib.lua
+++ b/lua/starfall/sflib.lua
@@ -1950,6 +1950,7 @@ do
 				if file.Exists(sv_filename, "LUA") then
 					addModule(name, sv_filename, true)
 				end
+				SF.Permissions.loadPermissions()
 			end
 			if file.Exists(cl_filename, "LUA") then
 				addModule(name, cl_filename, false)
@@ -1993,6 +1994,7 @@ do
 						t2.source = code
 						if shouldrun then
 							t2.init = compileModule(code, path)
+							SF.Permissions.loadPermissions()
 						end
 					end
 				end


### PR DESCRIPTION
Fixes: #1561

This will reload all permissions if file matches the realm or is shared, is that correct or does it also need to reload them if the realm is different?  
It seems to work just fine.