### PR TITLE
Add PostEntityFireBullets hook

### DIFF
--- a/lua/starfall/libs_sh/hook.lua
+++ b/lua/starfall/libs_sh/hook.lua
@@ -456,17 +456,9 @@ add("PropBreak")
 -- @shared
 -- @param Entity ent The entity that fired the bullet
 -- @param table data The bullet data. See http://wiki.facepunch.com/gmod/Structures/Bullet
--- @return function? Optional callback to called as if it were the Bullet structure's Callback. Called before the bullet deals damage with attacker, traceResult.
 add("EntityFireBullets", nil, function(instance, ent, data)
 	return true, { instance.WrapObject(ent), SF.StructWrapper(instance, data, "Bullet") }
-end, function(instance, ret, ent, data)
-	if ret[1] and isfunction(ret[2]) then
-		data.Callback = function(attacker, tr, dmginfo)
-			instance:runFunction(ret[2], instance.WrapObject(attacker), SF.StructWrapper(instance, tr, "TraceResult"))
-		end
-		return true
-	end
-end, true)
+end)
 
 --- Called whenever a sound has been played. This will not be called clientside if the server played the sound without the client also calling Entity:EmitSound.
 -- @name EntityEmitSound

--- a/lua/starfall/libs_sh/hook.lua
+++ b/lua/starfall/libs_sh/hook.lua
@@ -460,6 +460,26 @@ add("EntityFireBullets", nil, function(instance, ent, data)
 	return true, { instance.WrapObject(ent), SF.StructWrapper(instance, data, "Bullet") }
 end)
 
+--- Called after a bullet is fired and it's trace has been calculated
+-- @name PostEntityFireBullets
+-- @class hook
+-- @shared
+-- @param Entity ent The entity that fired the bullet
+-- @param table data A table containing Trace (See http://wiki.facepunch.com/gmod/Structures/TraceResult) and AmmoType, Tracer, Damage, Force, Attacker, TracerName (see http://wiki.facepunch.com/gmod/Structures/Bullet)
+add("PostEntityFireBullets", nil, function(instance, ent, data)
+	return true, {
+		instance.WrapObject(ent), {
+			["Trace"] = SF.StructWrapper(instance, data["Trace"], "TraceResult"),
+			["AmmoType"] = data["AmmoType"],
+			["Tracer"] = data["Tracer"],
+			["Damage"] = data["Damage"],
+			["Force"] = data["Force"],
+			["Attacker"] = instance.WrapObject(data["Attacker"]),
+			["TracerName"] = data["TracerName"]
+		}
+	}
+end)
+
 --- Called whenever a sound has been played. This will not be called clientside if the server played the sound without the client also calling Entity:EmitSound.
 -- @name EntityEmitSound
 -- @class hook

--- a/lua/starfall/libs_sh/hook.lua
+++ b/lua/starfall/libs_sh/hook.lua
@@ -456,9 +456,17 @@ add("PropBreak")
 -- @shared
 -- @param Entity ent The entity that fired the bullet
 -- @param table data The bullet data. See http://wiki.facepunch.com/gmod/Structures/Bullet
+-- @return function? Optional callback to called as if it were the Bullet structure's Callback. Called before the bullet deals damage with attacker, traceResult.
 add("EntityFireBullets", nil, function(instance, ent, data)
 	return true, { instance.WrapObject(ent), SF.StructWrapper(instance, data, "Bullet") }
-end)
+end, function(instance, ret, ent, data)
+	if ret[1] and isfunction(ret[2]) then
+		data.Callback = function(attacker, tr, dmginfo)
+			instance:runFunction(ret[2], instance.WrapObject(attacker), SF.StructWrapper(instance, tr, "TraceResult"))
+		end
+		return true
+	end
+end, true)
 
 --- Called after a bullet is fired and it's trace has been calculated
 -- @name PostEntityFireBullets
@@ -467,17 +475,9 @@ end)
 -- @param Entity ent The entity that fired the bullet
 -- @param table data A table containing Trace (See http://wiki.facepunch.com/gmod/Structures/TraceResult) and AmmoType, Tracer, Damage, Force, Attacker, TracerName (see http://wiki.facepunch.com/gmod/Structures/Bullet)
 add("PostEntityFireBullets", nil, function(instance, ent, data)
-	return true, {
-		instance.WrapObject(ent), {
-			["Trace"] = SF.StructWrapper(instance, data["Trace"], "TraceResult"),
-			["AmmoType"] = data["AmmoType"],
-			["Tracer"] = data["Tracer"],
-			["Damage"] = data["Damage"],
-			["Force"] = data["Force"],
-			["Attacker"] = instance.WrapObject(data["Attacker"]),
-			["TracerName"] = data["TracerName"]
-		}
-	}
+	local ret = SF.StructWrapper(instance, data, "Bullet")
+	ret.Trace = SF.StructWrapper(instance, data.Trace, "TraceResult")
+	return true, ret
 end)
 
 --- Called whenever a sound has been played. This will not be called clientside if the server played the sound without the client also calling Entity:EmitSound.

--- a/lua/starfall/libs_sh/hook.lua
+++ b/lua/starfall/libs_sh/hook.lua
@@ -477,7 +477,7 @@ end, true)
 add("PostEntityFireBullets", nil, function(instance, ent, data)
 	local ret = SF.StructWrapper(instance, data, "Bullet")
 	ret.Trace = SF.StructWrapper(instance, data.Trace, "TraceResult")
-	return true, ret
+	return true, {instance.WrapObject(ent), ret}
 end)
 
 --- Called whenever a sound has been played. This will not be called clientside if the server played the sound without the client also calling Entity:EmitSound.


### PR DESCRIPTION
Reverts the placeholder 053474d and adds the new [PostEntityFireBullets](https://wiki.facepunch.com/gmod/GM:PostEntityFireBullets) shared hook.

The hook is not yet in the production version of Garry's Mod and appears to still have some issues, such as not being called on the client-side despite being documented as shared. Hence why this is a draft.