### PR TITLE
Add `input.setCursorPos` to control position of the mouse

### DIFF
--- a/lua/starfall/libs_sh/input.lua
+++ b/lua/starfall/libs_sh/input.lua
@@ -291,6 +291,24 @@ function input_library.getCursorPos()
 	return input.GetCursorPos()
 end
 
+--- Sets position of the mouse, relative to the top left corner of the game window, starting from 0, 0
+-- @client
+function input_library.setCursorPos(x, y)
+	checkpermission(instance, nil, "input.emulate")
+	checkluatype(x, TYPE_NUMBER)
+	checkluatype(y, TYPE_NUMBER)
+
+	if not SF.IsHUDActive(instance.entity) then
+		SF.Throw("No HUD component connected", 2)
+	elseif not vgui.CursorVisible() then
+		SF.Throw("Cursor must be visible in order to set its position", 2)
+	end
+
+	x = math.Clamp(x, 0, ScrW() - 1)
+	y = math.Clamp(y, 0, ScrH() - 1)
+	input.SetCursorPos(x, y)
+end
+
 --- Gets whether the cursor is visible on the screen
 -- @client
 -- @return boolean The cursor's visibility


### PR DESCRIPTION
Adds `input.setCursorPos(x, y)`, requires `input.emulate` permission and HUD connection.

Needs to be clamped, otherwise you can control it outside of the window until the game loses focus.

The `vgui.CursorVisible()` check is technically not needed, I couldn't get the cursor to change position anyway.
I left it in as a safety check however and to communicate to the user that it will not work. Can be removed if you want though *(as long as the behavior doesn't differ on Windows)*.