### PR TITLE
Implemented SF version of GM PlayerBindPress hook

### DIFF
--- a/lua/starfall/libs_sh/input.lua
+++ b/lua/starfall/libs_sh/input.lua
@@ -114,6 +114,19 @@ else
 	-- @param number button Number of the button
 	SF.hookAdd("PlayerButtonDown", "inputpressed", CheckButtonPerms)
 
+	--- Called when a keybind is pressed
+	-- @client
+	-- @name inputBindPressed
+	-- @class hook
+	-- @param Player ply Player pressing the keybind
+	-- @param string bind Name of keybind pressed
+	SF.hookAdd("PlayerBindPress", "inputbindpressed", function(instance, ply, bind)
+		if haspermission(instance, nil, "input") then
+			return true, {ply, bind}
+		end
+		return false
+	end)
+	
 	--- Called when a button is released
 	-- @client
 	-- @name inputReleased
@@ -164,21 +177,6 @@ function wpanel:OnMouseWheeled(delta)
 		end
 	end
 end
-
---- Called when a keybind is pressed
--- @client
--- @name playerBindPressed
--- @class hook
--- @param Player ply Player pressing the keybind
--- @param string bind Name of keybind pressed
--- @param boolean pressed If the key is pressed. This will always return true as it is a GMod bug.
-SF.hookAdd("PlayerBindPress", "playerbindpressed", function(instance, ply, bind, pressed)
-	if haspermission(instance, nil, "input") then
-		return true, {ply, bind, pressed}
-	else
-		return false
-	end
-end)
 
 --- Input library.
 -- @name input

--- a/lua/starfall/libs_sh/input.lua
+++ b/lua/starfall/libs_sh/input.lua
@@ -165,6 +165,21 @@ function wpanel:OnMouseWheeled(delta)
 	end
 end
 
+--- Called when a keybind is pressed
+-- @client
+-- @name playerBindPressed
+-- @class hook
+-- @param Player ply Player pressing the keybind
+-- @param string bind Name of keybind pressed
+-- @param boolean pressed If the key is pressed. This will always return true as it is a GMod bug.
+SF.hookAdd("PlayerBindPress", "playerbindpressed", function(instance, ply, bind, pressed)
+	if haspermission(instance, nil, "input") then
+		return true, {ply, bind, pressed}
+	else
+		return false
+	end
+end)
+
 --- Input library.
 -- @name input
 -- @class library

--- a/lua/starfall/libs_sh/input.lua
+++ b/lua/starfall/libs_sh/input.lua
@@ -113,19 +113,6 @@ else
 	-- @class hook
 	-- @param number button Number of the button
 	SF.hookAdd("PlayerButtonDown", "inputpressed", CheckButtonPerms)
-
-	--- Called when a keybind is pressed
-	-- @client
-	-- @name inputBindPressed
-	-- @class hook
-	-- @param Player ply Player pressing the keybind
-	-- @param string bind Name of keybind pressed
-	SF.hookAdd("PlayerBindPress", "inputbindpressed", function(instance, ply, bind)
-		if haspermission(instance, nil, "input") then
-			return true, {ply, bind}
-		end
-		return false
-	end)
 	
 	--- Called when a button is released
 	-- @client
@@ -134,6 +121,19 @@ else
 	-- @param number button Number of the button
 	SF.hookAdd("PlayerButtonUp", "inputreleased", CheckButtonPerms)
 end
+
+--- Called when a keybind is pressed
+-- @client
+-- @name inputBindPressed
+-- @class hook
+-- @param Player ply Player pressing the keybind
+-- @param string bind Name of keybind pressed
+SF.hookAdd("PlayerBindPress", "inputbindpressed", function(instance, ply, bind)
+	if haspermission(instance, nil, "input") then
+		return true, {ply, bind}
+	end
+	return false
+end)
 
 --- Called when the mouse is moved
 -- @client


### PR DESCRIPTION
This pr is to add the PlayerBindPress hook to SF named playerBindPressed to have the option to run code on specific binds. I've tested it to the best of my ability, however, I would ask that another person ensures the permissions are setup properly before merging it.

There is a known bug with the PlayerBindPress hook that is mentioned for the "pressed" parameter. This will always return true and is noted in this merge as well as in the GMod wiki.
(https://wiki.facepunch.com/gmod/GM:PlayerBindPress)
