### PR TITLE
Add collision sounds to custom props

### DIFF
--- a/lua/entities/starfall_prop/shared.lua
+++ b/lua/entities/starfall_prop/shared.lua
@@ -1,5 +1,6 @@
 ENT.Type            = "anim"
 ENT.Base            = "base_anim"
+ENT.PhysicsSounds   = true
 
 ENT.PrintName       = "Starfall Custom Prop"
 ENT.Author          = "Sparky OvO"


### PR DESCRIPTION
Properly adds in physics collision sounds

GMod Wiki definition:
<img width="489" height="117" alt="image" src="https://github.com/user-attachments/assets/bdb484e3-09c5-4ed6-b246-a2bf5e12503f" />
