### PR TITLE
Make HudEnabled provider not auto-allow for owner

### DIFF
--- a/lua/starfall/permissions/providers_cl/client.lua
+++ b/lua/starfall/permissions/providers_cl/client.lua
@@ -20,7 +20,7 @@ P.checks = {
 	"allow",
 	"block",
 	function(instance, target, key)
-		return LocalPlayer()==instance.player or SF.IsHUDActive(instance.entity), "No HUD connected"
+		return SF.IsHUDActive(instance.entity), "No HUD connected"
 	end,
 }
 


### PR DESCRIPTION
Previously, functionality that required HUD access (`drawhud` hook, etc) didn't care whether the player was the chip owner or not. However, the recent permission changes made it so those features always run for the owner, even if they don't have a HUD connected.

This is rather annoying, as it changes underlying behavior and would require many scripts to be retrofitted with manual HUD checks. If the owner wants to enable HUD-based features without using a component, they can just use `enableHud()`.

This pr simply gets rid of the owner-based bypass, restoring the previous behavior.