### PR TITLE
Editor quality of life improvements

### DIFF
--- a/lua/starfall/editor/sfderma.lua
+++ b/lua/starfall/editor/sfderma.lua
@@ -443,6 +443,24 @@ function PANEL:DoRightClick(node)
 					"Cancel")
 			end)
 	elseif menu == "folder" then
+		local function expandChildren(node, expand)
+			for k, child in pairs(node:GetChildNodes()) do
+				if child:GetFolder() then
+					child:SetExpanded(expand)
+					expandChildren(child, expand)
+				end
+			end
+		end
+
+		self.menu:AddOption("Expand recursively", function ()
+			node:SetExpanded(true)
+			expandChildren(node, true)
+		end)
+		self.menu:AddOption("Collapse recursively", function ()
+			node:SetExpanded(false)
+			expandChildren(node, false)
+		end)
+		self.menu:AddSpacer()
 		self.menu:AddOption("New file", function ()
 				Derma_StringRequestNoBlur("New file",
 					"",


### PR DESCRIPTION
The editor has made me angry many many times. I've decided to add a few QoL improvements to make working with it less stressing.

What I added:
- When using the file tree "Refresh" button, it will now remember what folders were expanded
- Added debounce to file search field (0.5s), because typing anything before would lag everything
- Added recursive expand/collapse to context menu for folders

I hope this helps other SF fans too, I am very happy with it.