### PR TITLE
Normalize letter case for hook names

### DIFF
--- a/lua/starfall/libs_cl/midi.lua
+++ b/lua/starfall/libs_cl/midi.lua
@@ -27,7 +27,7 @@ end)
 --- Event hook for midi devices.  
 -- Everytime a midi device outputs a signal, the callback function on the hook is called.
 -- Read up on the MIDI protocol to make better sense of everything -> https://ccrma.stanford.edu/~craig/articles/linuxmidi/misc/essenmidi.html
--- @name midi
+-- @name MIDI
 -- @class hook
 -- @client
 -- @libtbl midi_library

--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -193,7 +193,7 @@ local function hudPrepareSafeArgs(instance, ...)
 end
 
 --- Called when a frame is requested to be drawn. Doesn't require a screen or HUD but only works on rendertargets. (2D Context)
--- @name renderoffscreen
+-- @name RenderOffscreen
 -- @class hook
 -- @client
 SF.hookAdd("PreRender", "renderoffscreen", function(instance)
@@ -205,7 +205,7 @@ SF.hookAdd("PreRender", "renderoffscreen", function(instance)
 end, cleanupRender)
 
 --- Called when a scene is requested to be drawn. This is used for the render.renderview function.
--- @name renderscene
+-- @name RenderScene
 -- @class hook
 -- @client
 -- @param Vector origin View origin
@@ -225,7 +225,7 @@ function(instance)
 end)
 
 --- Called before entities are drawn. You can't render anything, but you can edit hologram matrices before they are drawn.
--- @name hologrammatrix
+-- @name HologramMatrix
 -- @class hook
 -- @client
 SF.hookAdd("PreDrawOpaqueRenderables", "hologrammatrix", function(instance, drawdepth, drawskybox)
@@ -233,13 +233,13 @@ SF.hookAdd("PreDrawOpaqueRenderables", "hologrammatrix", function(instance, draw
 end)
 
 --- Called when a frame is requested to be drawn on hud. (2D Context)
--- @name drawhud
+-- @name DrawHUD
 -- @class hook
 -- @client
 SF.hookAdd("HUDPaint", "drawhud", hudPrepareSafeArgs, cleanupRender)
 
 --- Called when a hud element is attempting to be drawn
--- @name hudshoulddraw
+-- @name HUDShouldDraw
 -- @class hook
 -- @client
 -- @param string str The name of the hud element trying to be drawn
@@ -254,7 +254,7 @@ end, function(instance, args)
 end)
 
 --- Called before opaque entities are drawn. (Only works with HUD) (3D context)
--- @name predrawopaquerenderables
+-- @name PreDrawOpaqueRenderables
 -- @class hook
 -- @client
 -- @param boolean depth Whether the current draw is writing depth
@@ -263,7 +263,7 @@ end)
 SF.hookAdd("PreDrawOpaqueRenderables", nil, hudPrepareSafeArgs, cleanupRender)
 
 --- Called after opaque entities are drawn. (Only works with HUD) (3D context)
--- @name postdrawopaquerenderables
+-- @name PostDrawOpaqueRenderables
 -- @class hook
 -- @client
 -- @param boolean depth Whether the current draw is writing depth
@@ -272,7 +272,7 @@ SF.hookAdd("PreDrawOpaqueRenderables", nil, hudPrepareSafeArgs, cleanupRender)
 SF.hookAdd("PostDrawOpaqueRenderables", nil, hudPrepareSafeArgs, cleanupRender)
 
 --- Called before translucent entities are drawn. (Only works with HUD) (3D context)
--- @name predrawtranslucentrenderables
+-- @name PreDrawTranslucentRenderables
 -- @class hook
 -- @client
 -- @param boolean depth Whether the current draw is writing depth
@@ -281,7 +281,7 @@ SF.hookAdd("PostDrawOpaqueRenderables", nil, hudPrepareSafeArgs, cleanupRender)
 SF.hookAdd("PreDrawTranslucentRenderables", nil, hudPrepareSafeArgs, cleanupRender)
 
 --- Called after translucent entities are drawn. (Only works with HUD) (3D context)
--- @name postdrawtranslucentrenderables
+-- @name PostDrawTranslucentRenderables
 -- @class hook
 -- @client
 -- @param boolean depth Whether the current draw is writing depth
@@ -290,13 +290,13 @@ SF.hookAdd("PreDrawTranslucentRenderables", nil, hudPrepareSafeArgs, cleanupRend
 SF.hookAdd("PostDrawTranslucentRenderables", nil, hudPrepareSafeArgs, cleanupRender)
 
 --- Called before drawing HUD (2D Context)
--- @name predrawhud
+-- @name PreDrawHUD
 -- @class hook
 -- @client
 SF.hookAdd("PreDrawHUD", nil, hudPrepareSafeArgs, cleanupRender)
 
 --- Called after drawing HUD (2D Context)
--- @name postdrawhud
+-- @name PostDrawHUD
 -- @class hook
 -- @client
 SF.hookAdd("PostDrawHUD", nil, function(instance)
@@ -307,13 +307,13 @@ SF.hookAdd("PostDrawHUD", nil, function(instance)
 end, cleanupRender)
 
 --- Called before drawing the viewmodel rendergroup (3D Context)
--- @name predrawviewmodels
+-- @name PreDrawViewModels
 -- @class hook
 -- @client
 SF.hookAdd("PreDrawViewModels", nil, hudPrepareSafeArgs, cleanupRender)
 
 --- Called when world fog is drawn.
--- @name setupworldfog
+-- @name SetupWorldFog
 -- @class hook
 -- @client
 SF.hookAdd("SetupWorldFog", nil, function(instance)
@@ -329,7 +329,7 @@ end, function(instance)
 end)
 
 --- Called when skybox fog is drawn.
--- @name setupskyboxfog
+-- @name SetupSkyboxFog
 -- @class hook
 -- @client
 -- @param number scale Skybox scale
@@ -346,7 +346,7 @@ end, function(instance)
 end)
 
 --- Called before the 3D skybox is drawn. This will not be called for maps with no 3D skybox, or when the 3d skybox is disabled
--- @name predrawskybox
+-- @name PreDrawSkyBox
 -- @class hook
 -- @client
 -- @return boolean Return true to not predraw the skybox both 2d and 3d
@@ -356,19 +356,19 @@ SF.hookAdd("PreDrawSkyBox", nil, hudPrepareSafeArgs, function(instance, args)
 end)
 
 --- Called right after the 2D skybox has been drawn - allowing you to draw over it.
--- @name postdraw2dskybox
+-- @name PostDraw2DSkyBox
 -- @class hook
 -- @client
 SF.hookAdd("PostDraw2DSkyBox", nil, hudPrepareSafeArgs, cleanupRender)
 
 --- Called after the 3D skybox is drawn. This will not be called if PreDrawSkyBox has prevented rendering of the skybox
--- @name postdrawskybox
+-- @name PostDrawSkyBox
 -- @class hook
 -- @client
 SF.hookAdd("PostDrawSkyBox", nil, hudPrepareSafeArgs, cleanupRender)
 
 --- Called when the engine wants to calculate the player's view. Only works if connected to Starfall HUD
--- @name calcview
+-- @name CalcView
 -- @class hook
 -- @client
 -- @param Vector pos Current position of the camera

--- a/lua/starfall/libs_cl/xinput.lua
+++ b/lua/starfall/libs_cl/xinput.lua
@@ -4,7 +4,7 @@ local checkluatype = SF.CheckLuaType
 
 --- Called when a controller has been connected. Client must have XInput Lua binary installed.
 -- @client
--- @name xinputConnected
+-- @name XInputConnected
 -- @class hook
 -- @param number id Controller number. Starts at 0
 -- @param number when The timer.realtime() at which this event occurred.
@@ -12,7 +12,7 @@ SF.hookAdd("xinputConnected", "xinputconnected")
 
 --- Called when a controller has been disconnected. Client must have XInput Lua binary installed.
 -- @client
--- @name xinputDisconnected
+-- @name XInputDisconnected
 -- @class hook
 -- @param number id Controller number. Starts at 0
 -- @param number when The timer.realtime() at which this event occurred.
@@ -20,7 +20,7 @@ SF.hookAdd("xinputDisconnected", "xinputdisconnected")
 
 --- Called when a controller button has been pressed. Client must have XInput Lua binary installed.
 -- @client
--- @name xinputPressed
+-- @name XInputPressed
 -- @class hook
 -- @param number id Controller number. Starts at 0
 -- @param number button The button that was pushed. See https://github.com/mitterdoo/garrysmod-xinput#xinput_gamepad_
@@ -29,7 +29,7 @@ SF.hookAdd("xinputPressed", "xinputpressed")
 
 --- Called when a controller button has been released. Client must have XInput Lua binary installed.
 -- @client
--- @name xinputReleased
+-- @name XInputReleased
 -- @class hook
 -- @param number id Controller number. Starts at 0
 -- @param number button The button that was released. See https://github.com/mitterdoo/garrysmod-xinput#xinput_gamepad_
@@ -38,7 +38,7 @@ SF.hookAdd("xinputReleased", "xinputreleased")
 
 --- Called when a trigger on the controller has moved. Client must have XInput Lua binary installed.
 -- @client
--- @name xinputTrigger
+-- @name XInputTrigger
 -- @class hook
 -- @param number id Controller number. Starts at 0
 -- @param number value The position of the trigger. 0-255 inclusive
@@ -48,7 +48,7 @@ SF.hookAdd("xinputTrigger", "xinputtrigger")
 
 --- Called when a stick on the controller has moved. Client must have XInput Lua binary installed.
 -- @client
--- @name xinputStick
+-- @name XInputStick
 -- @class hook
 -- @param number id Controller number. Starts at 0
 -- @param number x The X coordinate of the trigger. -32768 - 32767 inclusive

--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -324,7 +324,7 @@ end
 if CLIENT then
 
 	--- Called when local client changed instance permissions
-	-- @name permissionrequest
+	-- @name PermissionRequest
 	-- @class hook
 	-- @client
 

--- a/lua/starfall/libs_sh/darkrp2.lua
+++ b/lua/starfall/libs_sh/darkrp2.lua
@@ -455,7 +455,7 @@ if SERVER then
 	--- Called when a money printer is about to catch fire. DarkRP only. Called between moneyPrinterPrintMoney and moneyPrinterPrinted.
 	-- Not guaranteed to work for non-vanilla money printers.
 	-- Only works if the owner of the chip also owns the money printer, or if the chip is running in superuser mode.
-	-- @name moneyPrinterCatchFire
+	-- @name MoneyPrinterCatchFire
 	-- @class hook
 	-- @server
 	-- @param Entity moneyprinter The money printer that is about to catch fire
@@ -471,7 +471,7 @@ if SERVER then
 	--- Called after a money printer is has printed money. DarkRP only.
 	-- Not guaranteed to work for non-vanilla money printers.
 	-- Only works if the owner of the chip also owns the money printer, or if the chip is running in superuser mode.
-	-- @name moneyPrinterPrinted
+	-- @name MoneyPrinterPrinted
 	-- @class hook
 	-- @server
 	-- @param Entity moneyprinter The money printer
@@ -489,7 +489,7 @@ if SERVER then
 	-- Not guaranteed to work for non-vanilla money printers.
 	-- You should use moneyPrinterPrinted instead, as the printer is not guaranteed to print money even if this hook is called.
 	-- Only works if the owner of the chip also owns the money printer, or if the chip is running in superuser mode.
-	-- @name moneyPrinterPrintMoney
+	-- @name MoneyPrinterPrintMoney
 	-- @class hook
 	-- @server
 	-- @param Entity moneyprinter The money printer
@@ -506,7 +506,7 @@ if SERVER then
 	
 	--- Called when a player receives money. DarkRP only.
 	-- Will only be called if the recipient is the owner of the chip, or if the chip is running in superuser mode.
-	-- @name playerWalletChanged
+	-- @name PlayerWalletChanged
 	-- @class hook
 	-- @server
 	-- @param Player ply The player who is getting money.
@@ -522,7 +522,7 @@ if SERVER then
 	end)
 	
 	--- Called when a lockdown has ended. DarkRP only.
-	-- @name lockdownEnded
+	-- @name LockdownEnded
 	-- @class hook
 	-- @server
 	-- @param Player? actor The player who ended the lockdown, or nil.
@@ -532,7 +532,7 @@ if SERVER then
 	end)
 
 	--- Called when a lockdown has started. DarkRP only.
-	-- @name lockdownStarted
+	-- @name LockdownStarted
 	-- @class hook
 	-- @server
 	-- @param Player? actor The player who started the lockdown, or nil.
@@ -542,7 +542,7 @@ if SERVER then
 	end)
 
 	--- Called when a law is added. DarkRP only.
-	-- @name addLaw
+	-- @name AddLaw
 	-- @class hook
 	-- @param number index Index of the law
 	-- @param string law Law string
@@ -554,7 +554,7 @@ if SERVER then
 	end)
 
 	--- Called when a law is removed. DarkRP only. Not usually called when /resetlaws is used.
-	-- @name removeLaw
+	-- @name RemoveLaw
 	-- @class hook
 	-- @server
 	-- @param number index Index of the law
@@ -567,7 +567,7 @@ if SERVER then
 	end)
 
 	--- Called when laws are reset. DarkRP only. Usually the only hook called when /resetlaws is used.
-	-- @name resetLaws
+	-- @name ResetLaws
 	-- @class hook
 	-- @server
 	-- @param Player? player The player resetting the laws.
@@ -578,7 +578,7 @@ if SERVER then
 
 	--- Called when a player is about to pick a lock. DarkRP only.
 	-- Will only be called if the lockpicker is the owner of the chip, or if the chip is running in superuser mode.
-	-- @name lockpickStarted
+	-- @name LockpickStarted
 	-- @class hook
 	-- @server
 	-- @param Player ply The player that is about to pick a lock.
@@ -598,7 +598,7 @@ if SERVER then
 
 	--- Called when a player has finished picking a lock, successfully or otherwise. DarkRP only.
 	-- Will only be called if the lockpicker is the owner of the chip, or if the chip is running in superuser mode.
-	-- @name onLockpickCompleted
+	-- @name OnLockpickCompleted
 	-- @class hook
 	-- @server
 	-- @param Player ply The player attempting to lockpick the entity.

--- a/lua/starfall/libs_sh/hook.lua
+++ b/lua/starfall/libs_sh/hook.lua
@@ -562,7 +562,7 @@ add("EndEntityDriving")
 add("StartEntityDriving")
 
 --- Tick hook. Called each game tick on both the server and client.
--- @name tick
+-- @name Tick
 -- @class hook
 -- @shared
 add("Tick")
@@ -684,7 +684,7 @@ end
 
 --- Remote hook.
 -- This hook can be called from other instances
--- @name remote
+-- @name Remote
 -- @class hook
 -- @shared
 -- @param Entity sender The entity that caused the hook to run
@@ -754,7 +754,7 @@ end
 -- Hooks below are not simple gmod hooks and are called by other events in other files.
 
 --- Think hook. Called each frame on the client and each game tick on the server.
--- @name think
+-- @name Think
 -- @class hook
 -- @shared
 
@@ -788,27 +788,27 @@ end
 -- @param Entity ent The component entity
 
 --- Called when the player disconnects from a HUD component linked to the Starfall Chip
--- @name huddisconnected
+-- @name HUDDisconnected
 -- @class hook
 -- @shared
 -- @param Entity ent The hud component entity
 -- @param Player ply The player who disconnected
 
 --- Called when the player connects to a HUD component linked to the Starfall Chip
--- @name hudconnected
+-- @name HUDConnected
 -- @class hook
 -- @shared
 -- @param Entity ent The hud component entity
 -- @param Player ply The player who connected
 
 --- Called when a player uses the screen
--- @name starfallUsed
+-- @name StarfallUsed
 -- @class hook
 -- @param Player activator Player who used the screen or chip
 -- @param Entity used The screen or chip entity that was used
 
 --- Called when a frame is requested to be drawn on screen. (2D/3D Context)
--- @name render
+-- @name Render
 -- @class hook
 -- @client
 

--- a/lua/starfall/libs_sh/input.lua
+++ b/lua/starfall/libs_sh/input.lua
@@ -109,14 +109,14 @@ if game.SinglePlayer() then
 else
 	--- Called when a button is pressed
 	-- @client
-	-- @name inputPressed
+	-- @name InputPressed
 	-- @class hook
 	-- @param number button Number of the button
 	SF.hookAdd("PlayerButtonDown", "inputpressed", CheckButtonPerms)
 	
 	--- Called when a button is released
 	-- @client
-	-- @name inputReleased
+	-- @name InputReleased
 	-- @class hook
 	-- @param number button Number of the button
 	SF.hookAdd("PlayerButtonUp", "inputreleased", CheckButtonPerms)
@@ -124,7 +124,7 @@ end
 
 --- Called when a keybind is pressed
 -- @client
--- @name inputBindPressed
+-- @name InputBindPressed
 -- @class hook
 -- @param string bind Name of keybind pressed
 SF.hookAdd("PlayerBindPress", "inputbindpressed", function(instance, ply, bind)
@@ -136,7 +136,7 @@ end)
 
 --- Called when the mouse is moved
 -- @client
--- @name mousemoved
+-- @name MouseMoved
 -- @class hook
 -- @param number x X coordinate moved
 -- @param number y Y coordinate moved
@@ -152,7 +152,7 @@ end)
 
 --- Called when the mouse wheel is rotated
 -- @client
--- @name mouseWheeled
+-- @name MouseWheeled
 -- @class hook
 -- @param number delta Rotate delta
 SF.hookAdd("StartCommand", "mousewheeled", function(instance, ply, cmd)

--- a/lua/starfall/libs_sh/net.lua
+++ b/lua/starfall/libs_sh/net.lua
@@ -518,7 +518,7 @@ end
 end
 
 --- Called when a net message arrives
--- @name net
+-- @name Net
 -- @class hook
 -- @param string name Name of the arriving net message
 -- @param number len Length of the arriving net message in bits

--- a/lua/starfall/libs_sv/wire.lua
+++ b/lua/starfall/libs_sv/wire.lua
@@ -874,20 +874,20 @@ wire_library.ports = setmetatable({}, {
 -- ------------------------- Hook Documentation ------------------------- --
 
 --- Called when an input on a wired SF chip is written to
--- @name input
+-- @name Input
 -- @class hook
 -- @param string input The input name
 -- @param any value The value of the input
 
 --- Called when a high speed device reads from a wired SF chip
--- @name readcell
+-- @name ReadCell
 -- @class hook
 -- @server
 -- @param any address The address requested
 -- @return any The value read
 
 --- Called when a high speed device writes to a wired SF chip
--- @name writecell
+-- @name WriteCell
 -- @class hook
 -- @param any address The address written to
 -- @param table data The data being written


### PR DESCRIPTION
The hook names were borderline unreadable. This is a purely cosmetic change.