### PR TITLE
Map entity functions

### DIFF
--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -86,14 +86,6 @@ function builtins_library.entity(num)
 	return owrap(Entity(num))
 end
 
---- Returns entity that has given Entity:mapCreationID.
--- @param number num Entity's creation id
--- @return Entity Found entity
-function builtins_library.getMapCreatedEntity(num)
-	checkluatype(num, TYPE_NUMBER)
-	return owrap(ents.GetMapCreatedEntity(num))
-end
-
 
 --- Used to select single values from a vararg or get the count of values in it.
 -- @name builtins_library.select

--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -86,6 +86,14 @@ function builtins_library.entity(num)
 	return owrap(Entity(num))
 end
 
+--- Returns entity that has given Entity:mapCreationID.
+-- @param number num Entity's creation id
+-- @return Entity Found entity
+function builtins_library.getMapCreatedEntity(num)
+	checkluatype(num, TYPE_NUMBER)
+	return owrap(ents.GetMapCreatedEntity(num))
+end
+
 
 --- Used to select single values from a vararg or get the count of values in it.
 -- @name builtins_library.select

--- a/lua/starfall/libs_sh/entities.lua
+++ b/lua/starfall/libs_sh/entities.lua
@@ -1893,4 +1893,12 @@ function ents_methods:getInternalVariable(variableName)
 	return istable(result) and instance.Sanitize(result) or owrap(result)
 end
 
+--- Returns entity's map creation ID. Unlike Entity:EntIndex or Entity:GetCreationID, it will always be the same on same map, no matter how much you clean up or restart it.
+-- @shared
+-- @param Entity ent
+-- @return number The map creation ID or -1 if the entity is not compiled into the map.
+function ents_methods:mapCreationID()
+	return getent(self):MapCreationID()
+end
+
 end

--- a/lua/starfall/libs_sh/entities.lua
+++ b/lua/starfall/libs_sh/entities.lua
@@ -1893,7 +1893,7 @@ function ents_methods:getInternalVariable(variableName)
 	return istable(result) and instance.Sanitize(result) or owrap(result)
 end
 
---- Returns entity's map creation ID. Unlike Entity:EntIndex or Entity:GetCreationID, it will always be the same on same map, no matter how much you clean up or restart it.
+--- Returns entity's map creation ID. Unlike Entity:entIndex or Entity:getCreationID, it will always be the same on same map, no matter how much you clean up or restart it.
 -- @shared
 -- @param Entity ent
 -- @return number The map creation ID or -1 if the entity is not compiled into the map.

--- a/lua/starfall/libs_sh/entities.lua
+++ b/lua/starfall/libs_sh/entities.lua
@@ -1895,7 +1895,6 @@ end
 
 --- Returns entity's map creation ID. Unlike Entity:entIndex or Entity:getCreationID, it will always be the same on same map, no matter how much you clean up or restart it.
 -- @shared
--- @param Entity ent
 -- @return number The map creation ID or -1 if the entity is not compiled into the map.
 function ents_methods:mapCreationID()
 	return getent(self):MapCreationID()

--- a/lua/starfall/libs_sh/find.lua
+++ b/lua/starfall/libs_sh/find.lua
@@ -14,24 +14,24 @@ return function(instance)
 local checkpermission = instance.player ~= SF.Superuser and SF.Permissions.check or function() end
 
 local find_library = instance.Libraries.find
+local owrap, ounwrap = instance.WrapObject, instance.UnwrapObject
 local vec_meta, vwrap, vunwrap = instance.Types.Vector, instance.Types.Vector.Wrap, instance.Types.Vector.Unwrap
 local plywrap = instance.Types.Player.Wrap
 
 local function convert(results, func)
 	if func~=nil then checkluatype (func, TYPE_FUNCTION) end
-	local wrap = instance.WrapObject
 
 	local t = {}
 	if func then
 		for i = 1, #results do
-			local e = wrap(results[i])
+			local e = owrap(results[i])
 			if e and func(e) then
 				t[#t + 1] = e
 			end
 		end
 	else
 		for i = 1, #results do
-			local e = wrap(results[i])
+			local e = owrap(results[i])
 			if e then
 				t[#t + 1] = e
 			end

--- a/lua/starfall/libs_sh/find.lua
+++ b/lua/starfall/libs_sh/find.lua
@@ -265,4 +265,12 @@ function find_library.playerBySteamID64(steamid)
 	if found then return plywrap(found) end
 end
 
+--- Returns entity that has given Entity:mapCreationID.
+-- @param number num Entity's creation id
+-- @return Entity Found entity
+function find_library.getMapCreatedEntity(num)
+	checkluatype(num, TYPE_NUMBER)
+	return owrap(ents.GetMapCreatedEntity(num))
+end
+
 end

--- a/lua/starfall/libs_sh/find.lua
+++ b/lua/starfall/libs_sh/find.lua
@@ -267,7 +267,7 @@ end
 
 --- Returns entity that has given Entity:mapCreationID.
 -- @param number num Entity's creation id
--- @return Entity Found entity
+-- @return Entity? The found entity or nil if not found
 function find_library.getMapCreatedEntity(num)
 	checkluatype(num, TYPE_NUMBER)
 	return owrap(ents.GetMapCreatedEntity(num))


### PR DESCRIPTION
Two new functions for Starfall, entity:mapCreationID() and getMapCreatedEntity(num). These use special entity IDs that are the same for map entities every time that map is loaded.