### PR TITLE
Add StarfallError hook and rework processor error reporting

### DIFF
--- a/lua/entities/starfall_processor/cl_init.lua
+++ b/lua/entities/starfall_processor/cl_init.lua
@@ -131,6 +131,7 @@ else
 end
 
 hook.Add("StarfallError", "StarfallErrorReport", function(_, owner, client, main_file, message, traceback, should_notify)
+	if not (owner and owner:IsValid()) then return end
 	local local_player = LocalPlayer()
 	if owner == local_player then
 		if not client or client == owner then

--- a/lua/entities/starfall_processor/cl_init.lua
+++ b/lua/entities/starfall_processor/cl_init.lua
@@ -130,6 +130,28 @@ else
 	end
 end
 
+hook.Add("StarfallError", "StarfallErrorReport", function(_, owner, client, main_file, message, traceback, should_notify)
+	local local_player = LocalPlayer()
+	if owner == local_player then
+		if not client or client == owner then
+			SF.AddNotify(owner, message, "ERROR", 7, "ERROR1")
+		elseif client then
+			if should_notify then
+				SF.AddNotify(owner, string.format("Starfall '%s' errored for player %s", main_file, client:Nick()), "ERROR", 7, "SILENT")
+				print(message)
+			else
+				print(string.format("Starfall '%s' errored for player %s: %s", main_file, client:Nick(), message))
+			end
+		end
+
+		if #traceback > 0 then
+			print(traceback)
+		end
+	elseif client == local_player then
+		print(string.format("Starfall '%s' owned by %s has errored: %s", main_file, owner:Nick(), message))
+	end
+end)
+
 net.Receive("starfall_processor_download", function(len)
 	net.ReadStarfall(nil, function(ok, sfdata)
 		if ok then

--- a/lua/entities/starfall_processor/init.lua
+++ b/lua/entities/starfall_processor/init.lua
@@ -219,7 +219,8 @@ util.AddNetworkString("starfall_processor_used")
 util.AddNetworkString("starfall_processor_link")
 util.AddNetworkString("starfall_processor_kill")
 util.AddNetworkString("starfall_processor_clinit")
-util.AddNetworkString("starfall_report_error")
+util.AddNetworkString("starfall_processor_error")
+-- util.AddNetworkString("starfall_report_error")
 
 -- Request code from the chip. If the chip doesn't have code yet add player to list to send when there is code.
 net.Receive("starfall_processor_download", function(len, ply)
@@ -257,14 +258,14 @@ net.Receive("starfall_processor_clinit", function(len, ply)
 	end
 end)
 
-net.Receive("starfall_report_error", function(len, ply)
-	local chip = net.ReadEntity()
-	if chip:IsValid() and IsValid(chip.owner) and chip.ErroredPlayers and not chip.ErroredPlayers[ply] and chip.owner ~= ply then
-		chip.ErroredPlayers[ply] = true
-		SF.AddNotify(chip.owner, "Starfall: ("..chip.sfdata.mainfile..") errored for player: ("..ply:Nick()..")", "ERROR", 7, "SILENT")
-		SF.Print(chip.owner, string.sub(net.ReadString(), 1, 2048))
-	end
-end)
+-- net.Receive("starfall_report_error", function(len, ply)
+-- 	local chip = net.ReadEntity()
+-- 	if chip:IsValid() and IsValid(chip.owner) and chip.ErroredPlayers and not chip.ErroredPlayers[ply] and chip.owner ~= ply then
+-- 		chip.ErroredPlayers[ply] = true
+-- 		SF.AddNotify(chip.owner, "Starfall: ("..chip.sfdata.mainfile..") errored for player: ("..ply:Nick()..")", "ERROR", 7, "SILENT")
+-- 		SF.Print(chip.owner, string.sub(net.ReadString(), 1, 2048))
+-- 	end
+-- end)
 
 SF.WaitForPlayerInit(function(ply)
 	for k, v in ipairs(ents.FindByClass("starfall_processor")) do

--- a/lua/entities/starfall_processor/init.lua
+++ b/lua/entities/starfall_processor/init.lua
@@ -220,7 +220,6 @@ util.AddNetworkString("starfall_processor_link")
 util.AddNetworkString("starfall_processor_kill")
 util.AddNetworkString("starfall_processor_clinit")
 util.AddNetworkString("starfall_processor_error")
--- util.AddNetworkString("starfall_report_error")
 
 -- Request code from the chip. If the chip doesn't have code yet add player to list to send when there is code.
 net.Receive("starfall_processor_download", function(len, ply)
@@ -257,15 +256,6 @@ net.Receive("starfall_processor_clinit", function(len, ply)
 		end
 	end
 end)
-
--- net.Receive("starfall_report_error", function(len, ply)
--- 	local chip = net.ReadEntity()
--- 	if chip:IsValid() and IsValid(chip.owner) and chip.ErroredPlayers and not chip.ErroredPlayers[ply] and chip.owner ~= ply then
--- 		chip.ErroredPlayers[ply] = true
--- 		SF.AddNotify(chip.owner, "Starfall: ("..chip.sfdata.mainfile..") errored for player: ("..ply:Nick()..")", "ERROR", 7, "SILENT")
--- 		SF.Print(chip.owner, string.sub(net.ReadString(), 1, 2048))
--- 	end
--- end)
 
 SF.WaitForPlayerInit(function(ply)
 	for k, v in ipairs(ents.FindByClass("starfall_processor")) do

--- a/lua/entities/starfall_processor/init.lua
+++ b/lua/entities/starfall_processor/init.lua
@@ -219,7 +219,6 @@ util.AddNetworkString("starfall_processor_used")
 util.AddNetworkString("starfall_processor_link")
 util.AddNetworkString("starfall_processor_kill")
 util.AddNetworkString("starfall_processor_clinit")
-util.AddNetworkString("starfall_processor_error")
 
 -- Request code from the chip. If the chip doesn't have code yet add player to list to send when there is code.
 net.Receive("starfall_processor_download", function(len, ply)

--- a/lua/entities/starfall_processor/shared.lua
+++ b/lua/entities/starfall_processor/shared.lua
@@ -202,6 +202,7 @@ else
 			elseif client then
 				if should_notify then
 					SF.AddNotify(owner, string.format("Starfall '%s' errored for player %s", main_file, client:Nick()), "ERROR", 7, "SILENT")
+					print(message)
 				else
 					print(string.format("Starfall '%s' errored for player %s: %s", main_file, client:Nick(), message))
 				end

--- a/lua/entities/starfall_processor/shared.lua
+++ b/lua/entities/starfall_processor/shared.lua
@@ -121,30 +121,6 @@ function ENT:GetGateName()
 	return self.name
 end
 
-if CLIENT then
-	hook.Add("StarfallError", "StarfallErrorReport", function(_, owner, client, main_file, message, traceback, should_notify)
-		local local_player = LocalPlayer()
-		if owner == local_player then
-			if not client or client == owner then
-				SF.AddNotify(owner, message, "ERROR", 7, "ERROR1")
-			elseif client then
-				if should_notify then
-					SF.AddNotify(owner, string.format("Starfall '%s' errored for player %s", main_file, client:Nick()), "ERROR", 7, "SILENT")
-					print(message)
-				else
-					print(string.format("Starfall '%s' errored for player %s: %s", main_file, client:Nick(), message))
-				end
-			end
-
-			if #traceback > 0 then
-				print(traceback)
-			end
-		elseif client == local_player then
-			print(string.format("Starfall '%s' owned by %s has errored: %s", main_file, owner:Nick(), message))
-		end
-	end)
-end
-
 function ENT:Error(err)
 	self.error = err
 

--- a/lua/entities/starfall_processor/shared.lua
+++ b/lua/entities/starfall_processor/shared.lua
@@ -195,8 +195,9 @@ else
 		end
 	end)
 
-	hook.Add("StarfallError", "StarfallErrorNotify", function(chip, owner, client, main_file, message, traceback, should_notify)
-		if owner == LocalPlayer() then
+	hook.Add("StarfallError", "StarfallErrorReport", function(chip, owner, client, main_file, message, traceback, should_notify)
+		local local_player = LocalPlayer()
+		if owner == local_player then
 			if not client or client == owner then
 				SF.AddNotify(owner, message, "ERROR", 7, "ERROR1")
 			elseif client then
@@ -211,7 +212,7 @@ else
 			if #traceback > 0 then
 				print(traceback)
 			end
-		elseif client == LocalPlayer() then
+		elseif client == local_player then
 			print(string.format("Starfall '%s' owned by %s has errored: %s", main_file, owner:Nick(), message))
 		end
 	end)

--- a/lua/entities/starfall_processor/shared.lua
+++ b/lua/entities/starfall_processor/shared.lua
@@ -195,7 +195,7 @@ else
 		end
 	end)
 
-	hook.Add("StarfallError", "StarfallErrorReport", function(chip, owner, client, main_file, message, traceback, should_notify)
+	hook.Add("StarfallError", "StarfallErrorReport", function(_, owner, client, main_file, message, traceback, should_notify)
 		local local_player = LocalPlayer()
 		if owner == local_player then
 			if not client or client == owner then

--- a/lua/entities/starfall_processor/shared.lua
+++ b/lua/entities/starfall_processor/shared.lua
@@ -127,7 +127,7 @@ if SERVER then
 		net.Start("starfall_processor_error")
 			net.WriteBool(false) -- is_clientside?
 			net.WriteEntity(chip)
-			net.WritePlayer(chip.owner)
+			net.WriteEntity(chip.owner)
 			net.WriteString(chip.sfdata.mainfile)
 			net.WriteString(message)
 			net.WriteString(traceback)
@@ -136,9 +136,9 @@ if SERVER then
 	local function relay_error(chip, message, traceback, client, should_notify)
 		net.Start("starfall_processor_error")
 			net.WriteBool(true) -- is_clientside?
-			net.WritePlayer(client)
+			net.WriteEntity(client)
 			net.WriteEntity(chip)
-			net.WritePlayer(chip.owner)
+			net.WriteEntity(chip.owner)
 			net.WriteString(chip.sfdata.mainfile)
 			net.WriteString(message)
 			net.WriteString(traceback)
@@ -178,10 +178,10 @@ else
 		net.SendToServer()
 	end
 	local function read_error()
-		local client = net.ReadBool() and net.ReadPlayer()
+		local client = net.ReadBool() and net.ReadEntity()
 		if not client or (client and client:IsValid()) then
 			local chip = net.ReadEntity()
-			local owner = net.ReadPlayer()
+			local owner = net.ReadEntity()
 			if chip:IsValid() and owner:IsValid() then
 				return chip, owner, client, net.ReadString(), net.ReadString(), net.ReadString(), net.ReadBool()
 			end

--- a/lua/starfall/sflib.lua
+++ b/lua/starfall/sflib.lua
@@ -1513,8 +1513,11 @@ else
 		if ply == LocalPlayer() then
 			print(msg)
 			GAMEMODE:AddNotify(msg, notificationsMap[type], duration)
-			if soundsMap[sound] and soundsMap[soundsMap[sound]] then
-				surface.PlaySound(soundsMap[soundsMap[sound]])
+			if soundsMap[sound] then
+				local path = soundsMap[soundsMap[sound]]
+				if path then
+					surface.PlaySound(path)
+				end
 			end
 		end
 	end
@@ -1524,7 +1527,10 @@ else
 		print(msg)
 		GAMEMODE:AddNotify(msg, type, duration)
 		if soundsMap[sound] then
-			surface.PlaySound(soundsMap[sound])
+			local path = soundsMap[soundsMap[sound]]
+			if path then
+				surface.PlaySound(path)
+			end
 		end
 	end)
 

--- a/lua/starfall/sflib.lua
+++ b/lua/starfall/sflib.lua
@@ -1513,7 +1513,7 @@ else
 		if ply == LocalPlayer() then
 			print(msg)
 			GAMEMODE:AddNotify(msg, notificationsMap[type], duration)
-			if soundsMap[sound] then
+			if soundsMap[sound] and soundsMap[soundsMap[sound]] then
 				surface.PlaySound(soundsMap[soundsMap[sound]])
 			end
 		end

--- a/lua/starfall/sflib.lua
+++ b/lua/starfall/sflib.lua
@@ -1488,7 +1488,7 @@ if SERVER then
 		if not (ply and ply:IsValid()) then return end
 
 		net.Start("starfall_addnotify")
-		net.WriteString(msg)
+		net.WriteString(string.sub(msg, 1, 1024))
 		net.WriteUInt(notificationsMap[notifyType], 8)
 		net.WriteFloat(duration)
 		net.WriteUInt(soundsMap[sound], 8)

--- a/lua/starfall/transfer.lua
+++ b/lua/starfall/transfer.lua
@@ -110,6 +110,7 @@ if SERVER then
 	function SF.SendError(chip, message, traceback, client, should_notify)
 		net.Start("starfall_error")
 			net.WriteEntity(chip)
+			net.WriteEntity(chip.owner)
 			net.WriteString(string.sub(chip.sfdata.mainfile, 1, 1024))
 			net.WriteString(string.sub(message, 1, 1024))
 			net.WriteString(string.sub(traceback, 1, 1024))
@@ -207,7 +208,7 @@ else
 	net.Receive("starfall_error", function()
 		local chip = net.ReadEntity()
 		if not chip:IsValid() then return end
-		local owner = chip.owner
+		local owner = net.ReadEntity()
 		if not owner:IsValid() then return end
 		local mainfile = net.ReadString()
 		local message = net.ReadString()

--- a/lua/starfall/transfer.lua
+++ b/lua/starfall/transfer.lua
@@ -80,6 +80,7 @@ end
 if SERVER then
 	util.AddNetworkString("starfall_upload")
 	util.AddNetworkString("starfall_upload_push")
+	util.AddNetworkString("starfall_error")
 
 	function SF.SendStarfall(msg, sfdata, recipient, callback)
 		net.Start(msg)
@@ -105,6 +106,35 @@ if SERVER then
 		}
 		return true
 	end
+
+	function SF.SendError(chip, message, traceback, client, should_notify)
+		net.Start("starfall_error")
+			net.WriteEntity(chip)
+			net.WriteEntity(chip.owner)
+			net.WriteString(string.sub(chip.sfdata.mainfile, 1, 1024)
+			net.WriteString(string.sub(message, 1, 1024)
+			net.WriteString(string.sub(traceback, 1, 1024)
+		if client~=nil and should_notify~=nil then
+			net.WriteBool(true)
+			net.WriteEntity(client)
+			net.WriteBool(should_notify)
+			net.SendOmit(client)
+		else
+			net.WriteBool(false)
+			net.Broadcast()
+		end
+	end
+
+	net.Receive("starfall_error", function(_, ply)
+		local chip = net.ReadEntity()
+		if not (chip and chip:IsValid()) then return end
+		if chip.ErroredPlayers[ply] then return end
+		chip.ErroredPlayers[ply] = true
+
+		local message, traceback, should_notify = net.ReadString(), net.ReadString(), net.ReadBool()
+		hook.Run("StarfallError", chip, chip.owner, ply, chip.sfdata.mainfile, message, traceback, should_notify)
+		SF.SendError(chip, message, traceback, ply, should_notify)
+	end)
 
 	net.Receive("starfall_upload", function(len, ply)
 		local updata = uploaddata[ply]
@@ -160,6 +190,36 @@ else
 			net.WriteStarfall(sfdata)
 		net.SendToServer()
 	end
+
+	
+	function SF.SendError(chip, message, traceback)
+		local owner, is_blocked = chip.owner, false
+		if owner and owner:IsValid() then
+			is_blocked = SF.BlockedUsers:isBlocked(owner:SteamID())
+		end
+		net.Start("starfall_error")
+			net.WriteEntity(chip)
+			net.WriteString(string.sub(message, 1, 1024))
+			net.WriteString(string.sub(traceback, 1, 1024))
+			net.WriteBool(GetConVarNumber("sf_timebuffer_cl") > 0 and not is_blocked)
+		net.SendToServer()
+	end
+
+	net.Receive("starfall_error", function()
+		local chip = net.ReadEntity()
+		local owner = net.ReadEntity()
+		if not chip:IsValid() or not owner:IsValid() then return end
+		local mainfile = net.ReadString()
+		local message = net.ReadString()
+		local traceback = net.ReadString()
+		local client, should_notify
+		if net.ReadBool() then
+			client = net.ReadEntity()
+			if not client:IsValid() then return end
+			should_notify = new.ReadBool()
+		end
+		hook.Run("StarfallError", chip, owner, client, main_file, message, traceback, should_notify)
+	end)
 
 	net.Receive("starfall_upload", function()
 		local mainfile = net.ReadString()

--- a/lua/starfall/transfer.lua
+++ b/lua/starfall/transfer.lua
@@ -110,7 +110,6 @@ if SERVER then
 	function SF.SendError(chip, message, traceback, client, should_notify)
 		net.Start("starfall_error")
 			net.WriteEntity(chip)
-			net.WriteEntity(chip.owner)
 			net.WriteString(string.sub(chip.sfdata.mainfile, 1, 1024)
 			net.WriteString(string.sub(message, 1, 1024)
 			net.WriteString(string.sub(traceback, 1, 1024)
@@ -207,8 +206,9 @@ else
 
 	net.Receive("starfall_error", function()
 		local chip = net.ReadEntity()
-		local owner = net.ReadEntity()
-		if not chip:IsValid() or not owner:IsValid() then return end
+		if not chip:IsValid() then return end
+		local owner = chip.owner
+		if not owner:IsValid() then return end
 		local mainfile = net.ReadString()
 		local message = net.ReadString()
 		local traceback = net.ReadString()

--- a/lua/starfall/transfer.lua
+++ b/lua/starfall/transfer.lua
@@ -216,7 +216,7 @@ else
 		if net.ReadBool() then
 			client = net.ReadEntity()
 			if not client:IsValid() then return end
-			should_notify = new.ReadBool()
+			should_notify = net.ReadBool()
 		end
 		hook.Run("StarfallError", chip, owner, client, mainfile, message, traceback, should_notify)
 	end)

--- a/lua/starfall/transfer.lua
+++ b/lua/starfall/transfer.lua
@@ -110,9 +110,9 @@ if SERVER then
 	function SF.SendError(chip, message, traceback, client, should_notify)
 		net.Start("starfall_error")
 			net.WriteEntity(chip)
-			net.WriteString(string.sub(chip.sfdata.mainfile, 1, 1024)
-			net.WriteString(string.sub(message, 1, 1024)
-			net.WriteString(string.sub(traceback, 1, 1024)
+			net.WriteString(string.sub(chip.sfdata.mainfile, 1, 1024))
+			net.WriteString(string.sub(message, 1, 1024))
+			net.WriteString(string.sub(traceback, 1, 1024))
 		if client~=nil and should_notify~=nil then
 			net.WriteBool(true)
 			net.WriteEntity(client)

--- a/lua/starfall/transfer.lua
+++ b/lua/starfall/transfer.lua
@@ -218,7 +218,7 @@ else
 			if not client:IsValid() then return end
 			should_notify = new.ReadBool()
 		end
-		hook.Run("StarfallError", chip, owner, client, main_file, message, traceback, should_notify)
+		hook.Run("StarfallError", chip, owner, client, mainfile, message, traceback, should_notify)
 	end)
 
 	net.Receive("starfall_upload", function()


### PR DESCRIPTION
Continuing the discussion from https://github.com/thegrb93/StarfallEx/pull/1582#discussion_r1435730248: How about this?

The hook runs on both realms and is relayed to ALL PLAYERS. This is something you didn't want, but I thought it could be useful in the future or maybe for other addons. I can change it if you <ins>really really</ins> want tho :(

Parameters in the global `StarfallError` hook are:
- Chip
- Owner of the chip
- Client it errored for or `nil` if the error originated on the serverside
- Path of the main script
- Error message
- Traceback
- Whether it should notify the owner. Note that this argument only exists if the error originated from other client and is undefined otherwise. This is used to determine whether the owner should receive a pop-up notificaiton.

Regarding the notifications, in addition to checking if `sf_timebuffer_cl` is greater than `0`, now it also checks whether the user has blocked your Starfalls. It's super annoying to constantly receive these notifications from people you might've allegedly minged in the past :)

I need clarification on 2 things though:
- Right now if somebody else's chip errors on your clientside, you only get `Starfall 'main' owned by Name has errored: SF:main:6: some error message` logged to the console, but no traceback unlike [previously](https://github.com/thegrb93/StarfallEx/blob/a278b41995a97f53feae931f22f8a737764c21f2/lua/entities/starfall_processor/shared.lua#L154C3-L154C3). Is that OK? Keep in mind that owner of the chip will still get the full traceback printed for that client so they can debug the script.
- [What's this limit and is it still needed?](https://github.com/thegrb93/StarfallEx/blob/a278b41995a97f53feae931f22f8a737764c21f2/lua/entities/starfall_processor/init.lua#L265)