### PR TITLE
Update starfall_whitelist_default.lua

### DIFF
--- a/lua/starfall/starfall_whitelist_default.lua
+++ b/lua/starfall/starfall_whitelist_default.lua
@@ -196,6 +196,7 @@ pattern [[tts.cyzon.us/(.+)]]
 ---  https://autumn.revolt.chat/attachments/mmCR_bFMLEfBAE8mweH2u4o9_x6DiDtU9JXoSbdvZE/live-bocchi-reaction.gif
 simple [[static.revolt.chat]]
 simple [[autumn.revolt.chat]]
+simple [[cdn.revoltusercontent.com]]
 
 -- Youtube Converter API
 --- Examples:


### PR DESCRIPTION
revolt changed their cdn endpoint

Just want to add that it would be nice to change the way the editable whitelist work because this change will not take effect unless a client decide to manually add this change to their whitelist 99% of player have no clue about starfall making their whitelist set in stone from the first time they joined anywhere that had sf. So if any already whitelisted site turn out to have a way to abuse it wont be possible to easily update people whitelist, and make adding any new useful safe site impossible.