### PR TITLE
Update fade max from exemple music_player.lua

### DIFF
--- a/lua/starfall/examples/music_player.lua
+++ b/lua/starfall/examples/music_player.lua
@@ -19,7 +19,7 @@ else
 		bass.loadURL(songURL, "3d noblock", function(snd, err, errtxt)
 			if snd then
 				song = snd
-				snd:setFade(500, 100000)
+				snd:setFade(500, 2000)
 				snd:setVolume(2)
 				pcall(snd.setLooping, snd, true) -- pcall in case of audio stream
 


### PR DESCRIPTION
Since the bass update with the fade max now fixed it make this exemple play sound across the whole map. 2000 unit seem reasonable range.