### PR TITLE
Documentation/general documentation cleanup

### DIFF
--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -2247,8 +2247,8 @@ end
 --- Gets a 2D cursor position where ply is aiming at the current rendered screen or nil if they aren't aiming at it.
 -- @param Player? ply player to get cursor position from. Default player()
 -- @param Entity? screen An explicit screen to get the cursor pos of (default: The current rendering screen using 'render' hook)
--- @return number X position
--- @return number Y position
+-- @return number? X position or nil if the player is not aiming at the screen
+-- @return number? Y position or nil if the player is not aiming at the screen
 function render_library.cursorPos(ply, screen)
 	if ply~=nil then
 		ply = getent(ply)

--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -824,7 +824,7 @@ end
 --- Runs all included scripts in a directory and caches the results.
 -- The path must be an actual path, including the file extension and using slashes for directory separators instead of periods.
 -- @param string path The directory to include. Make sure to --@includedir it
--- @param table loadpriority Table of files that should be loaded before any others in the directory
+-- @param table? loadpriority Table of files that should be loaded before any others in the directory
 -- @return table Table of return values of the scripts
 function builtins_library.requiredir(path, loadpriority)
 	checkluatype(path, TYPE_STRING)

--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -403,7 +403,7 @@ os_library.clock = os.clock
 --- Returns the date/time as a formatted string or in a table.
 -- See https://wiki.facepunch.com/gmod/Structures/DateData for the table structure
 -- @class function
--- @param string format The format string. If starts with an '!', it will use UTC timezone rather than the local timezone
+-- @param string? format The format string. If starts with an '!', it will use UTC timezone rather than the local timezone
 -- @param number? time Time to use for the format. Default os.time()
 -- @return string|table If format is equal to '*t' or '!*t' then it will return a table with DateData structure, otherwise a string
 os_library.date = function(format, time)

--- a/lua/starfall/libs_sh/entities.lua
+++ b/lua/starfall/libs_sh/entities.lua
@@ -266,10 +266,10 @@ end
 
 --- Plays a sound on the entity
 -- @param string snd Sound path
--- @param number soundLevel Default 75
--- @param number pitchPercent Default 100
--- @param number volume Default 1
--- @param number channel Default CHAN_AUTO or CHAN_WEAPON for weapons
+-- @param number? soundLevel Default 75
+-- @param number? pitchPercent Default 100
+-- @param number? volume Default 1
+-- @param number? channel Default CHAN_AUTO or CHAN_WEAPON for weapons
 function ents_methods:emitSound(snd, lvl, pitch, volume, channel)
 	checkluatype(snd, TYPE_STRING)
 	SF.CheckSound(instance.player, snd)

--- a/lua/starfall/libs_sh/find.lua
+++ b/lua/starfall/libs_sh/find.lua
@@ -209,7 +209,7 @@ end
 --- Returns a sorted array of entities by how close they are to a point
 -- @param table ents The array of entities
 -- @param Vector pos The position
--- @param boolean furthest Whether to have the further entities first
+-- @param boolean? furthest Whether to have the further entities first
 -- @return table A table of the closest entities
 function find_library.sortByClosest(ents, pos, furthest)
 	local distances = {}

--- a/lua/starfall/libs_sh/math.lua
+++ b/lua/starfall/libs_sh/math.lua
@@ -280,6 +280,7 @@ math_library.remap = math.Remap
 -- @class function
 -- @param number value The number to be rounded
 -- @param number? decimals Optional decimal places to round to. Defaults to 0
+-- @return number The rounded value
 math_library.round = math.Round
 
 --- Calculates the sine of given angle.

--- a/lua/starfall/libs_sh/string.lua
+++ b/lua/starfall/libs_sh/string.lua
@@ -33,8 +33,8 @@ end
 --- Returns the given string's characters in their numeric ASCII representation.
 -- @class function
 -- @param string str The string to get the chars from
--- @param number start The first character of the string to get the byte of
--- @param number end The last character of the string to get the byte of
+-- @param number? start The first character of the string to get the byte of. Defaults to 1
+-- @param number? end The last character of the string to get the byte of. Defaults to 'start'
 -- @return ... Vararg numerical bytes
 string_library.byte = sfstring.byte
 

--- a/lua/starfall/libs_sh/string.lua
+++ b/lua/starfall/libs_sh/string.lua
@@ -76,7 +76,7 @@ string_library.explode = sfstring.Explode
 -- @class function
 -- @param string haystack The string to search in
 -- @param string needle The string to find, can contain patterns if enabled
--- @param number start The position to start the search from, negative start position will be relative to the end position
+-- @param number? start The position to start the search from, negative start position will be relative to the end position
 -- @param boolean? noPatterns Disable patterns. Defaults to false
 -- @return number? Starting position of the found text, or nil if the text wasn't found
 -- @return number? Ending position of found text, or nil if the text wasn't found

--- a/lua/starfall/libs_sh/table.lua
+++ b/lua/starfall/libs_sh/table.lua
@@ -42,7 +42,7 @@ table_library.collapseKeyValue = table.CollapseKeyValue
 --- Concatenates the contents of a table to a string.
 -- @class function
 -- @param table tbl The table to concatenate
--- @param string concatenator A seperator to insert between each string
+-- @param string? concatenator A seperator to insert between each string. Defaults to ""
 -- @param number? startPos Optional key to start at. Defaults to 1
 -- @param number? endPos Optional key to end at. Defaults to #tbl
 -- @return string Concatenated string

--- a/lua/starfall/libs_sv/players.lua
+++ b/lua/starfall/libs_sv/players.lua
@@ -164,7 +164,7 @@ function player_methods:isHUDActive()
 end
 
 --- Sets the view entity of the player. Only works if they are linked to a hud.
--- @param Entity ent Entity to set the player's view entity to, or nothing to reset it
+-- @param Entity? ent Entity to set the player's view entity to, or nothing to reset it
 function player_methods:setViewEntity(ent)
 	local ply = getply(self)
 	if ent~=nil then ent = getent(ent) end


### PR DESCRIPTION
Fixed some less common issues regarding documentation.
This only modifies documentation.

Changes:

- `find.sortByClosest( Entity[], Vector, Boolean? )`
    The third argument 'furthest' is now optional.

- `Entity:emitSound( String, Number?, Number?, Number?, Number? )`
    Only the first argument 'snd' is required.

- `Player:setViewEntity( Entity? )`
    The argument 'ent' is now optional.

- `string.find( String, String, Number?, Boolean? )`
    The argument 'start' is now optional.

- `string.byte( String, Number?, Number? )`
    Only the first argument 'str' is required.

- `requiredir( String, Table? )`
    The argument 'loadpriority' is now optional.

- `table.concat( Table, String?, Number?, Number? )`
    The argument 'concatenator' is now optional.

- `os.date( String?, Number? )`
    The argument 'format' is now optional.

- `math.round( Number, Number? )`
    Now returns a `number`.

- `render.cursorPos( Player?, Entity? )`
    Indicates possible `nil` return values.