### PR TITLE
Improve the bass library

### DIFF
--- a/lua/starfall/libs_cl/bass.lua
+++ b/lua/starfall/libs_cl/bass.lua
@@ -79,6 +79,7 @@ local function loadSound(path, flags, callback, loadFunc)
 					flags = flags
 				}
 
+				snd:Set3DFadeDistance(200, 200000) -- Default fade distance
 				instance:runFunction(callback, wrap(snd), 0, "")
 			end
 		end

--- a/lua/starfall/libs_cl/bass.lua
+++ b/lua/starfall/libs_cl/bass.lua
@@ -280,4 +280,35 @@ function bass_methods:is3D()
 	return getsnd(self):Is3D()
 end
 
+--- Returns the state of the sound channel.
+-- @return number The state enum of the sound channel. https://wiki.facepunch.com/gmod/Enums/GMOD_CHANNEL
+function bass_methods:getState()
+	return getsnd(self):GetState()
+end
+
+--- Returns whether or not the sound channel is stopped.
+-- Only true if the `noplay` flag is used and Bass:play() hasn't been called yet, since Bass:stop() will destroy the sound channel.
+-- @return boolean True if the sound channel is stopped.
+function bass_methods:isStopped()
+	return getsnd(self):GetState() == GMOD_CHANNEL_STOPPED
+end
+
+--- Returns whether or not the sound channel is playing.
+-- @return boolean True if the sound channel is playing.
+function bass_methods:isPlaying()
+	return getsnd(self):GetState() == GMOD_CHANNEL_PLAYING
+end
+
+--- Returns whether or not the sound channel is paused.
+-- @return boolean True if the sound channel is paused.
+function bass_methods:isPaused()
+	return getsnd(self):GetState() == GMOD_CHANNEL_PAUSED
+end
+
+--- Returns whether or not the sound channel is stalled.
+-- @return boolean True if the sound channel is stalled.
+function bass_methods:isStalled()
+	return getsnd(self):GetState() == GMOD_CHANNEL_STALLED
+end
+
 end

--- a/lua/starfall/libs_cl/bass.lua
+++ b/lua/starfall/libs_cl/bass.lua
@@ -33,6 +33,7 @@ local checkpermission = instance.player ~= SF.Superuser and SF.Permissions.check
 
 -- Register functions to be called when the chip is initialised and deinitialised
 local sounds = {}
+local soundToFlags = {}
 instance:AddHook("deinitialize", function()
 	for s in pairs(sounds) do
 		deleteSound(instance.player, s)
@@ -75,6 +76,7 @@ local function loadSound(path, flags, callback, loadFunc)
 				snd:Stop()
 				plyCount:free(instance.player, 1)
 			else
+				soundToFlags[snd] = flags -- IGModAudioChannel is userdata, so we can't attach extra key-value pairs or functions to it.
 				sounds[snd] = true
 				instance:runFunction(callback, wrap(snd), 0, "")
 			end
@@ -134,6 +136,7 @@ function bass_methods:stop()
 	local snd = getsnd(self)
 	deleteSound(instance.player, snd)
 	sounds[snd] = nil
+	soundToFlags[snd] = nil
 
 	-- This makes the sound no longer unwrap
 	local sensitive2sf, sf2sensitive = bass_meta.sensitive2sf, bass_meta.sf2sensitive
@@ -257,6 +260,24 @@ end
 -- @return number The average bit rate of the sound channel.
 function bass_methods:getAverageBitRate()
 	return getsnd(self):GetAverageBitRate()
+end
+
+--- Returns the flags used to create the sound channel.
+-- @return string The flags of the sound channel (`3d`, `mono`, `noplay`, `noblock`).
+function bass_methods:getFlags()
+	return soundToFlags[getsnd(self)]
+end
+
+--- Returns whether or not the sound channel is 2D.
+-- @return boolean True if the sound channel is 2D.
+function bass_methods:is2D()
+	return not getsnd(self):Is3D()
+end
+
+--- Returns whether or not the sound channel is 3D.
+-- @return boolean True if the sound channel is 3D.
+function bass_methods:is3D()
+	return getsnd(self):Is3D()
 end
 
 end

--- a/lua/starfall/libs_cl/bass.lua
+++ b/lua/starfall/libs_cl/bass.lua
@@ -50,15 +50,15 @@ local function addSoundToSimpleFade(snd)
 	table.insert(simpleFadeSounds, snd)
 	applySimpleFading(snd)
 
-	if #simpleFadeSounds ~= 1 then return end -- Hook is already running.
-
-	hook.Add("Think", "SF_Bass_SimpleFade", function()
-		for _, s in ipairs(simpleFadeSounds) do
-			if s:IsValid() and s:GetState() == GMOD_CHANNEL_PLAYING then
-				applySimpleFading(s)
+	if #simpleFadeSounds == 1 then
+		hook.Add("Think", "SF_Bass_SimpleFade", function()
+			for _, s in ipairs(simpleFadeSounds) do
+				if s:IsValid() and s:GetState() == GMOD_CHANNEL_PLAYING then
+					applySimpleFading(s)
+				end
 			end
-		end
-	end)
+		end)
+	end
 end
 
 local function removeSoundFromSimpleFade(snd)
@@ -73,9 +73,9 @@ local function removeSoundFromSimpleFade(snd)
 		snd:SetVolume(sndData.targetVolume) -- Remove manual fading, reset to target volume.
 	end
 
-	if #simpleFadeSounds ~= 0 then return end -- Hook is still needed
-
-	hook.Remove("Think", "SF_Bass_SimpleFade")
+	if #simpleFadeSounds == 0 then
+		hook.Remove("Think", "SF_Bass_SimpleFade")
+	end
 end
 
 local function deleteSound(ply, snd)

--- a/lua/starfall/libs_cl/bass.lua
+++ b/lua/starfall/libs_cl/bass.lua
@@ -106,15 +106,14 @@ SF.RegisterType("Bass", true, false)
 return function(instance)
 local checkpermission = instance.player ~= SF.Superuser and SF.Permissions.check or function() end
 
--- Register functions to be called when the chip is initialized and deinitialized.
-local soundList = {}
+local instanceSounds = {} -- A list of sounds created by this instance.
 
 instance:AddHook("deinitialize", function()
-	for _, snd in ipairs(soundList) do
+	for _, snd in ipairs(instanceSounds) do
 		deleteSound(instance.player, snd)
 	end
 
-	soundList = nil
+	instanceSounds = nil
 end)
 
 
@@ -152,7 +151,7 @@ local function loadSound(path, flags, callback, loadFunc)
 				snd:Stop()
 				plyCount:free(instance.player, 1)
 			else
-				table.insert(soundList, snd)
+				table.insert(instanceSounds, snd)
 				soundDatas[snd] = { -- IGModAudioChannel is userdata, so we can't attach extra key-value pairs or functions to it directly.
 					flags = flags,
 					targetVolume = 1,
@@ -224,7 +223,7 @@ end
 function bass_methods:stop()
 	local snd = getsnd(self)
 	deleteSound(instance.player, snd)
-	table.RemoveByValue(soundList, snd)
+	table.RemoveByValue(instanceSounds, snd)
 
 	-- This makes the sound no longer unwrap
 	local sensitive2sf, sf2sensitive = bass_meta.sensitive2sf, bass_meta.sf2sensitive

--- a/lua/starfall/libs_cl/bass.lua
+++ b/lua/starfall/libs_cl/bass.lua
@@ -171,9 +171,9 @@ end
 
 --- Sets the fade distance of the sound in 3D space. Must have `3d` flag to get this work on.
 -- @param number min The channel's volume is at maximum when the listener is within this distance (50-1000)
--- @param number max The channel's volume stops decreasing when the listener is beyond this distance. (10,000-200,000)
+-- @param number max The channel's volume stops decreasing when the listener is beyond this distance. (1,100-200,000)
 function bass_methods:setFade(min, max)
-	getsnd(self):Set3DFadeDistance(math.Clamp(min, 50, 1000), math.Clamp(max, 10000, 200000))
+	getsnd(self):Set3DFadeDistance(math.Clamp(min, 50, 1000), math.Clamp(max, 1100, 200000))
 end
 
 --- Sets whether the sound channel should loop. Requires the 'noblock' flag

--- a/lua/starfall/libs_cl/bass.lua
+++ b/lua/starfall/libs_cl/bass.lua
@@ -164,23 +164,42 @@ function bass_methods:setPitch(pitch)
 	getsnd(self):SetPlaybackRate(math.Clamp(pitch, 0, 100))
 end
 
---- Sets the position of the sound in 3D space. Must have `3d` flag to get this work on.
+--- Sets the position of the sound in 3D space. Must have `3d` flag for this to have any effect.
 -- @param Vector pos Where to position the sound.
 function bass_methods:setPos(pos)
 	getsnd(self):SetPos(vunwrap(pos))
 end
 
---- Sets the fade distance of the sound in 3D space. Must have `3d` flag to get this work on.
+--- Gets the position of the sound in 3D space.
+-- @param Vector pos The position of the sound.
+function bass_methods:getPos()
+	return vwrap(getsnd(self):GetPos())
+end
+
+--- Sets the fade distance of the sound in 3D space. Must have `3d` flag for this to have any effect.
 -- @param number min The channel's volume is at maximum when the listener is within this distance (50-1000)
 -- @param number max The channel's volume stops decreasing when the listener is beyond this distance. (1,100-200,000)
 function bass_methods:setFade(min, max)
 	getsnd(self):Set3DFadeDistance(math.Clamp(min, 50, 1000), math.Clamp(max, 1100, 200000))
 end
 
---- Sets whether the sound channel should loop. Requires the 'noblock' flag
+--- Gets the fade distance of the sound in 3D space. 
+-- @param number min The channel's volume is at maximum when the listener is within this distance (50-1000)
+-- @param number max The channel's volume stops decreasing when the listener is beyond this distance. (1,100-200,000)
+function bass_methods:getFade()
+	return getsnd(self):Get3DFadeDistance()
+end
+
+--- Sets whether the sound channel should loop. Requires the 'noblock' flag.
 -- @param boolean loop Whether the sound channel should loop.
 function bass_methods:setLooping(loop)
 	getsnd(self):EnableLooping(loop)
+end
+
+--- Gets whether the sound channel loops.
+-- @param boolean loop Whether the sound channel loops.
+function bass_methods:isLooping()
+	return getsnd(self):IsLooping()
 end
 
 --- Gets the length of a sound channel.
@@ -189,7 +208,7 @@ function bass_methods:getLength()
 	return getsnd(self):GetLength()
 end
 
---- Sets the current playback time of the sound channel. Requires the 'noblock' flag
+--- Sets the current playback time of the sound channel. Requires the 'noblock' flag.
 -- @param number time Sound channel playback time in seconds.
 -- @param boolean? dontDecode Skip decoding to set time, which is much faster but less accurate. True by default.
 function bass_methods:setTime(time, dontDecode)
@@ -197,7 +216,7 @@ function bass_methods:setTime(time, dontDecode)
 	getsnd(self):SetTime(time, dontDecode ~= false)
 end
 
---- Gets the current playback time of the sound channel. Requires the 'noblock' flag
+--- Gets the current playback time of the sound channel. Requires the 'noblock' flag.
 -- @return number Sound channel playback time in seconds.
 function bass_methods:getTime()
 	return getsnd(self):GetTime()

--- a/lua/starfall/libs_cl/bass.lua
+++ b/lua/starfall/libs_cl/bass.lua
@@ -51,7 +51,7 @@ local function addSoundToSimpleFade(snd)
 	table.insert(simpleFadeSounds, snd)
 	applySimpleFading(snd)
 
-	if #simpleFadeSounds ~= 1 then return end -- Hook is already running
+	if #simpleFadeSounds ~= 1 then return end -- Hook is already running.
 
 	hook.Add("Think", "SF_Bass_SimpleFade", function()
 		for _, s in ipairs(simpleFadeSounds) do
@@ -106,7 +106,7 @@ SF.RegisterType("Bass", true, false)
 return function(instance)
 local checkpermission = instance.player ~= SF.Superuser and SF.Permissions.check or function() end
 
--- Register functions to be called when the chip is initialised and deinitialised
+-- Register functions to be called when the chip is initialized and deinitialized.
 local soundList = {}
 
 instance:AddHook("deinitialize", function()
@@ -174,10 +174,10 @@ local function loadSound(path, flags, callback, loadFunc)
 end
 
 
---- Loads a sound channel from a file.
+--- Loads a sound as a Bass object from a file.
 -- @param string path File path to play from.
 -- @param string flags Flags for the sound (`3d`, `mono`, `noplay`, `noblock`).
--- @param function callback Function which is called when the sound channel is loaded. It'll get 3 arguments: `Bass` object, error number and name.
+-- @param function callback Function which is called when the sound is loaded. It'll get 3 arguments: `Bass` object, error number and name.
 function bass_library.loadFile(path, flags, callback)
 	checkpermission(instance, nil, "bass.loadFile")
 
@@ -191,10 +191,10 @@ function bass_library.loadFile(path, flags, callback)
 	loadSound(path, flags, callback, sound.PlayFile)
 end
 
---- Loads a sound channel from an URL.
+--- Loads a sound as a Bass object from a URL.
 -- @param string path URL path to play from.
 -- @param string flags Flags for the sound (`3d`, `mono`, `noplay`, `noblock`). noblock will fail if the webserver doesn't provide file length.
--- @param function callback Function which is called when the sound channel is loaded. It'll get 3 arguments: `Bass` object, error number and name.
+-- @param function callback Function which is called when the sound is loaded. It'll get 3 arguments: `Bass` object, error number and name.
 function bass_library.loadURL(path, flags, callback)
 	checkpermission(instance, path, "bass.loadURL")
 
@@ -207,8 +207,8 @@ function bass_library.loadURL(path, flags, callback)
 	loadSound(path, flags, callback, sound.PlayURL)
 end
 
---- Returns the number of sounds left that can be created
--- @return number The number of sounds left
+--- Returns the number of sounds left that can be created.
+-- @return number The number of sounds left.
 function bass_library.soundsLeft()
 	return plyCount:check(instance.player)
 end
@@ -220,7 +220,7 @@ function bass_methods:play()
 	getsnd(self):Play()
 end
 
---- Stops playing the sound and destroys it. Use pause instead if you don't want it destroyed
+--- Stops playing the sound and destroys it. Use pause instead if you don't want it destroyed.
 function bass_methods:stop()
 	local snd = getsnd(self)
 	deleteSound(instance.player, snd)
@@ -237,7 +237,7 @@ function bass_methods:pause()
 	getsnd(self):Pause()
 end
 
---- Sets the volume of the sound channel.
+--- Sets the volume of the sound.
 -- @param number vol Volume multiplier (1 is normal), between 0x and 10x.
 function bass_methods:setVolume(vol)
 	checkluatype(vol, TYPE_NUMBER)
@@ -255,15 +255,15 @@ function bass_methods:setVolume(vol)
 	end
 end
 
---- Gets the base volume of the sound channel.
+--- Gets the base volume of the sound.
 -- This is the volume before distance fading is applied on 3D sounds.
 -- @return number Volume multiplier (1 is normal), between 0x and 10x.
 function bass_methods:getVolume()
 	return soundDatas[getsnd(self)].targetVolume
 end
 
---- Gets the distance-based fade multiplier of the sound channel.
--- Bass:getVolume() * Bass:getFadeMultiplier() is the effective volume of the sound channel.
+--- Gets the distance-based fade multiplier of the sound.
+-- Bass:getVolume() * Bass:getFadeMultiplier() is the effective volume of the sound.
 -- Always 1 for 2D sounds.
 -- Always 1 for 3D sounds that don't use simple fading. See Bass:setFade().
 -- Only updates once per frame while the sound is playing.
@@ -272,16 +272,16 @@ function bass_methods:getFadeMultiplier()
 	return soundDatas[getsnd(self)].fadeMult
 end
 
---- Returns whether or not the sound channel is out of earshot.
+--- Returns whether or not the sound is out of earshot.
 -- Always false for 2D sounds.
 -- Always true for 3D sounds that don't use simple fading. See Bass:setFade().
 -- Only updates once per frame while the sound is playing.
--- @return boolean True if the sound channel's distance is greater than its fade maximum.
+-- @return boolean True if the sound's distance is greater than its fade maximum.
 function bass_methods:isOutOfEarshot()
 	return soundDatas[getsnd(self)].outOfEarshot
 end
 
---- Sets the pitch of the sound channel.
+--- Sets the pitch of the sound.
 -- @param number pitch Pitch to set to. (0-100) 1 is normal pitch.
 function bass_methods:setPitch(pitch)
 	checkluatype(pitch, TYPE_NUMBER)
@@ -343,39 +343,39 @@ function bass_methods:getFade()
 	return min, max, simpleFadeEnabled
 end
 
---- Sets whether the sound channel should loop. Requires the 'noblock' flag.
--- @param boolean loop Whether the sound channel should loop.
+--- Sets whether the sound should loop. Requires the 'noblock' flag.
+-- @param boolean loop Whether the sound should loop.
 function bass_methods:setLooping(loop)
 	getsnd(self):EnableLooping(loop)
 end
 
---- Gets whether the sound channel loops.
--- @return boolean Whether the sound channel loops.
+--- Gets whether the sound loops.
+-- @return boolean Whether the sound loops.
 function bass_methods:isLooping()
 	return getsnd(self):IsLooping()
 end
 
---- Gets the length of a sound channel.
--- @return number Sound channel length in seconds.
+--- Gets the length of a sound.
+-- @return number Sound length in seconds.
 function bass_methods:getLength()
 	return getsnd(self):GetLength()
 end
 
---- Sets the current playback time of the sound channel. Requires the 'noblock' flag.
--- @param number time Sound channel playback time in seconds.
+--- Sets the current playback time of the sound. Requires the 'noblock' flag.
+-- @param number time Sound playback time in seconds.
 -- @param boolean? dontDecode Skip decoding to set time, which is much faster but less accurate. True by default.
 function bass_methods:setTime(time, dontDecode)
 	checkluatype(time, TYPE_NUMBER)
 	getsnd(self):SetTime(time, dontDecode ~= false)
 end
 
---- Gets the current playback time of the sound channel. Requires the 'noblock' flag.
--- @return number Sound channel playback time in seconds.
+--- Gets the current playback time of the sound. Requires the 'noblock' flag.
+-- @return number Sound playback time in seconds.
 function bass_methods:getTime()
 	return getsnd(self):GetTime()
 end
 
---- Perform fast Fourier transform algorithm to compute the DFT of the sound channel.
+--- Perform fast Fourier transform algorithm to compute the DFT of the sound.
 -- @param number n Number of consecutive audio samples, between 0 and 7. Depending on this parameter you will get 256*2^n samples.
 -- @return table Table containing DFT magnitudes, each between 0 and 1.
 function bass_methods:getFFT(n)
@@ -384,8 +384,8 @@ function bass_methods:getFFT(n)
 	return arr
 end
 
---- Gets whether the sound channel is streamed online.
--- @return boolean Boolean of whether the sound channel is streamed online.
+--- Gets whether the sound is streamed online.
+-- @return boolean Boolean of whether the sound is streamed online.
 function bass_methods:isOnline()
 	return getsnd(self):IsOnline()
 end
@@ -398,7 +398,7 @@ function bass_methods:isValid()
 	return isValid and isValid(uw) or false
 end
 
---- Gets the left and right levels of the audio channel
+--- Gets the left and right audio channel levels.
 -- @return number The left sound level, a value between 0 and 1.
 -- @return number The right sound level, a value between 0 and 1.
 function bass_methods:getLevels()
@@ -412,74 +412,74 @@ function bass_methods:getPan()
 end
 
 --- Sets the relative volume of the left and right channels.
--- @param number Relative integer volume between the left and right channels. Values must be -1 to 1 for relative left to right
+-- @param number Relative integer volume between the left and right channels. Values must be -1 to 1 for relative left to right.
 function bass_methods:setPan(pan)
 	checkluatype(pan, TYPE_NUMBER)
 
 	local uw = getsnd(self)
-	-- If we ever use / add Set3DEnabled to SF, remember to change this Is3D to Get3DEnabled
+	-- If we ever use / add Set3DEnabled to SF, remember to change this Is3D to Get3DEnabled.
 	if uw:Is3D() then SF.Throw("You cannot set the pan of a 3D Bass Object!", 2) end
 	uw:SetPan( pan )
 end
 
---- Retrieves the number of bits per sample of the sound channel.
+--- Retrieves the number of bits per sample of the sound.
 -- Doesn't work for mp3 and ogg files.
 -- @return number Floating point number of bits per sample, or 0 if unknown.
 function bass_methods:getBitsPerSample()
 	return getsnd(self):GetBitsPerSample()
 end
 
---- Returns the average bit rate of the sound channel.
--- @return number The average bit rate of the sound channel.
+--- Returns the average bit rate of the sound.
+-- @return number The average bit rate of the sound.
 function bass_methods:getAverageBitRate()
 	return getsnd(self):GetAverageBitRate()
 end
 
---- Returns the flags used to create the sound channel.
--- @return string The flags of the sound channel (`3d`, `mono`, `noplay`, `noblock`).
+--- Returns the flags used to create the sound.
+-- @return string The flags of the sound (`3d`, `mono`, `noplay`, `noblock`).
 function bass_methods:getFlags()
 	return sounds[getsnd(self)].flags
 end
 
---- Returns whether or not the sound channel is 2D.
--- @return boolean True if the sound channel is 2D.
+--- Returns whether or not the sound is 2D.
+-- @return boolean True if the sound is 2D.
 function bass_methods:is2D()
 	return not getsnd(self):Is3D()
 end
 
---- Returns whether or not the sound channel is 3D.
--- @return boolean True if the sound channel is 3D.
+--- Returns whether or not the sound is 3D.
+-- @return boolean True if the sound is 3D.
 function bass_methods:is3D()
 	return getsnd(self):Is3D()
 end
 
---- Returns the state of the sound channel.
--- @return number The state enum of the sound channel. https://wiki.facepunch.com/gmod/Enums/GMOD_CHANNEL
+--- Returns the state of the sound.
+-- @return number The state enum of the sound. https://wiki.facepunch.com/gmod/Enums/GMOD_CHANNEL
 function bass_methods:getState()
 	return getsnd(self):GetState()
 end
 
---- Returns whether or not the sound channel is stopped.
+--- Returns whether or not the sound is stopped.
 -- Only true if the `noplay` flag is used and Bass:play() hasn't been called yet, since Bass:stop() will destroy the sound channel.
--- @return boolean True if the sound channel is stopped.
+-- @return boolean True if the sound is stopped.
 function bass_methods:isStopped()
 	return getsnd(self):GetState() == GMOD_CHANNEL_STOPPED
 end
 
---- Returns whether or not the sound channel is playing.
--- @return boolean True if the sound channel is playing.
+--- Returns whether or not the sound is playing.
+-- @return boolean True if the sound is playing.
 function bass_methods:isPlaying()
 	return getsnd(self):GetState() == GMOD_CHANNEL_PLAYING
 end
 
---- Returns whether or not the sound channel is paused.
--- @return boolean True if the sound channel is paused.
+--- Returns whether or not the sound is paused.
+-- @return boolean True if the sound is paused.
 function bass_methods:isPaused()
 	return getsnd(self):GetState() == GMOD_CHANNEL_PAUSED
 end
 
---- Returns whether or not the sound channel is stalled.
--- @return boolean True if the sound channel is stalled.
+--- Returns whether or not the sound is stalled.
+-- @return boolean True if the sound is stalled.
 function bass_methods:isStalled()
 	return getsnd(self):GetState() == GMOD_CHANNEL_STALLED
 end

--- a/lua/starfall/libs_cl/bass.lua
+++ b/lua/starfall/libs_cl/bass.lua
@@ -118,10 +118,10 @@ SF.RegisterType("Bass", true, false)
 return function(instance)
 local checkpermission = instance.player ~= SF.Superuser and SF.Permissions.check or function() end
 
-local instanceSounds = {} -- A list of sounds created by this instance.
+local instanceSounds = {} -- A lookup table of sounds created by this instance.
 
 instance:AddHook("deinitialize", function()
-	for _, snd in ipairs(instanceSounds) do
+	for snd in pairs(instanceSounds) do
 		deleteSound(instance.player, snd)
 	end
 
@@ -163,7 +163,7 @@ local function loadSound(path, flags, callback, loadFunc)
 				snd:Stop()
 				plyCount:free(instance.player, 1)
 			else
-				table.insert(instanceSounds, snd)
+				instanceSounds[snd] = true
 				soundDatas[snd] = { -- IGModAudioChannel is userdata, so we can't attach extra key-value pairs or functions to it directly.
 					flags = flags,
 					targetVolume = 1,
@@ -235,7 +235,7 @@ end
 function bass_methods:stop()
 	local snd = getsnd(self)
 	deleteSound(instance.player, snd)
-	table.RemoveByValue(instanceSounds, snd)
+	instanceSounds[snd] = nil
 
 	-- This makes the sound no longer unwrap
 	local sensitive2sf, sf2sensitive = bass_meta.sensitive2sf, bass_meta.sf2sensitive

--- a/lua/starfall/libs_cl/bass.lua
+++ b/lua/starfall/libs_cl/bass.lua
@@ -438,7 +438,7 @@ end
 --- Returns the flags used to create the sound.
 -- @return string The flags of the sound (`3d`, `mono`, `noplay`, `noblock`).
 function bass_methods:getFlags()
-	return sounds[getsnd(self)].flags
+	return soundDatas[getsnd(self)].flags
 end
 
 --- Returns whether or not the sound is 2D.

--- a/lua/starfall/libs_cl/bass.lua
+++ b/lua/starfall/libs_cl/bass.lua
@@ -33,7 +33,6 @@ local checkpermission = instance.player ~= SF.Superuser and SF.Permissions.check
 
 -- Register functions to be called when the chip is initialised and deinitialised
 local sounds = {}
-local soundToFlags = {}
 instance:AddHook("deinitialize", function()
 	for s in pairs(sounds) do
 		deleteSound(instance.player, s)
@@ -76,8 +75,10 @@ local function loadSound(path, flags, callback, loadFunc)
 				snd:Stop()
 				plyCount:free(instance.player, 1)
 			else
-				soundToFlags[snd] = flags -- IGModAudioChannel is userdata, so we can't attach extra key-value pairs or functions to it.
-				sounds[snd] = true
+				sounds[snd] = { -- IGModAudioChannel is userdata, so we can't attach extra key-value pairs or functions to it directly.
+					flags = flags
+				}
+
 				instance:runFunction(callback, wrap(snd), 0, "")
 			end
 		end
@@ -136,7 +137,6 @@ function bass_methods:stop()
 	local snd = getsnd(self)
 	deleteSound(instance.player, snd)
 	sounds[snd] = nil
-	soundToFlags[snd] = nil
 
 	-- This makes the sound no longer unwrap
 	local sensitive2sf, sf2sensitive = bass_meta.sensitive2sf, bass_meta.sf2sensitive
@@ -265,7 +265,7 @@ end
 --- Returns the flags used to create the sound channel.
 -- @return string The flags of the sound channel (`3d`, `mono`, `noplay`, `noblock`).
 function bass_methods:getFlags()
-	return soundToFlags[getsnd(self)]
+	return sounds[getsnd(self)].flags
 end
 
 --- Returns whether or not the sound channel is 2D.

--- a/lua/starfall/libs_cl/bass.lua
+++ b/lua/starfall/libs_cl/bass.lua
@@ -171,7 +171,7 @@ function bass_methods:setPos(pos)
 end
 
 --- Gets the position of the sound in 3D space.
--- @param Vector pos The position of the sound.
+-- @return Vector The position of the sound.
 function bass_methods:getPos()
 	return vwrap(getsnd(self):GetPos())
 end
@@ -184,8 +184,8 @@ function bass_methods:setFade(min, max)
 end
 
 --- Gets the fade distance of the sound in 3D space. 
--- @param number min The channel's volume is at maximum when the listener is within this distance (50-1000)
--- @param number max The channel's volume stops decreasing when the listener is beyond this distance. (1,100-200,000)
+-- @return number The distance before the sound starts to fade. (50-1000)
+-- @return number The distance before the sound stops fading. (1,100-200,000)
 function bass_methods:getFade()
 	return getsnd(self):Get3DFadeDistance()
 end
@@ -197,7 +197,7 @@ function bass_methods:setLooping(loop)
 end
 
 --- Gets whether the sound channel loops.
--- @param boolean loop Whether the sound channel loops.
+-- @return boolean Whether the sound channel loops.
 function bass_methods:isLooping()
 	return getsnd(self):IsLooping()
 end

--- a/lua/starfall/libs_cl/bass.lua
+++ b/lua/starfall/libs_cl/bass.lua
@@ -25,10 +25,10 @@ local function getSimpleFading(snd)
 	if distSqr <= fadeMin * fadeMin then return 1 end
 	if distSqr >= fadeMax * fadeMax then return 0 end
 
+	-- Sounds falls off with dist^2. Unfortunately, we still have to do the square root inbetween.
 	local dist = math_sqrt(distSqr)
-	local farnessFrac = (dist - fadeMin) / (fadeMax - fadeMin)
 
-	return (1 - farnessFrac) ^ 2 -- Sounds falls off with dist^2. Unfortunately, we still have to do the square root inbetween.
+	return ((fadeMax - dist) / (fadeMax - fadeMin)) ^ 2
 end
 
 local function applySimpleFading(snd)

--- a/lua/starfall/libs_sh/enum.lua
+++ b/lua/starfall/libs_sh/enum.lua
@@ -1384,4 +1384,18 @@ env.DAMAGE = {
 	["MISSILEDEFENSE"] = 2147483648
 }
 
+--- ENUMs used by Bass:getState()
+-- @name bass.GMOD_CHANNEL
+-- @class table
+-- @field STOPPED 0
+-- @field PLAYING 1
+-- @field PAUSED 2
+-- @field STALLED 3
+env.GMOD_CHANNEL = {
+	STOPPED = GMOD_CHANNEL_STOPPED,
+	PLAYING = GMOD_CHANNEL_PLAYING,
+	PAUSED = GMOD_CHANNEL_PAUSED,
+	STALLED = GMOD_CHANNEL_STALLED
+}
+
 end

--- a/lua/starfall/libs_sh/enum.lua
+++ b/lua/starfall/libs_sh/enum.lua
@@ -1028,7 +1028,6 @@ env.RENDERFX = {
 --- VRmod library enums
 -- @name vr_library.VR
 -- @class table
--- @client
 -- @field BOOLEAN_PRIMARYFIRE
 -- @field VECTOR1_PRIMARYFIRE
 -- @field BOOLEAN_SECONDARYFIRE
@@ -1384,22 +1383,18 @@ env.DAMAGE = {
 	["MISSILEDEFENSE"] = 2147483648
 }
 
-
-if CLIENT then
-	--- ENUMs used by Bass:getState()
-	-- @name builtins_library.GMOD_CHANNEL
-	-- @class table
-	-- @client
-	-- @field STOPPED 0
-	-- @field PLAYING 1
-	-- @field PAUSED 2
-	-- @field STALLED 3
-	env.GMOD_CHANNEL = {
-		STOPPED = GMOD_CHANNEL_STOPPED,
-		PLAYING = GMOD_CHANNEL_PLAYING,
-		PAUSED = GMOD_CHANNEL_PAUSED,
-		STALLED = GMOD_CHANNEL_STALLED
-	}
-end
+--- ENUMs used by Bass:getState()
+-- @name builtins_library.GMOD_CHANNEL
+-- @class table
+-- @field STOPPED 0
+-- @field PLAYING 1
+-- @field PAUSED 2
+-- @field STALLED 3
+env.GMOD_CHANNEL = {
+	STOPPED = 0,
+	PLAYING = 1,
+	PAUSED = 2,
+	STALLED = 3
+}
 
 end

--- a/lua/starfall/libs_sh/enum.lua
+++ b/lua/starfall/libs_sh/enum.lua
@@ -1384,18 +1384,22 @@ env.DAMAGE = {
 	["MISSILEDEFENSE"] = 2147483648
 }
 
---- ENUMs used by Bass:getState()
--- @name bass.GMOD_CHANNEL
--- @class table
--- @field STOPPED 0
--- @field PLAYING 1
--- @field PAUSED 2
--- @field STALLED 3
-env.GMOD_CHANNEL = {
-	STOPPED = GMOD_CHANNEL_STOPPED,
-	PLAYING = GMOD_CHANNEL_PLAYING,
-	PAUSED = GMOD_CHANNEL_PAUSED,
-	STALLED = GMOD_CHANNEL_STALLED
-}
+
+if CLIENT then
+	--- ENUMs used by Bass:getState()
+	-- @name bass.GMOD_CHANNEL
+	-- @class table
+	-- @client
+	-- @field STOPPED 0
+	-- @field PLAYING 1
+	-- @field PAUSED 2
+	-- @field STALLED 3
+	env.GMOD_CHANNEL = {
+		STOPPED = GMOD_CHANNEL_STOPPED,
+		PLAYING = GMOD_CHANNEL_PLAYING,
+		PAUSED = GMOD_CHANNEL_PAUSED,
+		STALLED = GMOD_CHANNEL_STALLED
+	}
+end
 
 end

--- a/lua/starfall/libs_sh/enum.lua
+++ b/lua/starfall/libs_sh/enum.lua
@@ -1387,7 +1387,7 @@ env.DAMAGE = {
 
 if CLIENT then
 	--- ENUMs used by Bass:getState()
-	-- @name bass.GMOD_CHANNEL
+	-- @name builtins_library.GMOD_CHANNEL
 	-- @class table
 	-- @client
 	-- @field STOPPED 0


### PR DESCRIPTION
- Adds most of the missing getter functions for bass objects
- Adds GMOD_CHANNEL enums and related functions
- Changes the fadeMax clamp from `10000, 200000` to `1100, 200000` so close-ish range sounds are actually possible
- Applies a bandaid fix for `IGModAudioChannel` not handling sound fading correctly at all when the base volume is > 1