### PR TITLE
Fix :setVolume() for simply faded sounds

### DIFF
--- a/lua/starfall/libs_cl/bass.lua
+++ b/lua/starfall/libs_cl/bass.lua
@@ -260,7 +260,7 @@ function bass_methods:setVolume(vol)
 	sndData.targetVolume = vol
 
 	if sndData.simpleFadeEnabled then
-		applySimpleFading(snd)
+		snd:SetVolume(vol * sndData.fadeMult)
 	else
 		snd:SetVolume(vol)
 	end


### PR DESCRIPTION
Fixes `:setVolume()` doing nothing on simply-faded bass sounds after creation.

Previously, `applySimpleFading()` was used, which only sets the volume if the fadeMult changes, which is never the case when called between ticks (unless you `:setPos()` it first, but obviously that's bad).