### PR TITLE
Modified the STool to play nicer with the "--@model" directive.

### DIFF
--- a/lua/weapons/gmod_tool/stools/starfall_processor.lua
+++ b/lua/weapons/gmod_tool/stools/starfall_processor.lua
@@ -126,7 +126,10 @@ function TOOL:LeftClick(trace)
 	if ent:IsValid() and ent:GetClass() == "starfall_processor" then
 		sf = ent
 	else
-		local model = self:GetClientInfo("Model")
+		local model = self:GetClientInfo("ScriptModel")
+		if model=="" or not (util.IsValidModel(model) and util.IsValidProp(model)) then
+			model = self:GetClientInfo("Model")
+		end
 		if not self:GetSWEP():CheckLimit("starfall_processor") then return false end
 
 		local Ang = trace.HitNormal:Angle()
@@ -200,7 +203,7 @@ function TOOL:Think()
 	-- Ghost code
 	if (SERVER and game.SinglePlayer()) or (CLIENT and not game.SinglePlayer()) then
 		local model = self:GetClientInfo("ScriptModel")
-		if model=="" then
+		if model=="" or not (util.IsValidModel(model) and util.IsValidProp(model)) then
 			model = self:GetClientInfo("Model")
 		end
 		local ghost = self.GhostEntity

--- a/lua/weapons/gmod_tool/stools/starfall_processor.lua
+++ b/lua/weapons/gmod_tool/stools/starfall_processor.lua
@@ -126,13 +126,12 @@ function TOOL:LeftClick(trace)
 	if ent:IsValid() and ent:GetClass() == "starfall_processor" then
 		sf = ent
 	else
-		local ok, model = true, self:GetClientInfo("ScriptModel")
+		local ok_model, model = true, self:GetClientInfo("ScriptModel")
 		if model == "" then
 			model = self:GetClientInfo("Model")
 		end
-
-		ok, error = pcall(SF.CheckModel, model, ply, true)
-		if not ok then
+		ok_model, model = pcall(SF.CheckModel, model, ply, true)
+		if not ok_model then
 			SF.AddNotify(ply, "Invalid chip model specified: " .. model, "ERROR", 7, "ERROR1")
 			return false
 		end
@@ -208,10 +207,15 @@ function TOOL:Think()
 
 	-- Ghost code
 	if (SERVER and game.SinglePlayer()) or (CLIENT and not game.SinglePlayer()) then
-		local model = self:GetClientInfo("ScriptModel")
-		if model=="" then
+		local ok_model, model = true, self:GetClientInfo("ScriptModel")
+		if model == "" then
 			model = self:GetClientInfo("Model")
 		end
+		ok_model, model = pcall(SF.CheckModel, model, ply, true)
+		if not ok_model then
+			model = "models/spacecode/sfchip.mdl"
+		end
+
 		local ghost = self.GhostEntity
 		if not (ghost and ghost:IsValid() and ghost:GetModel() == model) then
 			self:MakeGhostEntity(model, Vector(0, 0, 0), Angle(0, 0, 0))

--- a/lua/weapons/gmod_tool/stools/starfall_processor.lua
+++ b/lua/weapons/gmod_tool/stools/starfall_processor.lua
@@ -126,9 +126,15 @@ function TOOL:LeftClick(trace)
 	if ent:IsValid() and ent:GetClass() == "starfall_processor" then
 		sf = ent
 	else
-		local model = self:GetClientInfo("ScriptModel")
-		if model=="" or not (util.IsValidModel(model) and util.IsValidProp(model)) then
+		local ok, model = true, self:GetClientInfo("ScriptModel")
+		if model == "" then
 			model = self:GetClientInfo("Model")
+		end
+
+		ok, model = pcall(SF.CheckModel, model, ply, true)
+		if not ok then
+			SF.AddNotify(ply, "Invalid chip model specified: " .. model, "ERROR", 7, "ERROR1")
+			return false
 		end
 		if not self:GetSWEP():CheckLimit("starfall_processor") then return false end
 

--- a/lua/weapons/gmod_tool/stools/starfall_processor.lua
+++ b/lua/weapons/gmod_tool/stools/starfall_processor.lua
@@ -210,9 +210,6 @@ function TOOL:Think()
 		if model == "" then
 			model = self:GetClientInfo("Model")
 		end
-		if not pcall(SF.CheckModel, model, ply, true) then
-			model = "models/spacecode/sfchip.mdl"
-		end
 
 		local ghost = self.GhostEntity
 		if not (ghost and ghost:IsValid() and ghost:GetModel() == model) then

--- a/lua/weapons/gmod_tool/stools/starfall_processor.lua
+++ b/lua/weapons/gmod_tool/stools/starfall_processor.lua
@@ -131,7 +131,7 @@ function TOOL:LeftClick(trace)
 			model = self:GetClientInfo("Model")
 		end
 
-		ok, model = pcall(SF.CheckModel, model, ply, true)
+		ok, error = pcall(SF.CheckModel, model, ply, true)
 		if not ok then
 			SF.AddNotify(ply, "Invalid chip model specified: " .. model, "ERROR", 7, "ERROR1")
 			return false
@@ -209,7 +209,7 @@ function TOOL:Think()
 	-- Ghost code
 	if (SERVER and game.SinglePlayer()) or (CLIENT and not game.SinglePlayer()) then
 		local model = self:GetClientInfo("ScriptModel")
-		if model=="" or not (util.IsValidModel(model) and util.IsValidProp(model)) then
+		if model=="" then
 			model = self:GetClientInfo("Model")
 		end
 		local ghost = self.GhostEntity

--- a/lua/weapons/gmod_tool/stools/starfall_processor.lua
+++ b/lua/weapons/gmod_tool/stools/starfall_processor.lua
@@ -126,12 +126,11 @@ function TOOL:LeftClick(trace)
 	if ent:IsValid() and ent:GetClass() == "starfall_processor" then
 		sf = ent
 	else
-		local ok_model, model = true, self:GetClientInfo("ScriptModel")
+		local model = self:GetClientInfo("ScriptModel")
 		if model == "" then
 			model = self:GetClientInfo("Model")
 		end
-		ok_model, model = pcall(SF.CheckModel, model, ply, true)
-		if not ok_model then
+		if not pcall(SF.CheckModel, model, ply, true) then
 			SF.AddNotify(ply, "Invalid chip model specified: " .. model, "ERROR", 7, "ERROR1")
 			return false
 		end
@@ -207,12 +206,11 @@ function TOOL:Think()
 
 	-- Ghost code
 	if (SERVER and game.SinglePlayer()) or (CLIENT and not game.SinglePlayer()) then
-		local ok_model, model = true, self:GetClientInfo("ScriptModel")
+		local model = self:GetClientInfo("ScriptModel")
 		if model == "" then
 			model = self:GetClientInfo("Model")
 		end
-		ok_model, model = pcall(SF.CheckModel, model, ply, true)
-		if not ok_model then
+		if not pcall(SF.CheckModel, model, ply, true) then
 			model = "models/spacecode/sfchip.mdl"
 		end
 


### PR DESCRIPTION
Modified the tool to use the script model when spawning, as well as check whether the model is valid for the clientside ghost.

I'm unsure whether this is an oversight, or intentional. But in any case it leads to any processor with a "--@model" directive not being properly positioned and spawning inside the ground/target entity.

This solution is pretty simple, and seems to work fine, although I imagine there's a reason this isn't already here.

I haven't tried contributing to a github repo before, so I don't really know what I'm doing.