### PR TITLE
Add UInt64 operations to net

### DIFF
--- a/lua/starfall/libs_sh/net.lua
+++ b/lua/starfall/libs_sh/net.lua
@@ -310,6 +310,24 @@ function net_library.readUInt(n)
 	return net.ReadUInt(n)
 end
 
+--- Writes an unsigned 64-bit integer to the net message
+-- @shared
+-- @param string t The integer to be written. Must be a string
+function net_library.writeUInt64(t)
+	if not netStarted then SF.Throw("net message not started", 2) end
+
+	checkluatype (t, TYPE_STRING)
+
+	write{net.WriteUInt64, 64, t}
+end
+
+--- Reads an unsigned 64-bit integer from the net message
+-- @shared
+-- @return string The unsigned integer that was read, as a string
+function net_library.readUInt64()
+	return net.ReadUInt64(n)
+end
+
 --- Writes a bit to the net message
 -- @shared
 -- @param number t The bit to be written. (0 for false, 1 (or anything) for true)

--- a/lua/starfall/libs_sh/net.lua
+++ b/lua/starfall/libs_sh/net.lua
@@ -325,7 +325,7 @@ end
 -- @shared
 -- @return string The unsigned integer that was read, as a string
 function net_library.readUInt64()
-	return net.ReadUInt64(n)
+	return net.ReadUInt64()
 end
 
 --- Writes a bit to the net message

--- a/lua/starfall/libs_sh/net.lua
+++ b/lua/starfall/libs_sh/net.lua
@@ -312,7 +312,7 @@ end
 
 --- Writes an unsigned 64-bit integer to the net message
 -- @shared
--- @param string t The integer to be written. Must be a string
+-- @param string t The 64-bit integer written as a string because lua numbers can't hold 64-bit ints
 function net_library.writeUInt64(t)
 	if not netStarted then SF.Throw("net message not started", 2) end
 


### PR DESCRIPTION
Added [`net.readUInt64`](https://wiki.facepunch.com/gmod/net.ReadUInt64) and [`net.writeUInt64`](https://wiki.facepunch.com/gmod/net.WriteUInt64). I decided to explicitly mention in the docs that the number must be represented as a string because I feel this might be easily overlooked, let me know if I should remove that if you think it's redundant.