### PR TITLE
Fix render.clearDepth()

### DIFF
--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -1994,12 +1994,14 @@ function render_library.setBlend(alpha)
 	render.SetBlend(alpha)
 end
 
---- Resets the depth buffer
+--- Resets the depth buffer. (Only works in a render target or with a connected HUD)
 -- @param boolean? clearStencil Also clears the stencil buffer. Default: true
 function render_library.clearDepth( clearStencil )
 	if not renderdata.isRendering then SF.Throw("Not in a rendering hook.", 2) end
 
-	render.ClearDepth( clearStencil )
+	if renderdata.usingRT or SF.IsHUDActive(instance.entity) then
+		render.ClearDepth( clearStencil )
+	end
 end
 
 --- Draws a sprite in 3d space.

--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -1995,11 +1995,11 @@ function render_library.setBlend(alpha)
 end
 
 --- Resets the depth buffer
-function render_library.clearDepth()
+-- @param boolean? clearStencil Also clears the stencil buffer. Default: true
+function render_library.clearDepth( clearStencil )
 	if not renderdata.isRendering then SF.Throw("Not in a rendering hook.", 2) end
-	if renderdata.usingRT then
-		render.ClearDepth()
-	end
+
+	render.ClearDepth( clearStencil )
 end
 
 --- Draws a sprite in 3d space.


### PR DESCRIPTION
- Exposes the `clearStencil` param to `render.clearDepth()` so users can clear depth without being forced to clear stencils.
- Removes the requirement for a rendertarget context, so the depth can be cleared when doing 3D renders, 3D2D renders straight to the HUD without an RT, etc.


For demonstration, the clip below has two identical meshes, where one is being clipped by the view matrix position, and the other (in red) is being clipped by a hologram clip. Even though the raised areas in the first mesh ultimately don't get drawn, they still write to the depth buffer, preventing the red mesh from drawing. Since starfall currently requires an RT to clear the depth buffer (something which would add needless overhead and pixelation to my project), it won't let me clear the depth buffer to allow the red mesh to draw.

https://github.com/user-attachments/assets/c72bd180-ce34-4600-9f39-d9c029c246b9

(Also yes I tried adding a manual clip to the first mesh as well, that still doesn't stop the clipped areas from writing to the buffer)