### PR TITLE
Material blacklist: Remove 'pp/copy', add 'debug/debugluxels'

### DIFF
--- a/lua/starfall/sflib.lua
+++ b/lua/starfall/sflib.lua
@@ -1272,6 +1272,7 @@ local shaderBlacklist = {
 }
 local materialBlacklist = {
 	["pp/copy"] = true,
+	["debug/debugluxels"] = true,
 	["effects/ar2_altfire1"] = true,
 }
 --- Checks that the material isn't malicious

--- a/lua/starfall/sflib.lua
+++ b/lua/starfall/sflib.lua
@@ -1271,7 +1271,6 @@ local shaderBlacklist = {
 	["LightmappedGeneric"] = true,
 }
 local materialBlacklist = {
-	["pp/copy"] = true,
 	["debug/debugluxels"] = true,
 	["effects/ar2_altfire1"] = true,
 }


### PR DESCRIPTION
`debug/debugluxels` - crashes Linux client
`pp/copy` - cannot reproduce the funky halo behavior anymore, it got fixed not that long ago: https://github.com/Facepunch/garrysmod-issues/issues/5157