### PR TITLE
fix not being able to set back to default rendergoup setting

### DIFF
--- a/lua/entities/starfall_hologram/cl_init.lua
+++ b/lua/entities/starfall_hologram/cl_init.lua
@@ -132,8 +132,7 @@ end
 function ENT:OnRenderGroupChanged(name, old, group)
 	if group == -1 then
 		self.RenderGroup = nil
-	else
-		if not SF.allowedRenderGroups[group] then return end
+	elseif SF.allowedRenderGroups[group] then
 		self.RenderGroup = group
 	end
 end

--- a/lua/entities/starfall_hologram/cl_init.lua
+++ b/lua/entities/starfall_hologram/cl_init.lua
@@ -130,10 +130,10 @@ function ENT:OnCullModeChanged()
 end
 
 function ENT:OnRenderGroupChanged(name, old, group)
-	if not SF.allowedRenderGroups[group] then return end
 	if group == -1 then
 		self.RenderGroup = nil
 	else
+		if not SF.allowedRenderGroups[group] then return end
 		self.RenderGroup = group
 	end
 end


### PR DESCRIPTION
Moves the check for valid rendergroups so that it does not prevent the default value from being set (-1 is not considered a valid rendergoup, since it's just being used as a networking trick)