### PR TITLE
Added support for booleans in wirelib

### DIFF
--- a/lua/starfall/libs_sv/wire.lua
+++ b/lua/starfall/libs_sv/wire.lua
@@ -266,7 +266,7 @@ local SFToWire =
 		elseif dataType == TYPE_BOOL then
 			return data and 1 or 0
 		else
-			SF.Throw( "Expected number or boolean", 2 )
+			SF.ThrowTypeError( "number or bool", SF.GetType( data ), 2 )
 		end
 	end,
 	STRING = function(data) checkluatype(data, TYPE_STRING, 2) return data end,


### PR DESCRIPTION
Basically if you do something like:
```lua
wire.ports.A = true
```
it will return 1, if false then 0.