### PR TITLE
ENT.DoNotDuplicate starfall_hologram(s)

### DIFF
--- a/lua/entities/starfall_hologram/shared.lua
+++ b/lua/entities/starfall_hologram/shared.lua
@@ -6,6 +6,7 @@ ENT.Author          = "Starfall Organization"
 
 ENT.Spawnable       = false
 ENT.AdminSpawnable  = false
+ENT.DoNotDuplicate  = true
 
 ENT.IsSFHologram = true
 


### PR DESCRIPTION
Was surprised these didn't already have this varable set

Clip of me duping holograms
https://www.youtube.com/watch?v=VDsdZ8BU6UI

Probably some unrelated bug causing them to be dupable just now, haven't tested it in singleplayer, but holograms really should have DoNotDuplicate be true, no reason to ever dupe them really.