### PR TITLE
Limit player model scale

### DIFF
--- a/lua/starfall/libs_sh/players.lua
+++ b/lua/starfall/libs_sh/players.lua
@@ -3,10 +3,13 @@ local checkluatype = SF.CheckLuaType
 local checkvalidnumber = SF.CheckValidNumber
 local registerprivilege = SF.Permissions.registerPrivilege
 
+local playerMaxScale
 if SERVER then
 	-- Register privileges
 	registerprivilege("player.dropweapon", "DropWeapon", "Drops a weapon from the player", { entities = {} })
 	registerprivilege("player.setammo", "SetAmmo", "Whether a player can set their ammo", { usergroups = { default = 1 }, entities = {} })
+
+	playerMaxScale = CreateConVar("sf_player_model_scale_max", "10", { FCVAR_ARCHIVE }, "Maximum player model scale the user is allowed to set using Player.setModelScale", 1, 100)
 else
 	registerprivilege("player.getFriendStatus", "FriendStatus", "Whether friend status can be retrieved", { client = { default = 1 } })
 end
@@ -504,7 +507,7 @@ if SERVER then
 		checkvalidnumber(scale)
 		local ply = getply(self)
 		checkpermission(instance, ply, "entities.setRenderProperty")
-		ply:SetModelScale(math.Clamp(math.Truncate(scale, 2), 0.01, 100))
+		ply:SetModelScale(math.Clamp(math.Truncate(scale, 2), 0.01, playerMaxScale:GetFloat()))
 	end
 
 	--- Sets the view entity of the player. Only works if they are linked to a hud.

--- a/lua/starfall/libs_sh/players.lua
+++ b/lua/starfall/libs_sh/players.lua
@@ -498,13 +498,13 @@ end
 
 if SERVER then
 	--- Lets you change the size of yourself if the server has sf_permissions_entity_owneraccess 1
-	-- @param number scale The scale to apply (min 0.001, max 100)
+	-- @param number scale The scale to apply, will be truncated to the first two decimal places (min 0.01, max 100)
 	-- @server
 	function player_methods:setModelScale(scale)
 		checkvalidnumber(scale)
 		local ply = getply(self)
 		checkpermission(instance, ply, "entities.setRenderProperty")
-		ply:SetModelScale(math.Clamp(scale, 0.001, 100))
+		ply:SetModelScale(math.Clamp(math.Truncate(scale, 2), 0.01, 100))
 	end
 
 	--- Sets the view entity of the player. Only works if they are linked to a hud.


### PR DESCRIPTION
Two decimal places is fine. New minimum scale is `0.01` and maximum is `10` by default, but can be set up to a `100` using the new `sf_player_model_scale_max` convar.