### PR TITLE
Fix error when player disconnect

### DIFF
--- a/lua/starfall/editor/sfframe.lua
+++ b/lua/starfall/editor/sfframe.lua
@@ -2083,8 +2083,7 @@ function PANEL:UpdatePlayers(players)
 			local svtotal = 0
 			local cltotal = 0
 			for instance, _ in pairs(SF.playerInstances[ply] or {}) do
-				if not isValid(instance.entity) then continue end
-				svtotal = svtotal + instance.entity:GetNWInt("CPUus")
+				svtotal = svtotal + (instance.entity:IsValid() and instance.entity:GetNWInt("CPUus") or 0)
 				cltotal = cltotal + instance.cpu_average
 			end
 			cpuServerText:SetText(string.format("SV CPU: %3.1f us", svtotal))

--- a/lua/starfall/editor/sfframe.lua
+++ b/lua/starfall/editor/sfframe.lua
@@ -2083,6 +2083,7 @@ function PANEL:UpdatePlayers(players)
 			local svtotal = 0
 			local cltotal = 0
 			for instance, _ in pairs(SF.playerInstances[ply] or {}) do
+				if not isValid(instance.entity) then continue end
 				svtotal = svtotal + instance.entity:GetNWInt("CPUus")
 				cltotal = cltotal + instance.cpu_average
 			end


### PR DESCRIPTION
if the frame is open and a player disconnect will error by trying to use a null entity