### PR TITLE
Added the instantaneous functions for physobj setAngleVelocity & setVelocity

### DIFF
--- a/lua/starfall/libs_sh/physobj.lua
+++ b/lua/starfall/libs_sh/physobj.lua
@@ -255,6 +255,19 @@ if SERVER then
 		phys:SetVelocity(vel)
 	end
 
+	--- Sets the instantaneous velocity of the physics object
+	-- @server
+	-- @param Vector vel The velocity vector to set it to
+	function physobj_methods:setVelocityInstantaneous(vel)
+
+		vel = vunwrap(vel)
+		checkvector(vel)
+
+		local phys = unwrap(self)
+		checkpermission(instance, phys:GetEntity(), "entities.setVelocity")
+		phys:SetVelocityInstantaneous(vel)
+	end
+
     --- Applies velocity to an object
     -- @server
     -- @param Vector vel The world velocity vector to apply
@@ -322,6 +335,19 @@ if SERVER then
 		checkpermission(instance, phys:GetEntity(), "entities.applyForce")
 
 		phys:AddAngleVelocity(angvel - phys:GetAngleVelocity())
+	end
+
+	--- Sets the specified instantaneous angular velocity on a physics object
+	-- @server
+	-- @param Vector angvel The new velocity to set velocity
+	function physobj_methods:setAngleVelocityInstantaneous(angvel)
+		angvel = vunwrap(angvel)
+		checkvector(angvel)
+
+		local phys = unwrap(self)
+		checkpermission(instance, phys:GetEntity(), "entities.applyForce")
+
+		phys:SetAngleVelocityInstantaneous(angvel)
 	end
 
 	--- Applies a angular velocity to an object


### PR DESCRIPTION
While browsing other addons code I noticed these physics object functions weren't in sf so I added them locally and tested them to see if they worked correctly (they do). 

It wasn't immediately obvious to me why these wouldn't be added regarding abuse as it is relatively easy to apply very similar results in regards to abuse with regular addVelocity/addAngleVelocity inside a think hook or something. 

I just found these added functions to be immediately useful for a few scripts I was working and I understand if it is prefered that the functions either need to be restricted more if added or not added in the first place (thought I would try my luck and see what your opinion is on having this added).

Cheers