### PR TITLE
Set cnextbot sent non spawnable

### DIFF
--- a/lua/entities/starfall_cnextbot.lua
+++ b/lua/entities/starfall_cnextbot.lua
@@ -1,7 +1,7 @@
 AddCSLuaFile()
 
 ENT.Base 		= "base_nextbot"
-ENT.Spawnable		= true
+ENT.Spawnable		= false
 
 function ENT:BodyUpdate()
 	self:BodyMoveXY()


### PR DESCRIPTION
Currently you can spawn the nextbot from the spawnmenu which just results in a error model, seems like it can just be disabled.
I've tested it and it doesn't seem to break spawning nextbots by chip.