### PR TITLE
Make preprocessor directive parsing less buggy

### DIFF
--- a/lua/starfall/preprocessor.lua
+++ b/lua/starfall/preprocessor.lua
@@ -58,7 +58,9 @@ SF.PreprocessData = {
 			return "?"
 		end,
 		Preprocess = function(self)
-			for wholedirective, directive, args in string.gmatch(self.code, "(%-%-@(%w+)([^\r\n]*))") do
+			-- Prepend a newline so every real line has a leading '\n'
+			-- Match: newline, optional leading whitespace, then --@..., up to end of line
+			for wholedirective, directive, args in string.gmatch("\n"..self.code, "\n%s*(%-%-@(%w+)([^\r\n]*))") do
 				local func = SF.PreprocessData.directives[directive]
 				if func then
 					local err = func(self, string.Trim(args))


### PR DESCRIPTION
Modified to enforce directives be at the beginning of the line, while still allowing leading whitespace

So for example, if you have:
```lua
--@client
print("--@server") --@name not allowed here anymore
         --@model however/this/is/fine.mdl
```

This PR solves it simply by prepending a newline and allowing leading whitespace, therefore the `"--@server"` and `--@name` would no longer match in the above case.