### PR TITLE
Localize SysTime for sethook

### DIFF
--- a/lua/starfall/instance.lua
+++ b/lua/starfall/instance.lua
@@ -505,6 +505,8 @@ local function safeThrow(self, msg, nocatch, force)
 	end
 end
 
+local SysTime = SysTime
+
 function SF.Instance:checkCpu()
 	if self.run ~= self.runWithOps then return end
 	self.cpu_total = SysTime() - self.start_time
@@ -522,8 +524,6 @@ local function xpcall_callback(err)
 	end
 	return err
 end
-
-local SysTime = SysTime
 
 --- Internal function - do not call.
 -- Runs a function while incrementing the instance ops coutner.

--- a/lua/starfall/instance.lua
+++ b/lua/starfall/instance.lua
@@ -6,6 +6,7 @@
 
 local dsethook, dgethook = debug.sethook, debug.gethook
 local dgetmeta = debug.getmetatable
+local SysTime = SysTime
 
 if SERVER then
 	SF.cpuQuota = CreateConVar("sf_timebuffer", 0.005, FCVAR_ARCHIVE, "The max average the CPU time can reach.")
@@ -504,8 +505,6 @@ local function safeThrow(self, msg, nocatch, force)
 		SF.Throw(msg, 3, nocatch)
 	end
 end
-
-local SysTime = SysTime
 
 function SF.Instance:checkCpu()
 	if self.run ~= self.runWithOps then return end

--- a/lua/starfall/instance.lua
+++ b/lua/starfall/instance.lua
@@ -523,6 +523,8 @@ local function xpcall_callback(err)
 	return err
 end
 
+local SysTime = SysTime
+
 --- Internal function - do not call.
 -- Runs a function while incrementing the instance ops coutner.
 -- This does no setup work and shouldn't be called by client code


### PR DESCRIPTION
I have not tested the performance gains from doing this, but if sethook runs as hot as I think it does, I'd imagine this would have some effect