### PR TITLE
Fix parameter documentation for `Player.setWeaponColor`

### DIFF
--- a/lua/starfall/libs_sv/players.lua
+++ b/lua/starfall/libs_sv/players.lua
@@ -412,7 +412,7 @@ function player_methods:setFriction(val)
 end
 
 --- Sets the player's weapon color
--- @param vector col The new color with values 0-1 in each vector component
+-- @param Vector col The new color with values 0-1 in each vector component
 function player_methods:setWeaponColor(col)
 	local ent = getply(self)
 	checkpermission(instance, ent, "entities.setPlayerRenderProperty")


### PR DESCRIPTION
Updated documentation for [`Player.setWeaponColor`](https://thegrb93.github.io/StarfallEx/#Types.Player.setWeaponColor) function.