### PR TITLE
Url whitelist changes

### DIFF
--- a/lua/starfall/permissions/providers_sh/url_whitelist.lua
+++ b/lua/starfall/permissions/providers_sh/url_whitelist.lua
@@ -250,3 +250,8 @@ pattern [[tts.cyzon.us/(.+)]]
 ---  https://autumn.revolt.chat/attachments/mmCR_bFMLEfBAE8mweH2u4o9_x6DiDtU9JXoSbdvZE/live-bocchi-reaction.gif
 simple [[static.revolt.chat]]
 simple [[autumn.revolt.chat]]
+
+-- Youtube Converter API
+--- Examples:
+---  https://youtube.michaelbelgium.me/storage/YTID.mp3
+simple [[youtube.michaelbelgium.me]]

--- a/lua/starfall/permissions/providers_sh/url_whitelist.lua
+++ b/lua/starfall/permissions/providers_sh/url_whitelist.lua
@@ -174,7 +174,6 @@ blacklist [[steamcommunity.com/linkfilter]]
 ---  https://cdn.discordapp.com/attachments/269175189382758400/421572398689550338/unknown.png
 ---  https://images-ext-2.discordapp.net/external/UVPTeOLUWSiDXGwwtZ68cofxU1uaA2vMb2ZCjRY8XXU/https/i.imgur.com/j0QGfKN.jpg?width=1202&height=67
 ---  https://media.discordapp.net/attachments/695591357158391879/1096409191792508958/image.png?width=1432&height=88
-
 pattern [[cdn[%w-_]*.discordapp%.com/(.+)]]
 pattern [[images-([%w%-]+)%.discordapp%.net/external/(.+)]]
 pattern [[media%.discordapp%.net/attachments/(.+)]]
@@ -184,7 +183,6 @@ pattern [[media%.discordapp%.net/attachments/(.+)]]
 ---  https://i.redd.it/u46wumt13an01.jpg
 ---  https://i.redditmedia.com/RowF7of6hQJAdnJPfgsA-o7ioo_uUzhwX96bPmnLo0I.jpg?w=320&s=116b72a949b6e4b8ac6c42487ffb9ad2
 ---  https://preview.redd.it/injjlk3t6lb51.jpg?width=640&height=800&crop=smart&auto=webp&s=19261cc37b68ae0216bb855f8d4a77ef92b76937
-
 simple [[i.redditmedia.com]]
 simple [[i.redd.it]]
 simple [[preview.redd.it]]
@@ -192,19 +190,16 @@ simple [[preview.redd.it]]
 -- Furry things
 --- Examples:
 --- https://static1.e621.net/data/8f/db/8fdbc9af34698d470c90ca6cb69c5529.jpg
-
 simple [[static1.e621.net]]
 
 -- ipfs
 --- Examples:
 --- https://ipfs.io/ipfs/QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco/I/m/Ellis_Sigil.jpg
-
 simple [[ipfs.io]]
 
 -- neocities
 --- Examples:
 --- https://fauux.neocities.org/LainDressSlow.gif
-
 pattern [[([%w-_]+)%.neocities%.org/(.+)]]
 
 -- Soundcloud
@@ -253,6 +248,5 @@ pattern [[tts.cyzon.us/(.+)]]
 ---  https://static.revolt.chat/emoji/mutant/1f440.svg?rev=3
 ---  https://autumn.revolt.chat/emojis/01G7J9RTHKEPJM8DM19TX35M8N
 ---  https://autumn.revolt.chat/attachments/mmCR_bFMLEfBAE8mweH2u4o9_x6DiDtU9JXoSbdvZE/live-bocchi-reaction.gif
-
 simple [[static.revolt.chat]]
 simple [[autumn.revolt.chat]]

--- a/lua/starfall/permissions/providers_sh/url_whitelist.lua
+++ b/lua/starfall/permissions/providers_sh/url_whitelist.lua
@@ -245,5 +245,5 @@ simple [[autumn.revolt.chat]]
 
 -- Youtube Converter API
 --- Examples:
----  https://youtube.michaelbelgium.me/storage/YTID.mp3
+---  https://youtube.michaelbelgium.me/storage/5zrORMBb0-8.mp3
 simple [[youtube.michaelbelgium.me]]

--- a/lua/starfall/permissions/providers_sh/url_whitelist.lua
+++ b/lua/starfall/permissions/providers_sh/url_whitelist.lua
@@ -61,7 +61,6 @@ end
 ---  https://dl.dropboxusercontent.com/u/12345/abc123/abc123.bin
 ---  https://www.dropbox.com/s/abcd123/efg123.txt?dl=0
 ---  https://dl.dropboxusercontent.com/content_link/abc123/file?dl=1
-
 simple [[dl.dropboxusercontent.com]]
 pattern [[%w+%.dl%.dropboxusercontent%.com/(.+)]]
 simple [[www.dropbox.com]]
@@ -70,13 +69,11 @@ simple [[dl.dropbox.com]] --Sometimes redirects to usercontent link
 -- OneDrive
 --- Examples:
 ---  https://onedrive.live.com/redir?resid=123!178&authkey=!gweg&v=3&ithint=abcd%2cefg
-
 simple [[onedrive.live.com/redir]]
 
 -- Google Drive
 --- Examples:
 ---  https://docs.google.com/uc?export=download&confirm=UYyi&id=0BxUpZqVaDxVPeENDM1RtZDRvaTA
-
 pattern [[docs%.google%.com/uc.+]]
 pattern [[drive%.google%.com/uc.+]]
 
@@ -88,21 +85,17 @@ pattern [[(%w+)%.backblazeb2%.com/(.+)]]
 -- Imgur
 --- Examples:
 ---  http://i.imgur.com/abcd123.xxx
-
 simple [[i.imgur.com]]
 
 -- pastebin
 --- Examples:
 ---  http://pastebin.com/abcdef
-
 simple [[pastebin.com]]
 
 -- gitlab
-
 simple [[gitlab.com]]
 
 -- bitbucket
-
 simple [[bitbucket.org]]
 
 -- github / gist
@@ -112,7 +105,6 @@ simple [[bitbucket.org]]
 ---  https://raw.github.com/github/explore/master/topics/lua/lua.png
 ---  https://user-images.githubusercontent.com/13347909/103649539-ef956e80-4f5e-11eb-94dc-d22ee20380e9.png
 ---  https://avatars2.githubusercontent.com/u/6713261?s=460&v=4
-
 simple [[raw.githubusercontent.com]]
 simple [[gist.githubusercontent.com]]
 simple [[raw.github.com]]


### PR DESCRIPTION
This pull request fixes the spacing of the urls added and comments to be all the same instead of some having a space after them. It also adds the url of a youtube to mp4 / mp3 converter as well.

**Youtube to MP3 / MP4 API:**
I have used this converter a lot inside gmod and it works well. There is a free plan as well as a paid plan for people who want more request / longer songs.