### PR TITLE
Fix lua error

### DIFF
--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -619,6 +619,7 @@ if SERVER then
 	function builtins_library.concmd(cmd)
 		checkluatype(cmd, TYPE_STRING)
 		if #cmd > 512 then SF.Throw("Console command is too long!", 2) end
+		if IsConCommandBlocked(cmd) then SF.Throw("Console command is blocked!", 2) end
 		checkpermission(instance, nil, "console.command")
 		concmdBurst:use(instance.player, #cmd)
 		instance.player:ConCommand(cmd)


### PR DESCRIPTION
Fixes:
```lua
--@name Untitled
--@author hi
--@shared

concmd("volume")
```
```
[starfallex-master] ConCommand is blocked! (volume)
    1. ConCommand - lua/includes/extensions/player.lua:71
        2. concmd - addons/starfallex-master/lua/starfall/libs_sh/builtins.lua:743
            3. unknown - SF:main:5
                4. xpcall - [C]:-1
                    5. run - addons/starfallex-master/lua/starfall/instance.lua:561
                        6. initialize - addons/starfallex-master/lua/starfall/instance.lua:590
                            7. Compile - addons/starfallex-master/lua/entities/starfall_processor/shared.lua:61
                                8. callback - addons/starfallex-master/lua/entities/starfall_processor/cl_init.lua:157
                                    9. setup - addons/starfallex-master/lua/starfall/transfer.lua:24
                                        10. unknown - addons/starfallex-master/lua/starfall/transfer.lua:38
                                            11. xpcall - [C]:-1
                                                12. Remove - addons/advdupe2-master/lua/autorun/netstream.lua:279
                                                    13. Read - addons/advdupe2-master/lua/autorun/netstream.lua:258
                                                        14. Read - addons/advdupe2-master/lua/autorun/netstream.lua:131
                                                            15. func - addons/advdupe2-master/lua/autorun/netstream.lua:385
                                                                16. unknown - lua/includes/extensions/net.lua:34
```