### PR TITLE
Rework `Entity.setCustomPropForces` and add `Entity.setCustomPropShadowForce`

### DIFF
--- a/lua/entities/starfall_prop/init.lua
+++ b/lua/entities/starfall_prop/init.lua
@@ -15,10 +15,31 @@ function ENT:Initialize()
 	self:AddEFlags( EFL_FORCE_CHECK_TRANSMIT )
 end
 
+function ENT:EnableCustomPhysics(mode)
+	if mode then
+		self.customPhysicsMode = mode
+		if not self.hasMotionController then
+			self:StartMotionController()
+			self.hasMotionController = true
+		end
+	else
+		self.customPhysicsMode = nil
+		self.customForceMode = nil
+		self.customForceLinear = nil
+		self.customForceAngular = nil
+		self.customShadowForce = nil
+		if self.hasMotionController then
+			self:StopMotionController()
+			self.hasMotionController = false
+		end
+	end
+end
+
 function ENT:PhysicsSimulate(physObj, dt)
-	if self.customForceMode then
+	local mode = self.customPhysicsMode
+	if mode == 1 then
 		return self.customForceAngular, self.customForceLinear, self.customForceMode
-	elseif self.customShadowForce then
+	elseif mode == 2 then
 		self.customShadowForce.deltatime = dt
 		physObj:ComputeShadowControl(self.customShadowForce)
 		return SIM_NOTHING

--- a/lua/entities/starfall_prop/init.lua
+++ b/lua/entities/starfall_prop/init.lua
@@ -15,6 +15,14 @@ function ENT:Initialize()
 	self:AddEFlags( EFL_FORCE_CHECK_TRANSMIT )
 end
 
+function ENT:PhysicsSimulate()
+	if self.customForceMode then
+		return ent.customForceAngular, ent.customForceLinear, self.customForceMode
+	else
+		return SIM_NOTHING
+	end
+end
+
 function ENT:UpdateTransmitState()
 	return TRANSMIT_ALWAYS
 end

--- a/lua/entities/starfall_prop/init.lua
+++ b/lua/entities/starfall_prop/init.lua
@@ -15,9 +15,14 @@ function ENT:Initialize()
 	self:AddEFlags( EFL_FORCE_CHECK_TRANSMIT )
 end
 
-function ENT:PhysicsSimulate()
+function ENT:PhysicsSimulate(physObj, dt)
 	if self.customForceMode then
-		return ent.customForceAngular, ent.customForceLinear, self.customForceMode
+		return self.customForceAngular, self.customForceLinear, self.customForceMode
+	elseif self.customShadowForce then
+		physObj:Wake()
+		self.customShadowForce.deltatime = dt
+		physObj:ComputeShadowControl(self.customShadowForce)
+		return SIM_NOTHING
 	else
 		return SIM_NOTHING
 	end

--- a/lua/entities/starfall_prop/init.lua
+++ b/lua/entities/starfall_prop/init.lua
@@ -19,7 +19,6 @@ function ENT:PhysicsSimulate(physObj, dt)
 	if self.customForceMode then
 		return self.customForceAngular, self.customForceLinear, self.customForceMode
 	elseif self.customShadowForce then
-		physObj:Wake()
 		self.customShadowForce.deltatime = dt
 		physObj:ComputeShadowControl(self.customShadowForce)
 		return SIM_NOTHING

--- a/lua/starfall/libs_sh/enum.lua
+++ b/lua/starfall/libs_sh/enum.lua
@@ -487,6 +487,22 @@ env.MOVETYPE = {
 	CUSTOM = MOVETYPE_CUSTOM,
 }
 
+--- ENUMs used by Entity.setCustomPropForces (Entity.PhysicsSimulate internally)
+-- @name builtins_library.SIM
+-- @class table
+-- @field NOTHING
+-- @field LOCAL_ACCELERATION
+-- @field LOCAL_FORCE
+-- @field GLOBAL_ACCELERATION
+-- @field GLOBAL_FORCE
+env.SIM = {
+	NOTHING = SIM_NOTHING,
+	LOCAL_ACCELERATION = SIM_LOCAL_ACCELERATION,
+	LOCAL_FORCE = SIM_LOCAL_FORCE,
+	GLOBAL_ACCELERATION = SIM_GLOBAL_ACCELERATION,
+	GLOBAL_FORCE = SIM_GLOBAL_FORCE,
+}
+
 --- ENUMs of in_keys for use with player:keyDown
 -- @name builtins_library.IN_KEY
 -- @class table

--- a/lua/starfall/libs_sv/entities.lua
+++ b/lua/starfall/libs_sv/entities.lua
@@ -147,16 +147,13 @@ function ents_methods:setCustomPropForces(ang, lin, mode)
 
 	checkpermission(instance, ent, "entities.applyForce")
 
-	checkluatype(mode, TYPE_NUMBER)
-	if mode ~= 0 and mode ~= 1 and mode ~= 2 and mode ~= 3 and mode ~= 4 then SF.Throw("Invalid mode", 2) end
-
 	if mode == 0 then
 		ent.customForceMode = nil
 		if self.hasMotionController then
 			ent:StopMotionController()
 			ent.hasMotionController = false
 		end
-	else
+	elseif mode == 1 or mode == 2 or mode == 3 then
 		ang = vunwrap(ang)
 		checkvector(ang)
 		lin = vunwrap(lin)
@@ -170,6 +167,8 @@ function ents_methods:setCustomPropForces(ang, lin, mode)
 			ent:StartMotionController()
 			ent.hasMotionController = true
 		end
+	else
+		SF.Throw("Invalid mode, see the SIM enum", 2)
 	end
 end
 

--- a/lua/starfall/libs_sv/entities.lua
+++ b/lua/starfall/libs_sv/entities.lua
@@ -173,6 +173,54 @@ function ents_methods:setCustomPropForces(ang, lin, mode)
 	end
 end
 
+--- Sets a custom prop's shadow forces, moving the entity to the desired position and angles
+-- @param data table Shadow physics data, excluding 'teleportdistance' and 'deltatime'. See: https://wiki.facepunch.com/gmod/PhysObj:ComputeShadowControl
+function ents_methods:setCustomPropShadowForce(data)
+	local ent = getent(self)
+	if ent:GetClass()~="starfall_prop" then SF.Throw("The entity isn't a custom prop", 2) end
+
+	checkpermission(instance, ent, "entities.applyForce")
+
+	if not data then
+		ent.shadowForce = nil
+		if ent.hasMotionController then
+			ent:StopMotionController()
+			ent.hasMotionController = false
+		end
+	else
+		local pos = vunwrap(data.pos)
+		checkvector(pos)
+		local ang = aunwrap(data.angle)
+		checkvector(ang)
+
+		checkluatype(data.secondstoarrive, TYPE_NUMBER)
+		if data.secondstoarrive < 1e-3 then SF.Throw("Shadow force property 'secondstoarrive' cannot be lower than 0.001") end
+		checkluatype(data.dampfactor, TYPE_NUMBER)
+		if data.dampfactor > 1 or data.dampfactor < 0 then SF.Throw("Shadow force property 'dampfactor' cannot be higher than 2 or lower than -1") end
+		checkluatype(data.maxangular, TYPE_NUMBER)
+		checkluatype(data.maxangulardamp, TYPE_NUMBER)
+		checkluatype(data.maxspeed, TYPE_NUMBER)
+		checkluatype(data.maxspeeddamp, TYPE_NUMBER)
+
+		ent.customShadowForce = {
+			pos = pos,
+			angle = ang,
+			secondstoarrive = data.secondstoarrive,
+			dampfactor = data.dampfactor,
+			maxangular = data.maxangular,
+			maxangulardamp = data.maxangulardamp,
+			maxspeed = data.maxspeed,
+			maxspeeddamp = data.maxspeeddamp,
+			teleportdistance = 0,
+		}
+
+		if not ent.hasMotionController then
+			ent:StartMotionController()
+			ent.hasMotionController = true
+		end
+	end
+end
+
 --- Set the angular velocity of an object
 -- @param Vector angvel The local angvel vector to set
 function ents_methods:setAngleVelocity(angvel)

--- a/lua/starfall/libs_sv/entities.lua
+++ b/lua/starfall/libs_sv/entities.lua
@@ -138,6 +138,7 @@ function ents_methods:applyDamage(amt, attacker, inflictor, dmgtype, pos)
 end
 
 --- Sets a custom prop's physics simulation forces. Thrusters and balloons use this.
+-- This takes precedence over Entity.setCustomPropShadowForce and cannot be used together
 -- @param Vector ang Angular Force (Torque)
 -- @param Vector lin Linear Force
 -- @param number mode The physics mode to use. 0 = Off, 1 = Local acceleration, 2 = Local force, 3 = Global Acceleration, 4 = Global force
@@ -173,6 +174,7 @@ function ents_methods:setCustomPropForces(ang, lin, mode)
 end
 
 --- Sets a custom prop's shadow forces, moving the entity to the desired position and angles
+-- This gets overriden by Entity.setCustomPropForces and cannot be used together
 -- @param data table Shadow physics data, excluding 'teleportdistance' and 'deltatime'. See: https://wiki.facepunch.com/gmod/PhysObj:ComputeShadowControl
 function ents_methods:setCustomPropShadowForce(data)
 	local ent = getent(self)

--- a/lua/starfall/libs_sv/entities.lua
+++ b/lua/starfall/libs_sv/entities.lua
@@ -196,7 +196,7 @@ function ents_methods:setCustomPropShadowForce(data)
 		checkluatype(data.secondstoarrive, TYPE_NUMBER)
 		if data.secondstoarrive < 1e-3 then SF.Throw("Shadow force property 'secondstoarrive' cannot be lower than 0.001") end
 		checkluatype(data.dampfactor, TYPE_NUMBER)
-		if data.dampfactor > 1 or data.dampfactor < 0 then SF.Throw("Shadow force property 'dampfactor' cannot be higher than 2 or lower than -1") end
+		if data.dampfactor > 1 or data.dampfactor < 0 then SF.Throw("Shadow force property 'dampfactor' cannot be higher than 1 or lower than 0") end
 		checkluatype(data.maxangular, TYPE_NUMBER)
 		checkluatype(data.maxangulardamp, TYPE_NUMBER)
 		checkluatype(data.maxspeed, TYPE_NUMBER)

--- a/lua/starfall/libs_sv/entities.lua
+++ b/lua/starfall/libs_sv/entities.lua
@@ -147,18 +147,30 @@ function ents_methods:setCustomPropForces(ang, lin, mode)
 
 	checkpermission(instance, ent, "entities.applyForce")
 
-	ang = vunwrap(ang)
-	checkvector(ang)
-	lin = vunwrap(lin)
-	checkvector(lin)
-
 	checkluatype(mode, TYPE_NUMBER)
 	if mode ~= 0 and mode ~= 1 and mode ~= 2 and mode ~= 3 and mode ~= 4 then SF.Throw("Invalid mode", 2) end
 
-	function ent:PhysicsSimulate()
-		return ang, lin, mode
+	if mode == 0 then
+		ent.customForceMode = nil
+		if self.hasMotionController then
+			ent:StopMotionController()
+			ent.hasMotionController = false
+		end
+	else
+		ang = vunwrap(ang)
+		checkvector(ang)
+		lin = vunwrap(lin)
+		checkvector(lin)
+
+		ent.customForceMode = mode
+		ent.customForceLinear = lin
+		ent.customForceAngular = ang
+
+		if not ent.hasMotionController then
+			ent:StartMotionController()
+			ent.hasMotionController = true
+		end
 	end
-	ent:StartMotionController()
 end
 
 --- Set the angular velocity of an object

--- a/lua/starfall/libs_sv/entities.lua
+++ b/lua/starfall/libs_sv/entities.lua
@@ -150,11 +150,7 @@ function ents_methods:setCustomPropForces(ang, lin, mode)
 	checkpermission(instance, ent, "entities.applyForce")
 
 	if mode == 0 then
-		ent.customForceMode = nil
-		if self.hasMotionController then
-			ent:StopMotionController()
-			ent.hasMotionController = false
-		end
+		ent:EnableCustomPhysics(false)
 	elseif mode == 1 or mode == 2 or mode == 3 then
 		ang = vunwrap(ang)
 		checkvector(ang)
@@ -164,11 +160,7 @@ function ents_methods:setCustomPropForces(ang, lin, mode)
 		ent.customForceMode = mode
 		ent.customForceLinear = lin
 		ent.customForceAngular = ang
-
-		if not ent.hasMotionController then
-			ent:StartMotionController()
-			ent.hasMotionController = true
-		end
+		ent:EnableCustomPhysics(1)
 	else
 		SF.Throw("Invalid mode, see the SIM enum", 2)
 	end
@@ -185,11 +177,7 @@ function ents_methods:setCustomPropShadowForce(data)
 	checkpermission(instance, ent, "entities.applyForce")
 
 	if not data then
-		ent.shadowForce = nil
-		if ent.hasMotionController then
-			ent:StopMotionController()
-			ent.hasMotionController = false
-		end
+		ent:EnableCustomPhysics(false)
 	else
 		local pos = vunwrap(data.pos)
 		checkvector(pos)
@@ -221,11 +209,7 @@ function ents_methods:setCustomPropShadowForce(data)
 			maxspeeddamp = data.maxspeeddamp,
 			teleportdistance = data.teleportdistance,
 		}
-
-		if not ent.hasMotionController then
-			ent:StartMotionController()
-			ent.hasMotionController = true
-		end
+		ent:EnableCustomPhysics(2)
 	end
 end
 

--- a/lua/starfall/libs_sv/entities.lua
+++ b/lua/starfall/libs_sv/entities.lua
@@ -151,7 +151,7 @@ function ents_methods:setCustomPropForces(ang, lin, mode)
 
 	if mode == 0 then
 		ent:EnableCustomPhysics(false)
-	elseif mode == 1 or mode == 2 or mode == 3 then
+	elseif mode == 1 or mode == 2 or mode == 3 or mode == 4 then
 		ang = vunwrap(ang)
 		checkvector(ang)
 		lin = vunwrap(lin)


### PR DESCRIPTION
## Changes:
- Move `ENT.PhysicsSimulate` function to `starfall_prop/init.lua`
- Rework the `Entity.setCustomPropForces` to work with the new static `ENT.PhysicsSimulate`
- Add the ability to disable motion controller *(stops calling the `ENT.PhysicsSimulate`)* by providing `0` as the `mode` argument to `Entity.setCustomPropForces`.
- Update documentation to state that `Entity.setCustomPropForces` cannot be used together with `Entity.setCustomPropShadowForce`

## Additions:
- Add `Entity.setCustomPropShadowForce` as a way to use [`PhysObj.ComputeShadowControl`](https://wiki.facepunch.com/gmod/PhysObj:ComputeShadowControl) inside the `ENT.PhysicsSimulate`
- Handle `deltatime` automatically inside the `ENT.PhysicsSimulate`
- Allow setting `teleportdistance` higher than `0`, only if the player has `entities.setPos` permission
- Limit the values that can crash the game: `dampfactor` to `[0..1]`, `secondstoarrive` to `[..0.001]` and perform `checkvector` on the angle *(no crash, but entity immediately disappears, better safe than sorry)*
- Add [`SIM`](https://wiki.facepunch.com/gmod/Enums/SIM) enum