### PR TITLE
Make getPrintName give "nice" text

### DIFF
--- a/lua/starfall/libs_sh/weapons.lua
+++ b/lua/starfall/libs_sh/weapons.lua
@@ -145,7 +145,7 @@ if CLIENT then
 	-- @client
 	-- @return string Display name of weapon
 	function weapon_methods:getPrintName()
-		return Wep_GetPrintName(getwep(self))
+		return language.GetPhrase(string.sub(Wep_GetPrintName(getwep(self)), 2))
 	end
 
 	--- Returns if the weapon is carried by the local player.


### PR DESCRIPTION
The title explains it. This fix automatically translates the print name. ex: #HL2_Crowbar -> CROWBAR