### PR TITLE
Use correct convar for client-side owner cpu quota

### DIFF
--- a/lua/starfall/instance.lua
+++ b/lua/starfall/instance.lua
@@ -573,7 +573,7 @@ function SF.Instance:setCheckCpu(runWithOps)
 			end
 		end
 
-		self.cpuQuota = (SERVER or LocalPlayer() ~= player) and SF.cpuQuota:GetFloat() or SF.cpuOwnerQuota:GetFloat()
+		self.cpuQuota = (SERVER or LocalPlayer() ~= self.player) and SF.cpuQuota:GetFloat() or SF.cpuOwnerQuota:GetFloat()
 		self.cpuQuotaRatio = 1 / SF.cpuBufferN:GetInt()
 	else
 		self.run = SF.Instance.runWithoutOps


### PR DESCRIPTION
This fixes the check to see if we should use the normal CPU quota convar, or use the owner CPU quota convar
`player` was not defined as a local or argument in the function, defaulting to the built-in **table**, `player`

Before (top 2) and after (bottom 2) below:
![before and after screenshot of cpuMax function](https://github.com/user-attachments/assets/4d259a43-9928-47e5-9a78-ce149b806117)

Convars:
![sf_timebuffer convars](https://github.com/user-attachments/assets/73d88bf0-290d-4936-9938-ec895c47eac5)

