### PR TITLE
Implemented writeZ parameter on render.draw3DLine

### DIFF
--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -1894,7 +1894,6 @@ end
 -- @param Vector endPos Ending position
 -- @param boolean? writeZ Optional should the line be drawn with depth considered (default: true)
 function render_library.draw3DLine(startPos, endPos, writeZ)
-	if writeZ ~= nil then checkluatype(writeZ, TYPE_BOOL) end
 	if writeZ == nil then writeZ = true end
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	startPos = vunwrap(startPos)

--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -1894,7 +1894,8 @@ end
 -- @param Vector endPos Ending position
 -- @param boolean? writeZ Optional should the line be drawn with depth considered (default: true)
 function render_library.draw3DLine(startPos, endPos, writeZ)
-	if writeZ ~= nil then checkluatype(writeZ, TYPE_BOOL) else writeZ = true end
+	if writeZ ~= nil then checkluatype(writeZ, TYPE_BOOL) end
+	if writeZ == nil then writeZ = true end
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	startPos = vunwrap(startPos)
 	endPos = vunwrap(endPos)

--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -1924,8 +1924,9 @@ end
 -- @param Angle angle Orientation of the box
 -- @param Vector mins Start position of the box, relative to origin.
 -- @param Vector maxs End position of the box, relative to origin.
--- @param boolean? writeZ Optional should the line be drawn with depth considered (default: false)
+-- @param boolean? writeZ Optional should the box be drawn with depth considered (default: true)
 function render_library.draw3DWireframeBox(origin, angle, mins, maxs, writeZ)
+	if writeZ == nil then writeZ = true end
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	origin = vunwrap(origin)
 	mins = vunwrap(mins)

--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -1894,7 +1894,7 @@ end
 -- @param Vector endPos Ending position
 -- @param boolean? writeZ Optional should the line be drawn with depth considered
 function render_library.draw3DLine(startPos, endPos, writeZ)
-	if writeZ ~= nil then checkluatype(writeZ, TYPE_BOOL)
+	if writeZ ~= nil then checkluatype(writeZ, TYPE_BOOL) end
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	startPos = vunwrap(startPos)
 	endPos = vunwrap(endPos)

--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -1892,12 +1892,14 @@ end
 --- Draws a 3D Line
 -- @param Vector startPos Starting position
 -- @param Vector endPos Ending position
-function render_library.draw3DLine(startPos, endPos)
+-- @param boolean? writeZ Optional should the line be drawn with depth considered
+function render_library.draw3DLine(startPos, endPos, writeZ)
+	if writeZ ~= nil then checkluatype(writeZ, TYPE_BOOL)
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	startPos = vunwrap(startPos)
 	endPos = vunwrap(endPos)
 
-	render.DrawLine(startPos, endPos, currentcolor, true)
+	render.DrawLine(startPos, endPos, currentcolor, writeZ)
 end
 
 --- Draws a box in 3D space

--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -1892,7 +1892,7 @@ end
 --- Draws a 3D Line
 -- @param Vector startPos Starting position
 -- @param Vector endPos Ending position
--- @param boolean? writeZ Optional should the line be drawn with depth considered
+-- @param boolean? writeZ Optional should the line be drawn with depth considered (default: true)
 function render_library.draw3DLine(startPos, endPos, writeZ)
 	if writeZ ~= nil then checkluatype(writeZ, TYPE_BOOL) else writeZ = true end
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end

--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -1894,7 +1894,7 @@ end
 -- @param Vector endPos Ending position
 -- @param boolean? writeZ Optional should the line be drawn with depth considered
 function render_library.draw3DLine(startPos, endPos, writeZ)
-	if writeZ ~= nil then checkluatype(writeZ, TYPE_BOOL) end
+	if writeZ ~= nil then checkluatype(writeZ, TYPE_BOOL) else writeZ = true end
 	if not renderdata.isRendering then SF.Throw("Not in rendering hook.", 2) end
 	startPos = vunwrap(startPos)
 	endPos = vunwrap(endPos)


### PR DESCRIPTION
* Implemented an optional boolean argument for draw3DLine. Setting writeZ to false will allow rendered lines to ignore z-depth.
* Parameter is optional and defaults to original behavior of true.

![image](https://github.com/thegrb93/StarfallEx/assets/9381835/f18932c6-53ad-488c-a157-8620d87c69b5)
From left to right:
`render.draw3DLine(chip():getPos()+chip():getUp()*1, chip():getUp()*1000, false)`
`render.draw3DLine(chip():getPos()+chip():getUp()*1, chip():getUp()*1000, true)`
`render.draw3DLine(chip():getPos()+chip():getUp()*1, chip():getUp()*1000)`