### PR TITLE
Allow multiple collision listeners per entity, for all instances, regardless of old ent:PhysicsCollide()

### DIFF
--- a/lua/starfall/libs_sv/entities.lua
+++ b/lua/starfall/libs_sv/entities.lua
@@ -6,9 +6,6 @@ local IsValid = FindMetaTable("Entity").IsValid
 local IsValidPhys = FindMetaTable("PhysObj").IsValid
 local isentity = isentity
 
-local huge = math.huge
-local abs = math.abs
-
 -- Register privileges
 registerprivilege("entities.applyDamage", "Apply damage", "Allows the user to apply damage to an entity", { entities = {} })
 registerprivilege("entities.applyForce", "Apply force", "Allows the user to apply force to an entity", { entities = {} })
@@ -40,7 +37,7 @@ SF.GlobalCollisionListeners = {
 	__index = {
 		create = function(self, ent)
 			local listenertable = {}
-		
+
 			local queue = {}
 			local nqueue = 0
 			local function collisionQueueProcess()
@@ -57,17 +54,17 @@ SF.GlobalCollisionListeners = {
 				end
 				nqueue = 0
 			end
-		
+
 			local function collisionQueueCallback(ent, data)
 				nqueue = nqueue + 1
 				queue[nqueue] = data
 				if nqueue==1 then timer.Simple(0, collisionQueueProcess) end
 			end
-		
+
 			if ent:IsScripted() then
 				local oldPhysicsCollide = ent.PhysicsCollide or base_physicscollide
 				ent.SF_OldPhysicsCollide = oldPhysicsCollide
-		
+
 				function ent:PhysicsCollide(data, phys)
 					oldPhysicsCollide(self, data, phys)
 					collisionQueueCallback(self, data)
@@ -94,7 +91,7 @@ SF.GlobalCollisionListeners = {
 				else
 					ent:RemoveCallback("PhysicsCollide", ent.SF_CollisionCallback)
 				end
-		
+
 				SF.RemoveCallOnRemove(ent, "RemoveCollisionListeners")
 			end
 		end,

--- a/lua/starfall/libs_sv/entities.lua
+++ b/lua/starfall/libs_sv/entities.lua
@@ -555,6 +555,23 @@ function ents_methods:removeCollisionListener(name)
 	collisionListenerInstanceInfosPerEnt[ent] = nil
 end
 
+--- Checks if an entity has a collision listener
+--- Only checks for listeners created by this chip
+-- @param string? name The name of the collision listener to check for. If nil, will check if any listeners exist.
+function ents_methods:hasCollisionListener( name )
+	local ent = getent(self)
+	if name ~= nil then checkluatype(name, TYPE_STRING) end
+
+	local infosPerInstance = collisionListenerInstanceInfosPerEnt[ent]
+	if not infosPerInstance then return false end
+
+	local listenerInfo = infosPerInstance[instance]
+	if not listenerInfo then return false end
+	if name == nil then return true end -- When listenerInfo ~= nil, there's at least one listener
+
+	return listenerInfo.listeners[name] ~= nil
+end
+
 --- Sets whether an entity's shadow should be drawn
 -- @param boolean draw Whether the shadow should draw
 function ents_methods:setDrawShadow(draw)

--- a/lua/starfall/libs_sv/entities.lua
+++ b/lua/starfall/libs_sv/entities.lua
@@ -572,6 +572,30 @@ function ents_methods:hasCollisionListener( name )
 	return listenerInfo.listeners[name] ~= nil
 end
 
+--- Returns a table of all collision listener names
+--- Only returns listeners created by this chip
+--- Nameless listeners will not be included
+function ents_methods:getCollisionListenerNames()
+	local ent = getent(self)
+
+	local infosPerInstance = collisionListenerInstanceInfosPerEnt[ent]
+	if not infosPerInstance then return {} end
+
+	local listenerInfo = infosPerInstance[instance]
+	if not listenerInfo then return {} end
+
+	local listeners = listenerInfo.listeners
+	local names = {}
+
+	for name in pairs(listeners) do
+		if type(name) == "string" then
+			names[#names + 1] = name
+		end
+	end
+
+	return names
+end
+
 --- Sets whether an entity's shadow should be drawn
 -- @param boolean draw Whether the shadow should draw
 function ents_methods:setDrawShadow(draw)

--- a/lua/starfall/libs_sv/entities.lua
+++ b/lua/starfall/libs_sv/entities.lua
@@ -48,7 +48,7 @@ SF.GlobalCollisionListeners = {
 					for _, listener in ipairs(listenertable) do
 						local instance = listener.instance
 						for i=1, nqueue do
-							listener:run(SF.StructWrapper(instance, queue[i], "CollisionData"))
+							listener:run(instance, SF.StructWrapper(instance, queue[i], "CollisionData"))
 						end
 					end
 				end

--- a/lua/starfall/libs_sv/entities.lua
+++ b/lua/starfall/libs_sv/entities.lua
@@ -42,24 +42,26 @@ SF.GlobalCollisionListeners = {
 			local listenertable = {}
 		
 			local queue = {}
+			local nqueue = 0
 			local function collisionQueueProcess()
 				if IsValid(ent) then
 					for _, listener in ipairs(listenertable) do
 						local instance = listener.instance
-						for i=1, #queue do
+						for i=1, nqueue do
 							listener:run(SF.StructWrapper(instance, queue[i], "CollisionData"))
 						end
 					end
 				end
-				for i=1, #queue do
+				for i=1, nqueue do
 					queue[i] = nil
 				end
+				nqueue = 0
 			end
 		
 			local function collisionQueueCallback(ent, data)
-				local i = #queue+1
-				queue[i] = data
-				if i==1 then timer.Simple(0, collisionQueueProcess) end
+				nqueue = nqueue + 1
+				queue[nqueue] = data
+				if nqueue==1 then timer.Simple(0, collisionQueueProcess) end
 			end
 		
 			if ent:IsScripted() then

--- a/lua/starfall/libs_sv/entities.lua
+++ b/lua/starfall/libs_sv/entities.lua
@@ -83,7 +83,7 @@ SF.GlobalCollisionListeners = {
 			if entlisteners==nil then return end
 			self.listeners[ent] = nil
 			for _, listener in ipairs(entlisteners) do
-				listener.manager:free(ent, listener)
+				listener.manager:free(ent)
 			end
 			if IsValid(ent) then
 				local oldPhysicsCollide = ent.SF_OldPhysicsCollide
@@ -137,7 +137,7 @@ SF.InstanceCollisionListeners = {
 				listener.instance = self.instance
 				self.hooksPerEnt[ent] = listener
 
-				globalListeners:add(listener)
+				globalListeners:add(ent, listener)
 				created = true
 			elseif not listener:exists(name) then
 				collisionListenerLimit:checkuse(self.instance.player, 1)
@@ -156,21 +156,23 @@ SF.InstanceCollisionListeners = {
 				listener:remove(name)
 				collisionListenerLimit:free(self.instance.player, 1)
 				if listener:isEmpty() then
-					globalListeners:remove(listener)
 					self.hooksPerEnt[ent] = nil
+					globalListeners:remove(ent, listener)
 				end
 			end
 		end,
-		free = function(self, ent, listener)
-			collisionListenerLimit:free(self.instance.player, listener.n)
-			self.hooksPerEnt[ent] = nil
+		free = function(self, ent)
+			local listener = self.hooksPerEnt[ent]
+			if listener then
+				collisionListenerLimit:free(self.instance.player, listener.n)
+				self.hooksPerEnt[ent] = nil
+			end
 		end,
 		destroy = function(self)
 			for ent, listener in pairs(self.hooksPerEnt) do
 				collisionListenerLimit:free(self.instance.player, listener.n)
 				self.hooksPerEnt[ent] = nil
-
-				globalListeners:remove(listener)
+				globalListeners:remove(ent, listener)
 			end
 		end
 	},

--- a/lua/starfall/libs_sv/entities.lua
+++ b/lua/starfall/libs_sv/entities.lua
@@ -99,7 +99,7 @@ instance:AddHook("deinitialize", function()
 		if not listenersPerInstance then continue end -- May be nil if the entity was removed before deinitialization (due to the SF.CallOnRemove())
 
 		local listeners = listenersPerInstance[instance]
-		if listeners then continue end -- Shouldn't ever be nil, but for in case
+		if listeners then continue end -- Shouldn't be nil at this point, but for in case
 
 		for name in pairs(listeners) do
 			collisionListenerLimit:free(instance.player, 1)

--- a/lua/starfall/sflib.lua
+++ b/lua/starfall/sflib.lua
@@ -909,6 +909,9 @@ do
 					self.pairs = self.dirtyPairs
 				end
 			end,
+			exists = function(self, index)
+				return self.hooks[index]~=nil or self.hookstoadd[index]~=nil
+			end,
 			isEmpty = function(self)
 				return self.n==0
 			end,


### PR DESCRIPTION
Similar to #1865, but allows entities that already have `:PhysicsCollide()` from glua to still have starfall collision listeners. Also allows for different chip instances to have their own listeners on the same entity.

Bonus side effect due to how `addCollisions()` was reworked: previously, if two entities had collision listeners, any time either of them made a collision, it would call both listeners, resulting in callbacks being called for the collisions of entities they weren't associated with. This issue is now resolved with the rewrite.