### PR TITLE
Remove coroutine.wait from cnextbot's RunBehaviour

### DIFF
--- a/lua/entities/starfall_cnextbot.lua
+++ b/lua/entities/starfall_cnextbot.lua
@@ -107,7 +107,6 @@ function ENT:RunBehaviour()
 			ent_tbl.approachPos = nil
 			ent_tbl.ReachCallbacks:run(ent_tbl.instance)
 		end
-		coroutine.wait( 1 )
 		coroutine.yield()
 	end
 end


### PR DESCRIPTION
Really shouldn't have been there in the first place. This is only there because I was copying the "Nextbot NPC Creation" tutorial from the GMod wiki and I was unexperienced, and didn't want to break anything.

The only thing this does right now is cause trouble for anyone wanting to make chaser nextbots or something with a path goal that updates regularly. It just causes the bot to stop for 1 second at bad times.

If performance is a concern, I think we should at least lower it to something like 33 or 66 ms.