### PR TITLE
Include nullable types for some functions

### DIFF
--- a/lua/starfall/libs_sh/bit.lua
+++ b/lua/starfall/libs_sh/bit.lua
@@ -648,9 +648,9 @@ bit_library.tohex = bit.tohex
 --- Creates a StringStream object
 -- @name bit_library.stringstream
 -- @class function
--- @param string stream String to set the initial buffer to (default "")
--- @param number i The initial buffer pointer (default 1)
--- @param string endian The endianness of number types. "big" or "little" (default "little")
+-- @param string? stream String to set the initial buffer to (default "")
+-- @param number? i The initial buffer pointer (default 1)
+-- @param string? endian The endianness of number types. "big" or "little" (default "little")
 -- @return StringStream StringStream object
 function bit_library.stringstream(stream, i, endian)
 	local ret = SF.StringStream(stream, i, endian)

--- a/lua/starfall/libs_sh/color.lua
+++ b/lua/starfall/libs_sh/color.lua
@@ -64,10 +64,10 @@ end
 --- Creates a table struct that resembles a Color
 -- @name builtins_library.Color
 -- @class function
--- @param number|string? r Red or string hexadecimal color
--- @param number? g Green
--- @param number? b Blue
--- @param number? a Alpha
+-- @param number|string? r Red component or string hexadecimal color. Defaults to 255.
+-- @param number? g Green component. Defaults to 255.
+-- @param number? b Blue component. Defaults to 255.
+-- @param number? a Alpha component. Defaults to 255.
 -- @return Color New color
 function instance.env.Color(r, g, b, a)
 	if isstring(r) then

--- a/lua/starfall/libs_sh/color.lua
+++ b/lua/starfall/libs_sh/color.lua
@@ -64,10 +64,10 @@ end
 --- Creates a table struct that resembles a Color
 -- @name builtins_library.Color
 -- @class function
--- @param number r Red or string hexadecimal color
--- @param number g Green
--- @param number b Blue
--- @param number a Alpha
+-- @param number|string? r Red or string hexadecimal color
+-- @param number? g Green
+-- @param number? b Blue
+-- @param number? a Alpha
 -- @return Color New color
 function instance.env.Color(r, g, b, a)
 	if isstring(r) then


### PR DESCRIPTION
Modified `bit.stringstream` documentation to include `nullable` arguments.
Modified `Color` documentation to include `nullable` arguments.
Added `string` type variant to `r` argument of `Color`
Added the default value for `Color` arguments.