### PR TITLE
Allow superusers to print on server/clients

### DIFF
--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -532,7 +532,7 @@ if SERVER then
 	function builtins_library.print(...)
 		local data, strlen, size = argsToChat(...)
 		if instance.player == SF.Superuser then
-			print("[SF] ".. ...)
+			print("[SF] ", unpack(data))
 			return
 		end
 		printBurst:use(instance.player, size)

--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -532,7 +532,7 @@ if SERVER then
 	function builtins_library.print(...)
 		local data, strlen, size = argsToChat(...)
 		if instance.player == SF.Superuser then
-			print("[SF] ", unpack(data))
+			MsgC("[SF] ", unpack(data))
 			return
 		end
 		printBurst:use(instance.player, size)

--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -641,20 +641,18 @@ else
 	-- @param number mtype How the message should be displayed. See http://wiki.facepunch.com/gmod/Enums/HUD
 	-- @param string text The message text.
 	function builtins_library.printMessage(mtype, text)
-		if instance.player == SF.Superuser then
-			LocalPlayer():PrintMessage(mtype, text)
-			return
-		end
-		if instance.player ~= LocalPlayer() then return end
 		checkluatype(text, TYPE_STRING)
-		instance.player:PrintMessage(mtype, text)
+		if instance.player == LocalPlayer() then
+			instance.player:PrintMessage(mtype, text)
+		elseif instance.player == SF.Superuser then
+			LocalPlayer():PrintMessage(mtype, text)
+		end
 	end
 
 	function builtins_library.print(...)
 		if instance.player == LocalPlayer() then
 			chat.AddText(unpack((argsToChat(...))))
-		end
-		if instance.player == SF.Superuser then
+		elseif instance.player == SF.Superuser then
 			chat.AddText(unpack((argsToChat(builtins_library.Color(5,125,222), "[SF] ", builtins_library.Color(255,255,255), ...))))
 		end
 	end

--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -531,6 +531,10 @@ if SERVER then
 	-- @param ... printArgs Values to print. Colors before text will set the text color
 	function builtins_library.print(...)
 		local data, strlen, size = argsToChat(...)
+		if instance.player == SF.Superuser then
+			print("[SF] ".. ...)
+			return
+		end
 		printBurst:use(instance.player, size)
 		sendPrintToPlayer(instance.player, data, false)
 	end
@@ -637,6 +641,10 @@ else
 	-- @param number mtype How the message should be displayed. See http://wiki.facepunch.com/gmod/Enums/HUD
 	-- @param string text The message text.
 	function builtins_library.printMessage(mtype, text)
+		if instance.player == SF.Superuser then
+			LocalPlayer():PrintMessage(mtype, text)
+			return
+		end
 		if instance.player ~= LocalPlayer() then return end
 		checkluatype(text, TYPE_STRING)
 		instance.player:PrintMessage(mtype, text)
@@ -645,6 +653,9 @@ else
 	function builtins_library.print(...)
 		if instance.player == LocalPlayer() then
 			chat.AddText(unpack((argsToChat(...))))
+		end
+		if instance.player == SF.Superuser then
+			chat.AddText(unpack((argsToChat(builtins_library.Color(5,125,222), "[SF] ", builtins_library.Color(255,255,255), ...))))
 		end
 	end
 
@@ -670,7 +681,7 @@ else
 
 	function builtins_library.printTable(tbl)
 		checkluatype(tbl, TYPE_TABLE)
-		if instance.player == LocalPlayer() then
+		if instance.player == LocalPlayer() or instance.player == SF.Superuser then
 			printTableX(tbl, 0, { tbl = true })
 		end
 	end


### PR DESCRIPTION
Superusers should be able to print on the server or on other people's clients, printhud can already do so by forcing people to enable hud but this way you don't have to relay on that, the print statements have [SF] included to avoid confusion.