### PR TITLE
Require either a HUD connection or the permission for `bass.play2D`

### DIFF
--- a/lua/starfall/libs_cl/bass.lua
+++ b/lua/starfall/libs_cl/bass.lua
@@ -163,10 +163,8 @@ end
 local function loadSound(path, flags, callback, loadFunc)
 	local is2D = not3D(flags)
 
-	if is2D then
-		if not SF.IsHUDActive(instance.entity) then 
-			checkpermission(instance, nil, "bass.play2D")
-		end
+	if is2D and not SF.IsHUDActive(instance.entity) then
+		checkpermission(instance, nil, "bass.play2D")
 	end
 
 	plyCount:use(instance.player, 1)

--- a/lua/starfall/libs_cl/bass.lua
+++ b/lua/starfall/libs_cl/bass.lua
@@ -164,8 +164,9 @@ local function loadSound(path, flags, callback, loadFunc)
 	local is2D = not3D(flags)
 
 	if is2D then
-		if not SF.IsHUDActive(instance.entity) then SF.Throw("Player isn't connected to HUD!", 2) end
-		checkpermission(instance, nil, "bass.play2D")
+		if not SF.IsHUDActive(instance.entity) then 
+			checkpermission(instance, nil, "bass.play2D")
+		end
 	end
 
 	plyCount:use(instance.player, 1)


### PR DESCRIPTION
Fixed 2D bass sounds requiring both a permission *and* a HUD connection to work.
It now requires one **or** the other.