### PR TITLE
Add missing return documentation for string.sub

### DIFF
--- a/lua/starfall/libs_sh/string.lua
+++ b/lua/starfall/libs_sh/string.lua
@@ -256,6 +256,7 @@ string_library.stripExtension = sfstring.StripExtension
 -- @param string str The string you'll take a sub-string out of
 -- @param number startPos The position of the first character that will be included in the sub-string
 -- @param number? endPos The position of the last character to be included in the sub-string. It can be negative to count from the end
+-- @return string The sub-string
 string_library.sub = sfstring.sub
 
 --- Converts time to minutes and seconds string.


### PR DESCRIPTION
Added the missing documentation for the `string.sub` function missing its return type.