### PR TITLE
Less arbitrary lower limit for entity:setMass()

### DIFF
--- a/lua/starfall/libs_sv/entities.lua
+++ b/lua/starfall/libs_sv/entities.lua
@@ -716,7 +716,7 @@ function ents_methods:setMass(mass)
 
 	checkpermission(instance, ent, "entities.setMass")
 
-	local m = math.Clamp(mass, 1, 50000)
+	local m = math.Clamp(mass, 0.001, 50000)
 	Phys_SetMass(phys, m)
 	duplicator.StoreEntityModifier(ent, "mass", { Mass = m })
 end


### PR DESCRIPTION
Lower than **1kg** values are usefull for example:
Light vehicles using prop weights as "constraint stifness" - leaf springs, roll bars

Both the weight tool and E2 allow values lower than **1kg**, so I propose a lower limit (**1g**) for starfall aswell.

Thank you