### PR TITLE
Fix DAMAGE

### DIFF
--- a/lua/starfall/libs_sh/enum.lua
+++ b/lua/starfall/libs_sh/enum.lua
@@ -1311,7 +1311,7 @@ env.NAV_TRAVERSE_TYPE = {
 	GO_ELEVATOR_DOWN = 8
 }
 
--- ENUMs used for anything that returns a damage type.
+--- ENUMs used for anything that returns a damage type.
 -- @name builtins_library.DAMAGE
 -- @class table
 -- @field GENERIC


### PR DESCRIPTION
Added a single missing hyphen that caused DAMAGE to not appear in documentation or in the editor correctly.