### PR TITLE
Add input.isGameUIVisible

### DIFF
--- a/lua/starfall/libs_sh/input.lua
+++ b/lua/starfall/libs_sh/input.lua
@@ -389,5 +389,12 @@ function input_library.canLockControls()
 	return SF.IsHUDActive(instance.entity) and lockedControlCooldown + inputLockCooldown:GetFloat() <= CurTime()
 end
 
+--- Returns whether the game menu overlay ( main menu ) is open or not.
+-- @client
+-- @return boolean Whether the game menu overlay ( main menu ) is open or not
+function input_library.isGameUIVisible()
+	return gui.IsGameUIVisible()
+end
+
 
 end


### PR DESCRIPTION
Adds a function which allows Starfall to reliably tell if a user has their main menu open or not. Useful if the goal is to ignore button presses while a user is in the menu.