### PR TITLE
fix holograms not fixing renderbounds after fullupdate

### DIFF
--- a/lua/entities/starfall_hologram/cl_init.lua
+++ b/lua/entities/starfall_hologram/cl_init.lua
@@ -185,17 +185,22 @@ end)
 
 -- For when the hologram matrix gets cleared
 hook.Add("NetworkEntityCreated", "starfall_hologram_rescale", function(holo)
+	local sf_userrenderbounds = holo.sf_userrenderbounds
 	if holo.IsSFHologram then
 		if holo.HoloMatrix then
 			holo:EnableMatrix("RenderMultiply", holo.HoloMatrix)
 		end
 			
-		local sf_userrenderbounds = holo.sf_userrenderbounds
-		if sf_userrenderbounds then
-			holo:SetRenderBounds(sf_userrenderbounds[1], sf_userrenderbounds[2])
-		else
-			holo:OnScaleChanged(nil, nil, holo:GetScale())
+		if not sf_userrenderbounds then		
+			local mins, maxs = self:GetModelBounds()
+			if mins then
+				self:SetRenderBounds(mins * scale, maxs * scale)
+			end
 		end
+	end
+
+	if sf_userrenderbounds then
+		holo:SetRenderBounds(sf_userrenderbounds[1], sf_userrenderbounds[2])
 	end
 end)
 

--- a/lua/entities/starfall_hologram/cl_init.lua
+++ b/lua/entities/starfall_hologram/cl_init.lua
@@ -185,23 +185,24 @@ end)
 
 -- For when the hologram matrix gets cleared
 hook.Add("NetworkEntityCreated", "starfall_hologram_rescale", function(holo)
-	local sf_userrenderbounds = holo.sf_userrenderbounds
-	if holo.IsSFHologram then
-		if holo.HoloMatrix then
-			holo:EnableMatrix("RenderMultiply", holo.HoloMatrix)
-		end
-			
-		if not sf_userrenderbounds then		
-			local mins, maxs = self:GetModelBounds()
-			if mins then
-				self:SetRenderBounds(mins * scale, maxs * scale)
-			end
-		end
-	end
-
-	if sf_userrenderbounds then
-		holo:SetRenderBounds(sf_userrenderbounds[1], sf_userrenderbounds[2])
-	end
+        local sf_userrenderbounds = holo.sf_userrenderbounds
+        if holo.IsSFHologram then
+            if holo.HoloMatrix then
+                holo:EnableMatrix("RenderMultiply", holo.HoloMatrix)
+            end
+    
+            if not sf_userrenderbounds then        
+                local mins, maxs = holo:GetModelBounds()
+                if mins then
+                    local scale = holo:GetScale()
+                    holo:SetRenderBounds(mins * scale, maxs * scale)
+                end
+            end
+        end
+    
+        if sf_userrenderbounds then
+            holo:SetRenderBounds(sf_userrenderbounds[1], sf_userrenderbounds[2])
+        end
 end)
 
 local function ShowHologramOwners()

--- a/lua/entities/starfall_hologram/cl_init.lua
+++ b/lua/entities/starfall_hologram/cl_init.lua
@@ -185,12 +185,17 @@ end)
 
 -- For when the hologram matrix gets cleared
 hook.Add("NetworkEntityCreated", "starfall_hologram_rescale", function(holo)
-	if holo.IsSFHologram and holo.HoloMatrix then
-		holo:EnableMatrix("RenderMultiply", holo.HoloMatrix)
-	end
-	local sf_userrenderbounds = holo.sf_userrenderbounds
-	if sf_userrenderbounds then
-		holo:SetRenderBounds(sf_userrenderbounds[1], sf_userrenderbounds[2])
+	if holo.IsSFHologram then
+		if holo.HoloMatrix then
+			holo:EnableMatrix("RenderMultiply", holo.HoloMatrix)
+		end
+			
+		local sf_userrenderbounds = holo.sf_userrenderbounds
+		if sf_userrenderbounds then
+			holo:SetRenderBounds(sf_userrenderbounds[1], sf_userrenderbounds[2])
+		else
+			holo:OnScaleChanged(nil, nil, holo:GetScale())
+		end
 	end
 end)
 


### PR DESCRIPTION
#1876 

i notice before that the existing code for setting render bounds didnt check for if the networkentitycreated ent was a hologram? is this hook in hologram cl_init also for custom props too?

# Before creating pull request
- Move all changes to **separate** branch (Don't use master of your fork).
- **Don't** reuse branches.
- **Don't** sync that branch after creating pull request unless it's really needed. (IE. upstream changed code structure).
- Test it and try fixing bugs ahead.
- If you know about any bugs, make sure to list them in PR message.
- Make sure pull request message informs about **ALL** the changes.
- Your pull request can be work-in-progress if you want others to help you with coding or give you  opinions, just make sure to state it's not ready.
- Try to avoid messing with whitespaces. (Setup your editor properly to follow our style).
- If you find whitespaces that don't follow our style you can fix them in separate commit.
- Read about [github flow](https://guides.github.com/introduction/flow/)
​

# Thank you

Thank you for contributing and helping StarfallEx community!