### PR TITLE
Fix typo in ent.HasFlexManipulatior

### DIFF
--- a/lua/starfall/libs_sh/entities.lua
+++ b/lua/starfall/libs_sh/entities.lua
@@ -1412,7 +1412,7 @@ end
 -- @return boolean True if the entity has flex manipulations, false otherwise.
 function ents_methods:hasFlexManipulations()
 	local ent = getent(self)
-	return ent:HasFlexManipulator()
+	return ent:HasFlexManipulatior()
 end
 
 --- Gets the weight (value) of a flex.


### PR DESCRIPTION
Yes, it's *Manipula<ins>tio</ins>r*, not *Manipulator*.  
https://wiki.facepunch.com/gmod/Entity:HasFlexManipulatior

```lua
local holo = hologram.create(chip():getPos(), Angle(), "models/gman_high.mdl")
holo:setFlexWeight(23, 10)
print(holo:hasFlexManipulations())
```