### PR TITLE
Implement `--@performant` tag

### DIFF
--- a/lua/starfall/sflib.lua
+++ b/lua/starfall/sflib.lua
@@ -1099,7 +1099,16 @@ function SF.CompileString(script, identifier, handle_error)
 	if string.match(script, "%f[%w_]repeat%f[^%w_].*%f[%w_]continue%f[^%w_].*%f[%w_]until%f[^%w_]") then
 		return "Using 'continue' in a repeat-until loop has been banned due to a glua bug."
 	end
-	return CompileString(script, identifier, handle_error)
+
+	local compiledFunctions = {}
+	jit.attach(function(func)
+		table.insert(compiledFunctions, jit.util.funcinfo(func))
+	end, "bc")
+
+	local func = CompileString(script, identifier, handle_error)
+	jit.attach(function() end, "bc")
+
+	return func, compiledFunctions
 end
 
 --- The safest write file function


### PR DESCRIPTION
# What is this
The `--@performant` is a tag that can be used on functions that do a lot of logic/math to improve their performance by removing the debug hook(cpu checks) before their execution and adding it back afterward.

Now, if there wouldn't be any restrictions, this could easily be abused.
So to for the `--@performant` tag to take action, these conditions must be met.
\- The function can't use `for`, `while`, `repeat` and `goto`
\- The function can't call another function
\- The function can't have any child functions
(Currently limited because else my code would die/the mapping I'm doing to verify functions would end up being incorrect)
\- The function must be global/on the `_G` table.
(Currently limited to this since I can't think of a good way to get a local function without it being a bad workaround)

The goal is it to end up allowing small functions to run without the cpu checks which greatly speeds up their execution time, while also trying to make sure that they can't freeze the game.

# Example
without and with it.

https://github.com/user-attachments/assets/aba5f26f-2a9a-43fc-990b-61420cb45d34

The Script used:
[starfall_particles.txt](https://github.com/user-attachments/files/18128186/starfall_particles.txt)

# Changes
\- Modified `SF.CompileString` to have a second return value
(a table that contains information about the compiled functions, similar to debug.getinfo)
\- Added `SF.Instance:readdCpuCheck()`
Restores the debug hook in the case it was removed.
\- Added `SF.Instance.CompileHighPerformance`
Implements the `--@performant` tag.
\- Modified `SF.Instance.Compile` to call `SF.Instance.CompileHighPerformance`

# ToDo
Things I have to do, before this is ready.

- [ ] Let `ValidateHighPerformanceFunction` account for comments.
- [ ] Go through all the code again and check the codestyle
- [ ] Somehow account for metatables since those could possibly make function calls?
- [ ] do a lot more testing