### PR TITLE
Fix clientside starfall instances not cleaning up after a fullupdate

### DIFF
--- a/lua/starfall/sflib.lua
+++ b/lua/starfall/sflib.lua
@@ -102,10 +102,12 @@ hook.Add("EntityRemoved","SF_CallOnRemove",function(ent)
 					for k, v in pairs(hooks) do
 						if v[2] then v[2](ent) end
 					end
+					removedHooks[ent] = nil
 				end
 			end)
+		elseif SERVER then
+			removedHooks[ent] = nil
 		end
-		removedHooks[ent] = nil
 	end
 end)
 function SF.CallOnRemove(ent, key, func, deferedfunc)


### PR DESCRIPTION
A starfall clientside instance fails to clean up after a fullupdate occurs. This is because the removedhook responsible for deinitialzing it is removed any time EntityRemoved is called. This is okay serverside, but clientside EntityRemoved can be called during a fullupdate. The entity still counts as valid, so the clientside instance is not removed by the fullupdate, however the removedhook is set to nil regardless, causing the clientside instance to now remain permanently.

The problem can be reproduced on current starfall by pasting a starfall with a clientside instance and then forcing a full update. (record a;stop or cl_fullupdate with sv_cheats 1). The clientside instance will remain after the chip's removal.
Video: https://cdn.discordapp.com/attachments/921945120167833613/1258172152721703094/2024-07-03_16-24-49.mp4?ex=668713a0&is=6685c220&hm=42b1b37adb0a3b7863ddd332aaf4a50470ef51d68141be20e3c2771deebb3a48&

# Before creating pull request
- Move all changes to **separate** branch (Don't use master of your fork).
- **Don't** reuse branches.
- **Don't** sync that branch after creating pull request unless it's really needed. (IE. upstream changed code structure).
- Test it and try fixing bugs ahead.
- If you know about any bugs, make sure to list them in PR message.
- Make sure pull request message informs about **ALL** the changes.
- Your pull request can be work-in-progress if you want others to help you with coding or give you  opinions, just make sure to state it's not ready.
- Try to avoid messing with whitespaces. (Setup your editor properly to follow our style).
- If you find whitespaces that don't follow our style you can fix them in separate commit.
- Read about [github flow](https://guides.github.com/introduction/flow/)
​

# Thank you

Thank you for contributing and helping StarfallEx community!