### PR TITLE
Add render.pixelVisible and render.getPixelVisibleHandle

### DIFF
--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -2399,6 +2399,23 @@ function render_library.depthRange(min, max)
 	render.DepthRange(min, max)
 end
 
+--- Creates a new PixVis handle. See render.pixelVisible.
+-- @client
+-- @return pixelvis_handle_t PixVis
+function render_library.getPixelVisibleHandle()
+	return util.GetPixelVisibleHandle()
+end
+
+--- Returns the visibility of a sphere in the world.
+-- @client
+-- @param Vector position
+-- @param number radius
+-- @param pixelvis_handle_t PixVis. Use render.getPixelVisibleHandle()
+-- @return number Percentage visible, from 0-1
+function render_library.pixelVisible(position,radius,PixVis)
+	return util.PixelVisible(vunwrap(position),radius,PixVis)
+end
+
 end
 
 ---

--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -171,9 +171,9 @@ hook.Add("PreRender", "SF_PreRender_ResetRenderedViews", function()
 		local render = instance.data.render
 		render.renderedViews = 0
 
-		for k, v in ipairs(render.usedPixelVis) do
-			pixhandle_bank:free(instance.player, v)
-			render.usedPixelVis[k] = nil
+		for i=1,#render.usedPixelVis do
+			pixhandle_bank:free(instance.player, render.usedPixelVis[i])
+			render.usedPixelVis[i] = nil
 		end
 	end
 end)
@@ -461,6 +461,10 @@ instance:AddHook("deinitialize", function ()
 		rt_bank:free(instance.player, v)
 		renderdata.rendertargets[k] = nil
 		renderdata.validrendertargets[v:GetName()] = nil
+	end
+	for i=1,#renderdata.usedPixelVis do
+		pixhandle_bank:free(instance.player, renderdata.usedPixelVis[i])
+		renderdata.usedPixelVis[i] = nil
 	end
 end)
 
@@ -2427,6 +2431,7 @@ function render_library.pixelVisible(position, radius)
 	checkluatype(radius, TYPE_NUMBER)
 	
 	local PixVis = pixhandle_bank:use(instance.player, 1)
+	if not PixVis then SF.Throw("Can't call PixelVisible more than "..cv_max_pixelhandles:GetInt().." times per frame!", 2) end
 	usedPixelVis[#usedPixelVis + 1] = PixVis
 	return util.PixelVisible(position, radius, PixVis)
 end

--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -2413,6 +2413,9 @@ end
 -- @param pixelvis_handle_t PixVis. Use render.getPixelVisibleHandle()
 -- @return number Percentage visible, from 0-1
 function render_library.pixelVisible(position,radius,PixVis)
+	checkluatype(radius, TYPE_NUMBER)
+	checkluatype(PixVis, TYPE_PIXELVISHANDLE)
+	
 	return util.PixelVisible(vunwrap(position),radius,PixVis)
 end
 

--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -168,12 +168,12 @@ end )
 
 hook.Add("PreRender", "SF_PreRender_ResetRenderedViews", function()
 	for instance, _ in pairs(SF.allInstances) do
-		local render = instance.data.render
-		render.renderedViews = 0
+		local renderdata = instance.data.render
+		renderdata.renderedViews = 0
 
-		for i=1,#render.usedPixelVis do
-			pixhandle_bank:free(instance.player, render.usedPixelVis[i])
-			render.usedPixelVis[i] = nil
+		for k, v in ipairs(renderdata.usedPixelVis) do
+			pixhandle_bank:free(instance.player, v)
+			renderdata.usedPixelVis[k] = nil
 		end
 	end
 end)
@@ -437,6 +437,7 @@ local renderdata = {}
 renderdata.renderedViews = 0
 renderdata.rendertargets = {}
 renderdata.validrendertargets = {}
+renderdata.usedPixelVis = {}
 renderdata.oldW = ScrW()
 renderdata.oldH = ScrH()
 instance.data.render = renderdata
@@ -462,9 +463,9 @@ instance:AddHook("deinitialize", function ()
 		renderdata.rendertargets[k] = nil
 		renderdata.validrendertargets[v:GetName()] = nil
 	end
-	for i=1,#renderdata.usedPixelVis do
-		pixhandle_bank:free(instance.player, renderdata.usedPixelVis[i])
-		renderdata.usedPixelVis[i] = nil
+	for k, v in ipairs(renderdata.usedPixelVis) do
+		pixhandle_bank:free(instance.player, v)
+		renderdata.usedPixelVis[k] = nil
 	end
 end)
 
@@ -545,9 +546,6 @@ function instance:cleanupRender()
 		renderdata.prevClippingState = nil
 	end
 end
-
-local usedPixelVis = {}
-instance.data.render.usedPixelVis = usedPixelVis
 
 -- ------------------------------------------------------------------ --
 --- Call EyePos()
@@ -2432,7 +2430,7 @@ function render_library.pixelVisible(position, radius)
 	
 	local PixVis = pixhandle_bank:use(instance.player, 1)
 	if not PixVis then SF.Throw("Can't call PixelVisible more than "..cv_max_pixelhandles:GetInt().." times per frame!", 2) end
-	usedPixelVis[#usedPixelVis + 1] = PixVis
+	renderdata.usedPixelVis[#renderdata.usedPixelVis + 1] = PixVis
 	return util.PixelVisible(position, radius, PixVis)
 end
 

--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -22,7 +22,7 @@ registerprivilege("render.fog", "Render Fog", "Allows the user to control fog", 
 local cv_max_fonts = CreateConVar("sf_render_maxfonts", "30", { FCVAR_ARCHIVE })
 local cv_max_rendertargets = CreateConVar("sf_render_maxrendertargets", "20", { FCVAR_ARCHIVE })
 local cv_max_maxrenderviewsperframe = CreateConVar("sf_render_maxrenderviewsperframe", "2", { FCVAR_ARCHIVE })
-local cv_max_pixelhandles = CreateConVar("sf_render_maxrenderviewsperframe", "50", { FCVAR_ARCHIVE })
+local cv_max_pixelhandles = CreateConVar("sf_render_maxpixvishandlesperframe", "50", { FCVAR_ARCHIVE })
 
 
 hook.Add("PreRender", "SF_PreRender_ResetRenderedViews", function()


### PR DESCRIPTION
This adds two functions to the render library, render.pixelVisible and render.getPixelVisibleHandle. They are in essence little more than wrapped versions of util.PixelVisible and util.GetPixelVisibleHandle and behave the same way. Need to be used in render hooks to work correctly.