### PR TITLE
Use CFC HTTP whitelist instead if available

### DIFF
--- a/lua/starfall/permissions/providers_sh/url_whitelist.lua
+++ b/lua/starfall/permissions/providers_sh/url_whitelist.lua
@@ -16,6 +16,18 @@ local function checkWhitelist(instance, url, key)
 	local prefix, site, data = string.match(url,"^(%w-)://([^/]*)/?(.*)")
 	if not site then return false, "This url is malformed" end
 	site = site.."/"..(data or "") -- Make sure there is / at the end of site
+
+	if CFCHTTP then
+		local url = prefix .. "://" .. site
+		local options = CFCHTTP.GetOptionsForURL(url)
+
+		if options.allowed then
+			return true
+		else
+			return false, "The url was blocked by the CFC HTTP whitelist."
+		end
+	end
+
 	return urlrestrictor:check(site), "This url is not whitelisted."
 end
 


### PR DESCRIPTION
If the CFC HTTP whitelist addon is detected it will use that instead of the Starfall whitelist.
This lets server owners and players have more control over what is and isn't allowed for Starfall.
If the Starfall whitelist is disabled and a url isn't whitelisted there won't be an error except for a CFC whitelist blocked message in console, but I decided to leave it this way.