### PR TITLE
Fix client download/initialization failing in high lag

### DIFF
--- a/lua/autorun/netstream.lua
+++ b/lua/autorun/netstream.lua
@@ -4,7 +4,7 @@ AddCSLuaFile()
 
 net.Stream = {}
 net.Stream.SendSize = 20000 --This is the size of each packet to send
-net.Stream.Timeout = 10 --How long to wait for client response before cleaning up
+net.Stream.Timeout = 30 --How long to wait for client response before cleaning up
 net.Stream.MaxWriteStreams = 1024 --The maximum number of write data items to store
 net.Stream.MaxReadStreams = 128 --The maximum number of queued read data items to store
 net.Stream.MaxChunks = 3200 --Maximum number of pieces the stream can send to the server. 64 MB

--- a/lua/entities/starfall_processor/cl_init.lua
+++ b/lua/entities/starfall_processor/cl_init.lua
@@ -157,32 +157,11 @@ net.Receive("starfall_processor_download", function(len)
 			if not (IsValid(owner) or IsWorld(owner)) then return end
 			sfdata.proc = proc
 			sfdata.owner = owner
-			if ok then
+			proc.owner = owner
+			if ok and false then
 				proc:SetupFiles(sfdata)
 			else
-				-- create dummy instance
-				local instance = setmetatable({}, SF.Instance)
-				instance.entity = proc
-				instance.player = owner
-				instance.data = {}
-				instance.stackn = 0
-				instance.sfhooks = {}
-				instance.hooks = {}
-				instance.scripts = {}
-				instance.requires = {}
-				instance.permissionOverrides = {}
-				proc.instance = instance
-
-				local msg = "Failed to download Starfall chip #" .. sfdata.procindex ..  "'s code client-side: " .. tostring(err)
-				proc:Error{
-					message = msg,
-					traceback = ""
-				}
-
-				-- I don't know why, but it isn't sending a notification
-				if owner == LocalPlayer() then
-					notification.AddLegacy(msg, NOTIFY_ERROR, 6)
-				end
+				proc:Error({message = "Failed to download and initialize client: " .. tostring(err), traceback = "" })
 			end
 		end
 
@@ -191,7 +170,6 @@ net.Receive("starfall_processor_download", function(len)
 		else
 			SF.WaitForEntity(sfdata.ownerindex, sfdata.ownercreateindex, function(e) owner = e setup() end)
 		end
-
 		SF.WaitForEntity(sfdata.procindex, sfdata.proccreateindex, function(e) proc = e setup() end)
 	end)
 end)

--- a/lua/entities/starfall_processor/cl_init.lua
+++ b/lua/entities/starfall_processor/cl_init.lua
@@ -158,7 +158,7 @@ net.Receive("starfall_processor_download", function(len)
 			sfdata.proc = proc
 			sfdata.owner = owner
 			proc.owner = owner
-			if ok and false then
+			if ok then
 				proc:SetupFiles(sfdata)
 			else
 				proc:Error({message = "Failed to download and initialize client: " .. tostring(err), traceback = "" })

--- a/lua/starfall/sflib.lua
+++ b/lua/starfall/sflib.lua
@@ -10,10 +10,6 @@ local dgetmeta = debug.getmetatable
 local TypeID = TypeID
 local IsValid = FindMetaTable("Entity").IsValid
 
-hook.Add("Initialize", "SF_Initialize_SetNetstreamParams", function()
-	net.Stream.Timeout = 30
-end)
-
 -- Make sure this is done after metatables have been set
 hook.Add("InitPostEntity","SF_SanitizeTypeMetatables",function()
 	local function sanitizeTypeMeta(theType, myMeta)

--- a/lua/starfall/sflib.lua
+++ b/lua/starfall/sflib.lua
@@ -10,6 +10,10 @@ local dgetmeta = debug.getmetatable
 local TypeID = TypeID
 local IsValid = FindMetaTable("Entity").IsValid
 
+hook.Add("Initialize", "SF_Initialize_SetNetstreamParams", function()
+	net.Stream.Timeout = 30
+end)
+
 -- Make sure this is done after metatables have been set
 hook.Add("InitPostEntity","SF_SanitizeTypeMetatables",function()
 	local function sanitizeTypeMeta(theType, myMeta)

--- a/lua/starfall/transfer.lua
+++ b/lua/starfall/transfer.lua
@@ -21,10 +21,10 @@ function net.ReadStarfall(ply, callback)
 				sfdata.files = files
 				callback(true, sfdata)
 			else
-				callback(false, files)
+				callback(false, sfdata, files)
 			end
 		else
-			callback(false, "Net timeout")
+			callback(false, sfdata, "Net timeout")
 		end
 	end)
 
@@ -171,15 +171,15 @@ if SERVER then
 
 		updata.reading = true
 
-		net.ReadStarfall(ply, function(ok, sfdata)
+		net.ReadStarfall(ply, function(ok, sfdata, err)
 			if ok then
 				if #sfdata.mainfile > 0 then
 					sfdata.owner = ply
 					updata.callback(sfdata)
 				end
 			else
-				if uploaddata[ply]==updata then
-					SF.AddNotify(ply, "There was a problem uploading your code ("..sfdata.."). Try again in a second.", "ERROR", 7, "ERROR1")
+				if uploaddata[ply] == updata then
+					SF.AddNotify(ply, "There was a problem uploading your code (" .. err .. "). Try again in a second.", "ERROR", 7, "ERROR1")
 				end
 			end
 			uploaddata[ply] = nil

--- a/lua/weapons/gmod_tool/stools/starfall_processor.lua
+++ b/lua/weapons/gmod_tool/stools/starfall_processor.lua
@@ -69,7 +69,7 @@ else
 		SF.Editor.open()
 
 		if net.ReadBool() then
-			net.ReadStarfall(nil, function(ok, sfdata)
+			net.ReadStarfall(nil, function(ok, sfdata, err)
 				if ok then
 					local mainfile = sfdata.files[sfdata.mainfile]
 					sfdata.files[sfdata.mainfile] = nil
@@ -79,7 +79,7 @@ else
 					-- Add mainfile last so it gets focus
 					SF.Editor.openWithCode(sfdata.mainfile, mainfile, nil, false)
 				else
-					SF.AddNotify(LocalPlayer(), "Error downloading SF code. ("..sfdata..")", "ERROR", 7, "ERROR1")
+					SF.AddNotify(LocalPlayer(), "Error downloading SF code. (" .. err .. ")", "ERROR", 7, "ERROR1")
 				end
 			end)
 		end


### PR DESCRIPTION
- Increases netstream timeout to 30 seconds to actually fix the issue (for the most part)
- Throws an error when downloading fails now rather than silently failing with no explanation (for the owner only)