### PR TITLE
fix content-type duplication bug in http.post

### DIFF
--- a/lua/starfall/libs_sh/http.lua
+++ b/lua/starfall/libs_sh/http.lua
@@ -116,6 +116,7 @@ function http_library.post(url, payload, callbackSuccess, callbackFail, headers)
 
 			if string.lower(k) == "content-type" then
 				request.type = v
+				headers[k] = nil
 			end
 		end
 


### PR DESCRIPTION
I discovered a bug in http.post() where passing content-type in your header causes it to be duplicated in the request and break it.

For example, if you set the content-type in the header to "application/json", you may get the following response:

`{
  "error": {
    "message": "Unsupported content type: 'application/json,application/json'. This API method only accepts 'application/json' or 'application/x-www-form-urlencoded' requests, but you specified the header 'Content-Type: application/json,application/json'. Please try again with a supported content type.",
    "type": "invalid_request_error",
    "param": null,
    "code": "unsupported_content_type"
  }
}`

As you can see, the service is reporting that I passed "application/json,application/json" in the header, even though I didn't.

The fix is to simply remove content-type from the headers table, since it is being stored in request.type