### PR TITLE
Add funcs for local position/angles and add Entity:setLightingOriginEntity

### DIFF
--- a/lua/starfall/libs_sh/entities.lua
+++ b/lua/starfall/libs_sh/entities.lua
@@ -1041,6 +1041,13 @@ function ents_methods:getPos()
 	return vwrap(getent(self):GetPos())
 end
 
+--- Returns the position of the entity, local to its parent
+-- @shared
+-- @return Vector The position vector
+function ents_methods:getLocalPos()
+	return vwrap(getent(self):GetLocalPos())
+end
+
 --- Returns how submerged the entity is in water
 -- @shared
 -- @return number The water level. 0 none, 1 slightly, 2 at least halfway, 3 all the way
@@ -1232,6 +1239,13 @@ end
 -- @return Angle The angle
 function ents_methods:getAngles()
 	return awrap(getent(self):GetAngles())
+end
+
+--- Returns the angle of the entity, local to its parent
+-- @shared
+-- @return Angle The angle
+function ents_methods:getLocalAngles()
+	return awrap(getent(self):GetLocalAngles())
 end
 
 --- Returns the mass of the entity

--- a/lua/starfall/libs_sh/hologram.lua
+++ b/lua/starfall/libs_sh/hologram.lua
@@ -212,10 +212,9 @@ else
 	-- @param Vector vec New position
 	function hologram_methods:setPos(vec)
 		local holo = getholo(self)
-		local pos = SF.clampPos(vunwrap(vec))
 		checkpermission(instance, holo, "hologram.setRenderProperty")
 
-		holo:SetPos(pos)
+		holo:SetPos(SF.clampPos(vunwrap(vec)))
 
 		local sfParent = holo.sfParent
 		if sfParent and IsValid(sfParent.parent) then
@@ -228,10 +227,9 @@ else
 	-- @param Angle ang New angles
 	function hologram_methods:setAngles(ang)
 		local holo = getholo(self)
-		local angle = aunwrap(ang)
 		checkpermission(instance, holo, "hologram.setRenderProperty")
 
-		holo:SetAngles(angle)
+		holo:SetAngles(aunwrap(ang))
 		
 		local sfParent = holo.sfParent
 		if sfParent and IsValid(sfParent.parent) then
@@ -244,10 +242,9 @@ else
 	-- @param Vector vec New position
 	function hologram_methods:setLocalPos(vec)
 		local holo = getholo(self)
-		local pos = SF.clampPos(vunwrap(vec))
 		checkpermission(instance, holo, "hologram.setRenderProperty")
 
-		holo:SetLocalPos(pos)
+		holo:SetLocalPos(SF.clampPos(vunwrap(vec)))
 
 		local sfParent = holo.sfParent
 		if sfParent and IsValid(sfParent.parent) then
@@ -260,10 +257,9 @@ else
 	-- @param Angle ang New angles
 	function hologram_methods:setLocalAngles(ang)
 		local holo = getholo(self)
-		local angle = aunwrap(ang)
 		checkpermission(instance, holo, "hologram.setRenderProperty")
 
-		holo:SetLocalAngles(angle)
+		holo:SetLocalAngles(aunwrap(ang))
 		
 		local sfParent = holo.sfParent
 		if sfParent and IsValid(sfParent.parent) then

--- a/lua/starfall/libs_sh/hologram.lua
+++ b/lua/starfall/libs_sh/hologram.lua
@@ -242,7 +242,7 @@ else
 	--- Sets the hologram's position local to its parent.
 	-- @shared
 	-- @param Vector vec New position
-	function hologram_methods:setPos(vec)
+	function hologram_methods:setLocalPos(vec)
 		local holo = getholo(self)
 		local pos = SF.clampPos(vunwrap(vec))
 		checkpermission(instance, holo, "hologram.setRenderProperty")
@@ -258,7 +258,7 @@ else
 	--- Sets the hologram's angles local to its parent.
 	-- @shared
 	-- @param Angle ang New angles
-	function hologram_methods:setAngles(ang)
+	function hologram_methods:setLocalAngles(ang)
 		local holo = getholo(self)
 		local angle = aunwrap(ang)
 		checkpermission(instance, holo, "hologram.setRenderProperty")

--- a/lua/starfall/libs_sh/hologram.lua
+++ b/lua/starfall/libs_sh/hologram.lua
@@ -238,6 +238,38 @@ else
 			sfParent:updateTransform()
 		end
 	end
+	
+	--- Sets the hologram's position local to its parent.
+	-- @shared
+	-- @param Vector vec New position
+	function hologram_methods:setPos(vec)
+		local holo = getholo(self)
+		local pos = SF.clampPos(vunwrap(vec))
+		checkpermission(instance, holo, "hologram.setRenderProperty")
+
+		holo:SetLocalPos(pos)
+
+		local sfParent = holo.sfParent
+		if sfParent and IsValid(sfParent.parent) then
+			sfParent:updateTransform()
+		end
+	end
+
+	--- Sets the hologram's angles local to its parent.
+	-- @shared
+	-- @param Angle ang New angles
+	function hologram_methods:setAngles(ang)
+		local holo = getholo(self)
+		local angle = aunwrap(ang)
+		checkpermission(instance, holo, "hologram.setRenderProperty")
+
+		holo:SetLocalAngles(angle)
+		
+		local sfParent = holo.sfParent
+		if sfParent and IsValid(sfParent.parent) then
+			sfParent:updateTransform()
+		end
+	end
 
 	--- Sets the texture filtering function when viewing a close texture
 	-- @client

--- a/lua/starfall/libs_sv/entities.lua
+++ b/lua/starfall/libs_sv/entities.lua
@@ -546,44 +546,32 @@ end
 -- @param Vector vec New position
 function ents_methods:setPos(vec)
 	local ent = getent(self)
-
-	vec = vunwrap(vec)
 	checkpermission(instance, ent, "entities.setPos")
-
-	ent:SetPos(SF.clampPos(vec))
+	ent:SetPos(SF.clampPos(vunwrap(vec)))
 end
 
 --- Sets the entity's angles
 -- @param Angle ang New angles
 function ents_methods:setAngles(ang)
 	local ent = getent(self)
-
-	ang = aunwrap(ang)
 	checkpermission(instance, ent, "entities.setAngles")
-
-	ent:SetAngles(ang)
+	ent:SetAngles(aunwrap(ang))
 end
 
 --- Sets the entity's position local to its parent
 -- @param Vector vec New position
 function ents_methods:setLocalPos(vec)
 	local ent = getent(self)
-
-	vec = vunwrap(vec)
 	checkpermission(instance, ent, "entities.setPos")
-
-	ent:SetLocalPos(vec)
+	ent:SetLocalPos(SF.clampPos(vunwrap(vec)))
 end
 
 --- Sets the entity's angles local to its parent
 -- @param Angle ang New angles
 function ents_methods:setLocalAngles(ang)
 	local ent = getent(self)
-
-	ang = aunwrap(ang)
 	checkpermission(instance, ent, "entities.setAngles")
-
-	ent:SetLocalAngles(ang)
+	ent:SetLocalAngles(aunwrap(ang))
 end
 
 --- Sets the entity's linear velocity. Physics entities, use physobj:setVelocity

--- a/lua/starfall/libs_sv/entities.lua
+++ b/lua/starfall/libs_sv/entities.lua
@@ -564,6 +564,28 @@ function ents_methods:setAngles(ang)
 	ent:SetAngles(ang)
 end
 
+--- Sets the entity's position local to its parent
+-- @param Vector vec New position
+function ents_methods:setLocalPos(vec)
+	local ent = getent(self)
+
+	vec = vunwrap(vec)
+	checkpermission(instance, ent, "entities.setPos")
+
+	ent:SetLocalPos(vec)
+end
+
+--- Sets the entity's angles local to its parent
+-- @param Angle ang New angles
+function ents_methods:setAngles(ang)
+	local ent = getent(self)
+
+	ang = aunwrap(ang)
+	checkpermission(instance, ent, "entities.setAngles")
+
+	ent:SetLocalAngles(ang)
+end
+
 --- Sets the entity's linear velocity. Physics entities, use physobj:setVelocity
 -- @param Vector vel New velocity
 function ents_methods:setVelocity(vel)
@@ -1090,6 +1112,14 @@ function ents_methods:getVar(key)
 	checkpermission(instance, ent, "entities.getTable")
 	local var = ent:GetVar(key)
 	return istable(var) and instance.Sanitize(var) or owrap(var)
+end
+
+--- Sets the entity to be used as the light origin position for this entity.
+-- @param Entity|nil lightOrigin The lighting entity.
+function ents_methods:setLightingOriginEntity(lightOrigin)
+	local ent = getent(self)
+	checkpermission(instance, ent, "entities.setRenderProperty")
+	ent:SetLightingOriginEntity(getent(lightOrigin))
 end
 
 end

--- a/lua/starfall/libs_sv/entities.lua
+++ b/lua/starfall/libs_sv/entities.lua
@@ -577,7 +577,7 @@ end
 
 --- Sets the entity's angles local to its parent
 -- @param Angle ang New angles
-function ents_methods:setAngles(ang)
+function ents_methods:setLocalAngles(ang)
 	local ent = getent(self)
 
 	ang = aunwrap(ang)


### PR DESCRIPTION
Adds a few new ent and hologram functions for setting and getting local transformations, tends to be significantly faster than doing Entity:setPos(Parent:localToWorld()) and has very little precision loss by comparison

Also adds Entity:setLightingOriginEntity which can be useful as a sv function to stop some models from becoming black due to their lighting origins slipping underground