### PR TITLE
Add function: Entity.setPhysicsUpdateListener

### DIFF
--- a/lua/starfall/libs_sh/hook.lua
+++ b/lua/starfall/libs_sh/hook.lua
@@ -559,12 +559,6 @@ return function(instance)
 local getent
 instance:AddHook("initialize", function()
 	getent = instance.Types.Entity.GetEntity
-
-	if SERVER then
-		instance.entity.PhysicsUpdate = function()
-			instance:runScriptHook("starfallphysicsupdate")
-		end
-	end
 end)
 
 instance:AddHook("deinitialize", function()
@@ -748,11 +742,6 @@ end
 -- @class hook
 -- @param Player activator Player who used the screen or chip
 -- @param Entity used The screen or chip entity that was used
-
---- Called when the Starfall chip's physics is updated. This won't be called if the physics object goes asleep.
--- @name starfallPhysicsUpdate
--- @class hook
--- @server
 
 --- Called when a frame is requested to be drawn on screen. (2D/3D Context)
 -- @name render

--- a/lua/starfall/libs_sh/hook.lua
+++ b/lua/starfall/libs_sh/hook.lua
@@ -559,6 +559,12 @@ return function(instance)
 local getent
 instance:AddHook("initialize", function()
 	getent = instance.Types.Entity.GetEntity
+
+	if SERVER then
+		instance.entity.PhysicsUpdate = function()
+			instance:runScriptHook("starfallphysicsupdate")
+		end
+	end
 end)
 
 instance:AddHook("deinitialize", function()
@@ -742,6 +748,11 @@ end
 -- @class hook
 -- @param Player activator Player who used the screen or chip
 -- @param Entity used The screen or chip entity that was used
+
+--- Called when the Starfall chip's physics is updated. This won't be called if the physics object goes asleep.
+-- @name starfallPhysicsUpdate
+-- @class hook
+-- @server
 
 --- Called when a frame is requested to be drawn on screen. (2D/3D Context)
 -- @name render

--- a/lua/starfall/libs_sv/entities.lua
+++ b/lua/starfall/libs_sv/entities.lua
@@ -848,5 +848,38 @@ function ents_methods:getCreationID()
 	return ent:GetCreationID()
 end
 
+local physUpdateWhitelist = {
+	["starfall_prop"] = true,
+	["starfall_processor"] = true,
+}
+
+--- Set the function to run whenever the physics of the entity are updated.
+--- This won't be called if the physics object goes asleep.
+---
+--- You can only use this function on these classes:
+--- - starfall_prop
+--- - starfall_processor
+-- @param function|nil func The callback function. Use nil to remove an existing callback.
+function ents_methods:setPhysicsUpdateListener(func)
+	local ent = getent(self)
+
+	checkpermission(instance, ent, "entities.canTool")
+
+	local class = ent:GetClass()
+
+	if not physUpdateWhitelist[class] then
+		SF.Throw("Cannot use physics update listener on " .. class, 2)
+	end
+
+	if func then
+		checkluatype(func, TYPE_FUNCTION)
+
+		ent.PhysicsUpdate = function()
+			instance:runFunction(func)
+		end
+	else
+		ent.PhysicsUpdate = nil
+	end
+end
 
 end


### PR DESCRIPTION
- ~~Added a new hook: `starfallPhysicsUpdate`. *Called when the Starfall chip's physics is updated.*~~
- ~~When a Starfall instance initializes, add a `PhysicsUpdate` function to the chip entity that runs it~~
- ~~Added the new hook to the docs~~

No longer a hook, now it's a serverside function: `Entity.setPhysicsUpdateListener`