### PR TITLE
Use a better hook for detecting mouse movement

### DIFF
--- a/lua/starfall/libs_sh/input.lua
+++ b/lua/starfall/libs_sh/input.lua
@@ -123,9 +123,8 @@ SF.hookAdd("PlayerButtonUp", "inputreleased", CheckButtonPerms)
 -- @class hook
 -- @param number x X coordinate moved
 -- @param number y Y coordinate moved
-SF.hookAdd("StartCommand", "mousemoved", function(instance, ply, cmd)
+SF.hookAdd("InputMouseApply", "mousemoved", function(instance, _, x, y)
 	if haspermission(instance, nil, "input") then
-		local x, y = cmd:GetMouseX(), cmd:GetMouseY()
 		if x~=0 or y~=0 then
 			return true, { x, y }
 		end


### PR DESCRIPTION
Mouse delta in `StartCommand` hook is very inaccurate, on small movements it doesn't even run. Using `InputMouseApply` and the provided `x`, `y` parameters instead of grabbing it from the `CUserCmd` works way better.  
No need to keep the old hook since values are relatively the same. The new one may be called more often and with floats instead of just integers. They are also called under the same conditions when it comes to locked controls, visible cursor, etc. so it shouldn't break anything.

Small demo:
*Red - old hook*
*Green - new hook*


https://github.com/thegrb93/StarfallEx/assets/7283019/a9a9b8a1-8c82-4517-91fd-43e8d0eeaf8a

