### PR TITLE
Add `math.tau`

### DIFF
--- a/lua/starfall/libs_sh/math.lua
+++ b/lua/starfall/libs_sh/math.lua
@@ -6,6 +6,7 @@ local checkluatype = SF.CheckLuaType
 -- @class library
 -- @field huge inf error-float. Represents infinity.
 -- @field pi mathematical constant pi (3.1415926535898).
+-- @field tau mathematical constant tau (2*pi = 6.2831853071796).
 -- @libtbl math_library
 SF.RegisterLibrary("math")
 
@@ -230,6 +231,8 @@ math_library.modf = math.modf
 math_library.normalizeAngle = math.NormalizeAngle
 
 math_library.pi = math.pi
+
+math_library.tau = math.tau
 
 --- Returns x raised to the power y
 -- @class function


### PR DESCRIPTION
Adds [`math.tau`](https://wiki.facepunch.com/gmod/math.tau) to the math library. It was added to the game back in 2023 and Expression 2 has it as `_TAU`, so why not also add it here for convenience?