### PR TITLE
Add Player:kill()

### DIFF
--- a/lua/starfall/libs_sh/players.lua
+++ b/lua/starfall/libs_sh/players.lua
@@ -807,7 +807,9 @@ if SERVER then
 	function player_methods:kill()
 		local ent = getply(self)
 		checkpermission(instance, ent, "entities.setHealth")
-		ent:Kill()
+		if ent:Alive() then
+			ent:Kill()
+		end
 	end
 end
 

--- a/lua/starfall/libs_sh/players.lua
+++ b/lua/starfall/libs_sh/players.lua
@@ -800,6 +800,15 @@ if SERVER then
 		checkvalidnumber(val)
 		ent:SetFriction(math.Clamp(val/cvars.Number("sv_friction"),0,10))
 	end
+	
+	--- Kills the target.
+	--- Requires 'entities.setHealth' permission.
+	-- @server
+	function player_methods:kill()
+		local ent = getply(self)
+		checkpermission(instance, ent, "entities.setHealth")
+		ent:Kill()
+	end
 end
 
 --- Returns whether or not the player is pushing the key.


### PR DESCRIPTION
Kills a player when run. Requires entities.setHealth permission to use