### PR TITLE
Add Hologram:setCullMode()

### DIFF
--- a/lua/entities/starfall_hologram/cl_init.lua
+++ b/lua/entities/starfall_hologram/cl_init.lua
@@ -85,6 +85,11 @@ function ENT:Draw(flags)
 			clipCount = clipCount + 1
 		end
 	end
+	
+	local cullMode = self:GetCullMode()
+	if cullMode then
+		render.CullMode(MATERIAL_CULLMODE_CW)
+	end
 
 	local filter_mag, filter_min = selfTbl.filter_mag, selfTbl.filter_min
 	if filter_mag then render.PushFilterMag(filter_mag) end
@@ -96,6 +101,10 @@ function ENT:Draw(flags)
 		render.SuppressEngineLighting(false)
 	else
 		self:DrawModel(flags)
+	end
+	
+	if cullMode then
+		render.CullMode(MATERIAL_CULLMODE_CCW)
 	end
 	
 	if filter_mag then render.PopFilterMag() end

--- a/lua/entities/starfall_hologram/init.lua
+++ b/lua/entities/starfall_hologram/init.lua
@@ -18,6 +18,7 @@ function ENT:Initialize()
 	self:SetScale(Vector(1,1,1))
 	self:SetPlayerColorInternal(VECTOR_PLAYER_COLOR_DISABLED)
 	self:SetSuppressEngineLighting(false)
+	self:SetCullMode(false)
 
 	self.updateClip = false
 	self.AutomaticFrameAdvance = false

--- a/lua/entities/starfall_hologram/shared.lua
+++ b/lua/entities/starfall_hologram/shared.lua
@@ -13,6 +13,7 @@ function ENT:SetupDataTables()
 	self:NetworkVar( "Vector", 0, "Scale" )
 	self:NetworkVar( "Vector", 1, "PlayerColorInternal" )
 	self:NetworkVar( "Bool", 0, "SuppressEngineLighting" )
+	self:NetworkVar( "Bool", 1, "CullMode" )
 
 	if CLIENT then
 		self:NetworkVarNotify( "Scale", self.OnScaleChanged )

--- a/lua/starfall/libs_sh/hologram.lua
+++ b/lua/starfall/libs_sh/hologram.lua
@@ -484,6 +484,18 @@ function hologram_methods:setAnimation(animation, frame, rate)
 	end
 end
 
+--- Set the cull mode for a hologram.
+-- @shared
+-- @param number mode Cull mode. 0 for counter clock wise, 1 for clock wise
+function hologram_methods:setCullMode(mode)
+	checkluatype(mode, TYPE_NUMBER)
+
+	local holo = getholo(self)
+	checkpermission(instance, holo, "entities.setRenderProperty")
+
+	holo:SetCullMode(mode==1)
+end
+
 --- Applies engine effects to the hologram
 -- @shared
 -- @param number effect The effects to add. See EF Enums


### PR DESCRIPTION
Adds a function that allows for the cull direction of holograms to be changed without forcing the user to create a render hook