### PR TITLE
Add game.getIPAddress

### DIFF
--- a/lua/starfall/libs_sh/game.lua
+++ b/lua/starfall/libs_sh/game.lua
@@ -98,7 +98,7 @@ game_library.getRealTickInterval = engine.AbsoluteFrameTime
 -- @return number Ticks
 game_library.getTickCount = engine.TickCount
 
---- Returns the public IP address and port of the current server. This will return the IP/port that you are connecting through when ran clientside.
+--- Returns the public IP address and port of the current server
 -- @name game_library.getIPAddress
 -- @class function
 -- @return string The IP address and port in the format "x.x.x.x:x"


### PR DESCRIPTION
This adds game.getIPAddress, which is just a direct function call to game.GetIPAddress.
I don't think strings need to be sandboxed, since I see other places in this file that don't sandbox strings - correct me if I'm wrong