### PR TITLE
Add extra entity.emitSound arguments and add sound.emitSound

### DIFF
--- a/lua/starfall/libs_sh/entities.lua
+++ b/lua/starfall/libs_sh/entities.lua
@@ -265,7 +265,6 @@ if sound_library then
 	end
 
 	--- Emits a sound not attached to any entity at the specified position
-	-- @param string path Filepath to the sound file.
 	-- @param string snd Sound path
 	-- @param number? soundLevel Default 75
 	-- @param number? pitchPercent Default 100

--- a/lua/starfall/libs_sh/entities.lua
+++ b/lua/starfall/libs_sh/entities.lua
@@ -263,6 +263,31 @@ if sound_library then
 	function sound_library:emitSoundsLeft()
 		return emitSoundBurst:check(instance.player)
 	end
+
+	--- Emits a sound not attached to any entity at the specified position
+	-- @param string path Filepath to the sound file.
+	-- @param string snd Sound path
+	-- @param number? soundLevel Default 75
+	-- @param number? pitchPercent Default 100
+	-- @param number? volume Default 1
+	-- @param number? channel Default CHAN_AUTO or CHAN_WEAPON for weapons
+	-- @param number? dsp Default 1 DSP preset
+	-- @param boolean? nofilter (Optional) Boolean Make the sound play for everyone regardless of range or location. Only affects Server-side sounds.
+	function sound_library.emitSound(snd, position, lvl, pitch, volume, channel, dsp, nofilter)
+		checkluatype(snd, TYPE_STRING)
+		SF.CheckSound(instance.player, snd)
+
+		checkpermission(instance, nil, "sound.emitSound")
+		emitSoundBurst:use(instance.player, 1)
+
+		local filter
+		if nofilter and SERVER then
+			filter = RecipientFilter()
+			filter:AddAllPlayers()
+		end
+		
+		EmitSound(snd, vunwrap1(position), 0, channel, volume, lvl, nil, pitch, number, filter)
+	end
 end
 
 --- Plays a sound on the entity
@@ -271,8 +296,11 @@ end
 -- @param number? pitchPercent Default 100
 -- @param number? volume Default 1
 -- @param number? channel Default CHAN_AUTO or CHAN_WEAPON for weapons
-function ents_methods:emitSound(snd, lvl, pitch, volume, channel)
+-- @param number? dsp Default 1 DSP preset
+-- @param boolean? nofilter (Optional) Boolean Make the sound play for everyone regardless of range or location. Only affects Server-side sounds.
+function ents_methods:emitSound(snd, lvl, pitch, volume, channel, dsp, nofilter)
 	checkluatype(snd, TYPE_STRING)
+	if nofilter~=nil then checkluatype(nofilter, TYPE_BOOL) end
 	SF.CheckSound(instance.player, snd)
 
 	local ent = getent(self)
@@ -282,7 +310,14 @@ function ents_methods:emitSound(snd, lvl, pitch, volume, channel)
 	local snds = soundsByEntity[ent]
 	if not snds then snds = {} soundsByEntity[ent] = snds end
 	snds[snd] = true
-	Ent_EmitSound(ent, snd, lvl, pitch, volume, channel)
+
+	local filter
+	if nofilter and SERVER then
+		filter = RecipientFilter()
+		filter:AddAllPlayers()
+	end
+	
+	Ent_EmitSound(ent, snd, lvl, pitch, volume, channel, nil, dsp, filter)
 end
 
 --- Stops a sound on the entity

--- a/lua/starfall/libs_sh/entities.lua
+++ b/lua/starfall/libs_sh/entities.lua
@@ -266,6 +266,7 @@ if sound_library then
 
 	--- Emits a sound not attached to any entity at the specified position
 	-- @param string snd Sound path
+	-- @param Vector position Where the sound originates from
 	-- @param number? soundLevel Default 75
 	-- @param number? pitchPercent Default 100
 	-- @param number? volume Default 1

--- a/lua/starfall/libs_sh/entities.lua
+++ b/lua/starfall/libs_sh/entities.lua
@@ -275,6 +275,7 @@ if sound_library then
 	-- @param boolean? nofilter (Optional) Boolean Make the sound play for everyone regardless of range or location. Only affects Server-side sounds.
 	function sound_library.emitSound(snd, position, lvl, pitch, volume, channel, dsp, nofilter)
 		checkluatype(snd, TYPE_STRING)
+		if nofilter~=nil then checkluatype(nofilter, TYPE_BOOL) end
 		SF.CheckSound(instance.player, snd)
 
 		checkpermission(instance, nil, "sound.emitSound")

--- a/lua/starfall/libs_sh/sound.lua
+++ b/lua/starfall/libs_sh/sound.lua
@@ -4,6 +4,7 @@ local registerprivilege = SF.Permissions.registerPrivilege
 
 -- Register Privileges
 registerprivilege("sound.create", "Sound", "Allows the user to create sounds", { client = {} })
+registerprivilege("sound.emitSound", "Sound", "Allows the user to emit detached sounds", { client = {} })
 
 local plyCount = SF.LimitObject("sounds", "sounds", 20, "The number of sounds allowed to be playing via Starfall client at once")
 local plySoundBurst = SF.BurstObject("sounds", "sounds", 10, 5, "The rate at which the burst regenerates per second.", "The number of sounds allowed to be made in a short interval of time via Starfall scripts for a single instance ( burst )")


### PR DESCRIPTION
Adds missing parameters to Entity.emitSound for DSP and nofilter. Also creates sound.emitSound, which functions almost identically but allows for emitting sounds that are detached from any entity