### PR TITLE
Allow ignorez and vertexlitgeneric image mat params

### DIFF
--- a/lua/starfall/libs_cl/material.lua
+++ b/lua/starfall/libs_cl/material.lua
@@ -555,7 +555,7 @@ function material_library.create(shader)
 	return wrap(m)
 end
 
-local image_params = {["nocull"] = true,["alphatest"] = true,["mips"] = true,["noclamp"] = true,["smooth"] = true}
+local image_params = {["nocull"] = true,["alphatest"] = true,["mips"] = true,["noclamp"] = true,["smooth"] = true,["ignorez"] = true,["vertexlitgeneric"] = true}
 --- Creates a .jpg or .png material from file
 --- Can't be modified
 -- @param string path The path to the image file, must be a jpg or png image


### PR DESCRIPTION
I'm not sure why these weren't in there already. I'd argue ignorez in particular is very useful, since to draw textured rects (with custom image materials) in render targets, they need to have ignoreZ or they'll get cut off if the resolution height is below 1024.