### PR TITLE
Fix clientside holograms not keeping offset from their parents

### DIFF
--- a/lua/entities/starfall_hologram/cl_init.lua
+++ b/lua/entities/starfall_hologram/cl_init.lua
@@ -10,6 +10,10 @@ function ENT:Initialize()
 	self.sf_userrenderbounds = false
 	self:SetupBones()
 	self:OnScaleChanged(nil, nil, self:GetScale())
+
+	-- Fixes future SetParent calls not keeping offset from the parent
+	self:SetParent(Entity(0))
+	self:SetParent()
 end
 
 function ENT:SetClip(index, enabled, normal, origin, entity)

--- a/lua/starfall/libs_sh/hologram.lua
+++ b/lua/starfall/libs_sh/hologram.lua
@@ -215,11 +215,9 @@ else
 
 		holo:SetPos(pos)
 
-		if CLIENT then
-			local sfParent = holo.sfParent
-			if sfParent and sfParent.parent and sfParent.parent:IsValid() then
-				sfParent:updateTransform()
-			end
+		local sfParent = holo.sfParent
+		if sfParent and sfParent.parent and sfParent.parent:IsValid() then
+			sfParent:updateTransform()
 		end
 	end
 
@@ -233,11 +231,9 @@ else
 
 		holo:SetAngles(angle)
 		
-		if CLIENT then
-			local sfParent = holo.sfParent
-			if sfParent and sfParent.parent and sfParent.parent:IsValid() then
-				sfParent:updateTransform()
-			end
+		local sfParent = holo.sfParent
+		if sfParent and sfParent.parent and sfParent.parent:IsValid() then
+			sfParent:updateTransform()
 		end
 	end
 


### PR DESCRIPTION
Fix #1407.
Remove a useless realm check in `Hologram.setPos` and `Hologram.setAngles`.

___
  
Turns out that the fix of parenting to a serverside entity persists even after unparenting it immediately. Simply parenting and unparenting from the World entity seems to fix all the problems outlined in #1407.

I don't think it has any negative side-effects.