### PR TITLE
Stop some wire lib functions from causing errors

### DIFF
--- a/lua/starfall/libs_sv/wire.lua
+++ b/lua/starfall/libs_sv/wire.lua
@@ -570,14 +570,13 @@ local function parseEntity(ent, io)
 	end
 
 	local names, types = {}, {}
-	if not ent[io] then
-		return names, types
-	end
-
-	for k, v in pairs(ent[io]) do
-		if isstring(k) and isstring(v.Type) and k ~= "" then
-			table.insert(names, k)
-			table.insert(types, v.Type)
+	
+	if ent[io] then
+		for k, v in pairs(ent[io]) do
+			if isstring(k) and isstring(v.Type) and k ~= "" then
+				table.insert(names, k)
+				table.insert(types, v.Type)
+			end
 		end
 	end
 


### PR DESCRIPTION
wire.getInputs() and wire.getOutputs() would cause an error if there was none, so i just added a check.