### PR TITLE
Fix duplicate argument name in Color div function

### DIFF
--- a/lua/starfall/libs_sh/color.lua
+++ b/lua/starfall/libs_sh/color.lua
@@ -171,7 +171,7 @@ function color_meta.__mul(a, b)
 end
 
 --- Division metamethod
--- @param number|Color b Number or Color dividend
+-- @param number|Color a Number or Color dividend
 -- @param number|Color b Number or Color divisor
 -- @return Color Scaled color.
 function color_meta.__div(a, b)


### PR DESCRIPTION
Modified the documentation for `Color:__div` to not use duplicate argument names.