### PR TITLE
Fixed getMaxYawRate function documentation

### DIFF
--- a/lua/starfall/libs_sv/nextbot.lua
+++ b/lua/starfall/libs_sv/nextbot.lua
@@ -535,6 +535,7 @@ end
 
 --- Gets the max rate at which the NextBot can visually rotate.
 -- @server
+-- @return number The nextbot's current maximum yaw rate.
 function nb_methods:getMaxYawRate()
 	local nb = nbunwrap(self)
 	return Ent_GetTable(nb).loco:GetMaxYawRate()


### PR DESCRIPTION
It had a param annotation when it is only a getter function. :p