### PR TITLE
Update OnPlayerChat hook

### DIFF
--- a/lua/starfall/libs_sh/hook.lua
+++ b/lua/starfall/libs_sh/hook.lua
@@ -269,20 +269,22 @@ else
 	-- @client
 	add("FinishChat")
 
-	--- Called when a chat message is printed your chat window (chip owner only)
+	--- Called when a chat message is printed in the local player chat window (only owner client can see message from other than local player or owner)
 	-- @name PlayerChat
 	-- @class hook
-	-- @shared
+	-- @client
 	-- @param Player ply Player that said the message
 	-- @param string text The message
 	-- @param boolean team Whether the message was team only
 	-- @param boolean isdead Whether the message was send from a dead player
-	-- @return boolean Return true to hide the message. Can only be done for the owner of the chip
+	-- @return boolean Return true to hide the message. Can only be done on message sent by the owner of the chip if local player is not the owner
 	add("OnPlayerChat", "playerchat", function(instance, ply, text, teamChat, isDead)
-		if ply~=LocalPlayer() then return false end
+		if LocalPlayer() ~= instance.player and (ply ~= LocalPlayer() and ply ~= instance.player) then
+			return false
+		end
 		return true, {instance.WrapObject(ply), text, teamChat, isDead}
-	end, function(instance, ret)
-		if ret[1] and instance.player == LocalPlayer() and ret[2] then return true end
+	end, function(instance, ret, ply)
+		if ret[1] and (instance.player == ply or instance.player == LocalPlayer()) and ret[2] then return true end
 	end)
 
 	--- Called when the player's chat box text changes.


### PR DESCRIPTION
- fix realm being wrong
- Only the owner client will be able to see every message that would normally trigger this hook.
- Non owner client will only see message sent by themself or owner.
- Only message sent by the owner can be hidden if the local player is not the owner.

I believe this is a more balanced approach than 
https://github.com/thegrb93/StarfallEx/pull/1709
who removed most usecase where this hook was used