### PR TITLE
Add more 'pose' related functions

### DIFF
--- a/lua/starfall/libs_sh/entities.lua
+++ b/lua/starfall/libs_sh/entities.lua
@@ -1400,16 +1400,11 @@ function ents_methods:getPoseName(id)
 end
 
 --- Returns pose value range
--- @param number|string pose Pose name or pose index (starting from 0)
+-- @param number Pose index (starting from 0)
 -- @return number? Minimum pose value or nil if pose not found
 -- @return number? Maximum pose value or nil if pose not found
 function ents_methods:getPoseRange(pose)
-	local ent = getent(self)
-	if type(pose) == "number" then
-		return ent:GetPoseParameterRange(pose)
-	else
-		return ent:GetPoseParameterRange(ent:LookupPoseParameter(pose))
-	end
+	return getent(self):GetPoseParameterRange(pose)
 end
 
 --- Returns a table of flexname -> flexid pairs for use in flex functions.

--- a/lua/starfall/libs_sh/entities.lua
+++ b/lua/starfall/libs_sh/entities.lua
@@ -1400,7 +1400,7 @@ function ents_methods:getPoseName(id)
 end
 
 --- Returns pose value range
--- @param number|string id Pose name or pose index (starting from 0)
+-- @param number|string pose Pose name or pose index (starting from 0)
 -- @return number? Minimum pose value or nil if pose not found
 -- @return number? Maximum pose value or nil if pose not found
 function ents_methods:getPoseRange(pose)

--- a/lua/starfall/libs_sh/entities.lua
+++ b/lua/starfall/libs_sh/entities.lua
@@ -1400,11 +1400,11 @@ function ents_methods:getPoseName(id)
 end
 
 --- Returns pose value range
--- @param number Pose index (starting from 0)
+-- @param number id Pose index (starting from 0)
 -- @return number? Minimum pose value or nil if pose not found
 -- @return number? Maximum pose value or nil if pose not found
-function ents_methods:getPoseRange(pose)
-	return getent(self):GetPoseParameterRange(pose)
+function ents_methods:getPoseRange(id)
+	return getent(self):GetPoseParameterRange(id)
 end
 
 --- Returns a table of flexname -> flexid pairs for use in flex functions.

--- a/lua/starfall/libs_sh/entities.lua
+++ b/lua/starfall/libs_sh/entities.lua
@@ -1379,6 +1379,39 @@ function ents_methods:getPose(pose)
 	return getent(self):GetPoseParameter(pose)
 end
 
+--- Returns the amount of pose parameters the entity has
+-- @return number Amount of poses
+function ents_methods:getPoseCount()
+	return getent(self):GetNumPoseParameters()
+end
+
+--- Returns pose index corresponding to the given name
+-- @param string pose Pose name
+-- @return number Pose index or -1 if not found
+function ents_methods:getPoseIndex(pose)
+	return getent(self):LookupPoseParameter(pose)
+end
+
+--- Returns pose name corresponding to the given index
+-- @param number id Pose index (starting from 0)
+-- @return string Pose name or empty string if not found
+function ents_methods:getPoseName(id)
+	return getent(self):GetPoseParameterName(id)
+end
+
+--- Returns pose value range
+-- @param number|string id Pose name or pose index (starting from 0)
+-- @return number? Minimum pose value or nil if pose not found
+-- @return number? Maximum pose value or nil if pose not found
+function ents_methods:getPoseRange(pose)
+	local ent = getent(self)
+	if type(pose) == "number" then
+		return ent:GetPoseParameterRange(pose)
+	else
+		return ent:GetPoseParameterRange(ent:LookupPoseParameter(pose))
+	end
+end
+
 --- Returns a table of flexname -> flexid pairs for use in flex functions.
 -- @return table Table of flexes
 function ents_methods:getFlexes()


### PR DESCRIPTION
Made `getPoseRange` also accept `string`, because all other functions besides `getPoseIndex` work on strings.