### PR TITLE
Reset `render.OverrideBlend` before disabling it

### DIFF
--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -474,6 +474,7 @@ end
 
 function instance:cleanupRender()
 	render.SetStencilEnable(false)
+	render.OverrideBlend(true, 0, 0, 0)
 	render.OverrideBlend(false)
 	render.OverrideDepthEnable(false, false)
 	render.SetScissorRect(0, 0, 0, 0, false)


### PR DESCRIPTION
`BLEND` parameters don't seem to matter, but `BLENDFUNC` needs to be reset to `0` *(BLENDFUNC_ADD)* for whatever reason.
Otherwise the `OverrideBlend` may not be correctly reset / disabled after certain draw operations.

Can't reproduce it with alpha arguments of this function, so not touching that.