### PR TITLE
Add workshop deploy workflow

### DIFF
--- a/.github/workflows/workshop.yml
+++ b/.github/workflows/workshop.yml
@@ -1,0 +1,21 @@
+name: Deploy to Workshop
+
+on:
+  push:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@master
+
+      - uses: vurv78/gmod-upload@v0.1.4
+        with:
+          id: 2273610511
+          changelog: ${{ github.event.head_commit.message }}
+        env:
+          STEAM_USERNAME: ${{ secrets.WORKSHOP_USERNAME }}
+          STEAM_PASSWORD: ${{ secrets.WORKSHOP_PASSWORD }}


### PR DESCRIPTION
This adds the same workflow wiremod uses for the canary build.

Runs on every commit and deploys to workshop with commit message as the changelog.

Uses `vurv78/gmod-upload` pinned to `v0.1.4` -- can be changed to a fork if desired

Needs `WORKSHOP_USERNAME` and `WORKSHOP_PASSWORD`, need an alt account with gmod you don't care about to use this, even if it did support 2fa (which it doesn't) I wouldn't take any chances