### PR TITLE
Use `FindMetaTable` instead of the deprecated `debug.getregistry`

### DIFF
--- a/lua/starfall/libs_sh/angles.lua
+++ b/lua/starfall/libs_sh/angles.lua
@@ -10,7 +10,7 @@ local dgetmeta = debug.getmetatable
 -- @field r The -180 to 180 roll value of the euler angle. Can also be indexed with [3]
 -- @libtbl ang_methods
 -- @libtbl ang_meta
-SF.RegisterType("Angle", nil, nil, debug.getregistry().Angle, nil, function(checktype, ang_meta)
+SF.RegisterType("Angle", nil, nil, FindMetaTable("Angle"), nil, function(checktype, ang_meta)
 	return function(ang)
 		return setmetatable({ ang:Unpack() }, ang_meta)
 	end,

--- a/lua/starfall/libs_sh/color.lua
+++ b/lua/starfall/libs_sh/color.lua
@@ -42,7 +42,7 @@ local hex_to_rgb = {
 -- @field a The 0-255 alpha value of the color. Can also be indexed with [4]
 -- @libtbl color_methods
 -- @libtbl color_meta
-SF.RegisterType("Color", nil, nil, debug.getregistry().Color, nil, function(checktype, color_meta)
+SF.RegisterType("Color", nil, nil, FindMetaTable("Color"), nil, function(checktype, color_meta)
 	return function(clr)
 		return setmetatable({ clr.r, clr.g, clr.b, clr.a }, color_meta)
 	end,

--- a/lua/starfall/libs_sh/entities.lua
+++ b/lua/starfall/libs_sh/entities.lua
@@ -56,7 +56,7 @@ end
 -- @class type
 -- @libtbl ents_methods
 -- @libtbl ent_meta
-SF.RegisterType("Entity", false, true, debug.getregistry().Entity)
+SF.RegisterType("Entity", false, true, FindMetaTable("Entity"))
 
 
 return function(instance)
@@ -103,7 +103,7 @@ function ents_methods:getOwner()
 end
 
 if CLIENT then
-	instance.object_wrappers[debug.getregistry().NextBot] = ewrap
+	instance.object_wrappers[FindMetaTable("NextBot")] = ewrap
 		
 	--- Allows manipulation of an entity's bones' positions
 	-- @client

--- a/lua/starfall/libs_sh/npc.lua
+++ b/lua/starfall/libs_sh/npc.lua
@@ -14,7 +14,7 @@ end
 -- @class type
 -- @libtbl npc_methods
 -- @libtbl npc_meta
-SF.RegisterType("Npc", false, true, debug.getregistry().NPC, "Entity")
+SF.RegisterType("Npc", false, true, FindMetaTable("NPC"), "Entity")
 
 return function(instance)
 local checkpermission = instance.player ~= SF.Superuser and SF.Permissions.check or function() end

--- a/lua/starfall/libs_sh/players.lua
+++ b/lua/starfall/libs_sh/players.lua
@@ -78,7 +78,7 @@ end
 -- @name Player
 -- @class type
 -- @libtbl player_methods
-SF.RegisterType("Player", false, true, debug.getregistry().Player, "Entity")
+SF.RegisterType("Player", false, true, FindMetaTable("Player"), "Entity")
 
 
 return function(instance)

--- a/lua/starfall/libs_sh/surfaceinfo.lua
+++ b/lua/starfall/libs_sh/surfaceinfo.lua
@@ -6,7 +6,7 @@
 -- @libtbl surfaceinfo_methods
 -- @libtbl surfaceinfo_meta
 
-SF.RegisterType("SurfaceInfo",true,false,debug.getregistry().SurfaceInfo)
+SF.RegisterType("SurfaceInfo",true,false,FindMetaTable("SurfaceInfo"))
 
 return function(instance)
 

--- a/lua/starfall/libs_sh/vectors.lua
+++ b/lua/starfall/libs_sh/vectors.lua
@@ -11,7 +11,7 @@ local dgetmeta = debug.getmetatable
 -- @field z The z value of the vector. Can also be indexed with [3]
 -- @libtbl vec_methods
 -- @libtbl vec_meta
-SF.RegisterType("Vector", nil, nil, debug.getregistry().Vector, nil, function(checktype, vec_meta)
+SF.RegisterType("Vector", nil, nil, FindMetaTable("Vector"), nil, function(checktype, vec_meta)
 	return function(vec)
 		return setmetatable({ vec:Unpack() }, vec_meta)
 	end,

--- a/lua/starfall/libs_sh/vehicles.lua
+++ b/lua/starfall/libs_sh/vehicles.lua
@@ -16,7 +16,7 @@ end
 -- @class type
 -- @libtbl vehicle_methods
 -- @libtbl vehicle_meta
-SF.RegisterType("Vehicle", false, true, debug.getregistry().Vehicle, "Entity")
+SF.RegisterType("Vehicle", false, true, FindMetaTable("Vehicle"), "Entity")
 
 return function(instance)
 local checkpermission = instance.player ~= SF.Superuser and SF.Permissions.check or function() end

--- a/lua/starfall/libs_sh/vmatrix.lua
+++ b/lua/starfall/libs_sh/vmatrix.lua
@@ -8,7 +8,7 @@ local dgetmeta = debug.getmetatable
 -- @class type
 -- @libtbl vmatrix_methods
 -- @libtbl vmatrix_meta
-SF.RegisterType("VMatrix", true, false, debug.getregistry().VMatrix)
+SF.RegisterType("VMatrix", true, false, FindMetaTable("VMatrix"))
 
 
 return function(instance)

--- a/lua/starfall/libs_sh/weapons.lua
+++ b/lua/starfall/libs_sh/weapons.lua
@@ -7,7 +7,7 @@ local checkluatype = SF.CheckLuaType
 -- @class type
 -- @libtbl weapon_methods
 -- @libtbl weapon_meta
-SF.RegisterType("Weapon", false, true, debug.getregistry().Weapon, "Entity")
+SF.RegisterType("Weapon", false, true, FindMetaTable("Weapon"), "Entity")
 
 
 return function(instance)

--- a/lua/starfall/libs_sv/nextbot.lua
+++ b/lua/starfall/libs_sv/nextbot.lua
@@ -7,7 +7,7 @@ local checkluatype = SF.CheckLuaType
 -- @server
 -- @libtbl nb_methods
 -- @libtbl nb_meta
-SF.RegisterType("NextBot", false, true, debug.getregistry().NextBot, "Entity")
+SF.RegisterType("NextBot", false, true, FindMetaTable("NextBot"), "Entity")
 
 --- Library for spawning NextBots.
 -- @name nextbot


### PR DESCRIPTION
[`debug.getregistry()`](https://wiki.facepunch.com/gmod/debug.getregistry) got deprecated in the [latest patch](https://gmod.facepunch.com/changelist/3968), it will now return an empty table.  
Solution is to swap `debug.getregistry().Type` to `FindMetaTable("Type")`.