### PR TITLE
Don't starve empty burst objects when trying to :use() them

### DIFF
--- a/lua/starfall/libs_sh/mesh.lua
+++ b/lua/starfall/libs_sh/mesh.lua
@@ -664,9 +664,10 @@ local plyMeshCount = SF.LimitObject("mesh", "total meshes", 1000, "How many mesh
 
 function plyTriangleRenderBurst:calc(obj)
 	local t = RealTime()
-	local ret = math.min(obj.val + (t - obj.lasttick)/RealFrameTime() * self.rate, self.max)
+	local new = math.min(obj.val + (t - obj.lasttick)/RealFrameTime() * self.rate, self.max)
+	obj.val = new
 	obj.lasttick = t
-	return ret
+	return new
 end
 
 --- Mesh library.

--- a/lua/starfall/sflib.lua
+++ b/lua/starfall/sflib.lua
@@ -192,9 +192,10 @@ setmetatable(SF.StructWrapper, SF.StructWrapper)
 SF.BurstObject = {
 	__index = {
 		calc = function(self, obj)
-			local ret = math.min(obj.val + (CurTime() - obj.lasttick) * self.rate, self.max)
+			local new = math.min(obj.val + (CurTime() - obj.lasttick) * self.rate, self.max)
+			obj.val = new
 			obj.lasttick = CurTime()
-			return ret
+			return new
 		end,
 		use = function(self, ply, amount)
 			local obj = self:get(ply)
@@ -206,8 +207,7 @@ SF.BurstObject = {
 		end,
 		check = function(self, ply)
 			local obj = self:get(ply)
-			obj.val = self:calc(obj)
-			return obj.val
+			return self:calc(obj)
 		end,
 		get = function(self, ply)
 			if ply~=SF.Superuser and not Ent_IsValid(ply) then SF.Throw("Invalid starfall user", 4) end


### PR DESCRIPTION
Makes `BurstObject:check()` automatically store the new value of the burst object, so that it doesn't get discarded when a `:use()` attempt is made without having at least one unit remaining.

In other words, this prevents snippets like this from completely starving a burst object:
```lua
hook.add( "think", "SurelyItWillLetMeSpawnPropsEventuallyRight", function()
   local ent = prop.create( wherever, someAngle, modelBlah )
end )
```