### PR TITLE
Add PreDrawPlayer and allow returning True from more render hooks

### DIFF
--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -260,7 +260,11 @@ end)
 -- @param boolean depth Whether the current draw is writing depth
 -- @param boolean skybox Whether the current draw is drawing the skybox
 -- @param boolean skybox3d Whether the current draw is drawing the 3D skybox
-SF.hookAdd("PreDrawOpaqueRenderables", nil, hudPrepareSafeArgs, cleanupRender)
+-- @return boolean Return true to prevent opaque entities from drawing
+SF.hookAdd("PreDrawOpaqueRenderables", nil, hudPrepareSafeArgs, function(instance, args)
+	instance:cleanupRender()
+	if args[1] and args[2]==true then return true end
+end)
 
 --- Called after opaque entities are drawn. (Only works with HUD) (3D context)
 -- @name PostDrawOpaqueRenderables
@@ -278,7 +282,11 @@ SF.hookAdd("PostDrawOpaqueRenderables", nil, hudPrepareSafeArgs, cleanupRender)
 -- @param boolean depth Whether the current draw is writing depth
 -- @param boolean skybox Whether the current draw is drawing the skybox
 -- @param boolean skybox3d Whether the current draw is drawing the 3D skybox
-SF.hookAdd("PreDrawTranslucentRenderables", nil, hudPrepareSafeArgs, cleanupRender)
+-- @return boolean Return true to prevent translucent entities from drawing
+SF.hookAdd("PreDrawTranslucentRenderables", nil, hudPrepareSafeArgs, function(instance, args)
+	instance:cleanupRender()
+	if args[1] and args[2]==true then return true end
+end)
 
 --- Called after translucent entities are drawn. (Only works with HUD) (3D context)
 -- @name PostDrawTranslucentRenderables
@@ -322,6 +330,7 @@ end, function(instance, args)
 	instance:cleanupRender()
 	if args[1] and args[2]==true then return true end
 end)
+
 --- Called before drawing the viewmodel rendergroup (3D Context)
 -- @name PreDrawViewModels
 -- @class hook

--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -180,6 +180,11 @@ local function cleanupRender(instance)
 	instance:cleanupRender()
 end
 
+local function cleanupRenderAllowTrueReturn(instance, args)
+	instance:cleanupRender()
+	if args[1] and args[2]==true then return true end
+end
+
 local function canRenderHud(instance)
 	return SF.IsHUDActive(instance.entity) and (haspermission(instance, nil, "render.hud") or instance.player == SF.Superuser)
 end
@@ -261,10 +266,7 @@ end)
 -- @param boolean skybox Whether the current draw is drawing the skybox
 -- @param boolean skybox3d Whether the current draw is drawing the 3D skybox
 -- @return boolean Return true to prevent opaque entities from drawing
-SF.hookAdd("PreDrawOpaqueRenderables", nil, hudPrepareSafeArgs, function(instance, args)
-	instance:cleanupRender()
-	if args[1] and args[2]==true then return true end
-end)
+SF.hookAdd("PreDrawOpaqueRenderables", nil, hudPrepareSafeArgs, cleanupRenderAllowTrueReturn)
 
 --- Called after opaque entities are drawn. (Only works with HUD) (3D context)
 -- @name PostDrawOpaqueRenderables
@@ -283,10 +285,7 @@ SF.hookAdd("PostDrawOpaqueRenderables", nil, hudPrepareSafeArgs, cleanupRender)
 -- @param boolean skybox Whether the current draw is drawing the skybox
 -- @param boolean skybox3d Whether the current draw is drawing the 3D skybox
 -- @return boolean Return true to prevent translucent entities from drawing
-SF.hookAdd("PreDrawTranslucentRenderables", nil, hudPrepareSafeArgs, function(instance, args)
-	instance:cleanupRender()
-	if args[1] and args[2]==true then return true end
-end)
+SF.hookAdd("PreDrawTranslucentRenderables", nil, hudPrepareSafeArgs, cleanupRenderAllowTrueReturn)
 
 --- Called after translucent entities are drawn. (Only works with HUD) (3D context)
 -- @name PostDrawTranslucentRenderables
@@ -326,10 +325,7 @@ SF.hookAdd("PrePlayerDraw", "predrawplayer", function(instance, ply, flags)
 		return true, { instance.Types.Player.Wrap(ply), flags }
 	end
 	return false
-end, function(instance, args)
-	instance:cleanupRender()
-	if args[1] and args[2]==true then return true end
-end)
+end, cleanupRenderAllowTrueReturn)
 
 --- Called before drawing the viewmodel rendergroup (3D Context)
 -- @name PreDrawViewModels
@@ -375,10 +371,7 @@ end)
 -- @class hook
 -- @client
 -- @return boolean Return true to not predraw the skybox both 2d and 3d
-SF.hookAdd("PreDrawSkyBox", nil, hudPrepareSafeArgs, function(instance, args)
-	instance:cleanupRender()
-    if args[1] and args[2]==true then return true end
-end)
+SF.hookAdd("PreDrawSkyBox", nil, hudPrepareSafeArgs, cleanupRenderAllowTrueReturn)
 
 --- Called right after the 2D skybox has been drawn - allowing you to draw over it.
 -- @name PostDraw2DSkyBox

--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -306,6 +306,22 @@ SF.hookAdd("PostDrawHUD", nil, function(instance)
 	end
 end, cleanupRender)
 
+--- Called before drawing the player. (Only works with HUD) (3D Context)
+-- @name PreDrawPlayer
+-- @class hook
+-- @client
+-- @param Player ply Player that's about to be drawn
+-- @param number flags STUDIO flags for the render operation
+-- @return boolean Return true to prevent the player from drawing
+SF.hookAdd("PrePlayerDraw", "predrawplayer", function(instance, ply, flags)
+	if canRenderHud(instance) then
+		return true, { instance.Types.Player.Wrap(ply), flags }
+	end
+	return false
+end, function(instance, args)
+	instance:cleanupRender()
+	if args[1] and args[2]==true then return true end
+end)
 --- Called before drawing the viewmodel rendergroup (3D Context)
 -- @name PreDrawViewModels
 -- @class hook


### PR DESCRIPTION
- Adds [`PrePlayerDraw`](https://wiki.facepunch.com/gmod/GM:PrePlayerDraw) as `PreDrawPlayer`
- Allow returning `true` from `PreDrawOpaqueRenderables`
- Allow returning `true` from `PreDrawTranslucentRenderables`
- New helper function that cleanups render, but allows user to return `true`.

No special permissions, besides the HUD check. I don't think they're needed.

Fixes: #1972