### PR TITLE
Add `render.setBlend` to modify alpha blending for model draw calls

### DIFF
--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -481,6 +481,7 @@ function instance:cleanupRender()
 	render.SetLightingMode(0)
 	render.ResetModelLighting(1, 1, 1)
 	render.DepthRange(0, 1)
+	render.SetBlend(1)
 	render.SuppressEngineLighting(false)
 	render.SetWriteDepthToDestAlpha(true)
 	render.SetViewPort(0, 0, renderdata.oldW, renderdata.oldH)
@@ -1772,6 +1773,13 @@ function render_library.overrideBlend(on, srcBlend, destBlend, blendFunc, srcBle
 	else
 		render.OverrideBlend(on, srcBlend, destBlend, blendFunc, srcBlendAlpha, destBlendAlpha, blendFuncAlpha)
 	end
+end
+
+--- Changes alpha blending for the upcoming model drawing operations
+-- @param alpha number Blending in the range 0 to 1
+function render_library.setBlend(alpha)
+	if not renderdata.isRendering then SF.Throw("Not in a rendering hook.", 2) end
+	render.SetBlend(alpha)
 end
 
 --- Resets the depth buffer


### PR DESCRIPTION
No need to reset it back to the previous value, everybody just sets this back to `1` anyway.
Type checking is done by GMod, values outside of the `0-1` range don't seem to break anything.

Can do some pretty cool stuff with this:
![image](https://github.com/thegrb93/StarfallEx/assets/7283019/071116cb-9a42-4e84-965f-662350856532)
