### PR TITLE
Fix joystick.numButtons() and joystick.numPovs() returning incorrect values

### DIFF
--- a/lua/starfall/libs_cl/joystick.lua
+++ b/lua/starfall/libs_cl/joystick.lua
@@ -71,18 +71,18 @@ function joystick_library.numAxes(enum)
 	return joystick.count(enum, 1)
 end
 
---- Gets the number of detected povs on a joystick
--- @param number enum Joystick number. Starts at 0
--- @return number Number of povs
-function joystick_library.numPovs(enum)
-	refresh(enum)
-	return joystick.count(enum, 2)
-end
-
 --- Gets the number of detected buttons on a joystick
 -- @param number enum Joystick number. Starts at 0
 -- @return number Number of buttons
 function joystick_library.numButtons(enum)
+	refresh(enum)
+	return joystick.count(enum, 2)
+end
+
+--- Gets the number of detected povs on a joystick
+-- @param number enum Joystick number. Starts at 0
+-- @return number Number of povs
+function joystick_library.numPovs(enum)
 	refresh(enum)
 	return joystick.count(enum, 3)
 end


### PR DESCRIPTION
The "option" number in **joystick.numButtons()** and **joystick.numPovs()** is switched around.

2 should be buttons
3 should be povs

See: https://github.com/AmyJeanes/Joystick-Module/blob/79789ee726c6a482688087ff7fa84129cccd15a4/src/main.cpp#L173
Thank you