### PR TITLE
Update url_whitelist.lua (Add Nekoweb.org)

### DIFF
--- a/lua/starfall/permissions/providers_sh/url_whitelist.lua
+++ b/lua/starfall/permissions/providers_sh/url_whitelist.lua
@@ -249,3 +249,8 @@ simple [[autumn.revolt.chat]]
 --- Examples:
 ---  https://youtube.michaelbelgium.me/storage/5zrORMBb0-8.mp3
 simple [[youtube.michaelbelgium.me]]
+
+-- Nekoweb
+--- Examples:
+---  https://website.nekoweb.org/path/to/resource
+pattern [[([%w-_]+)%.nekoweb%.org/(.+)]]


### PR DESCRIPTION
Nekoweb.org is an alternative to Neocities. Nekoweb defers from letting sub-site admins / page owners to check who visited their website, when, or if they did at all. Nekoweb.org has a non-strict CORS policy, meaning on HTML pages (exclusively pages, not files or .php or something) other sources may load e.g. last.fm as a sidebar widget on someones website.