### PR TITLE
Simplify SF.Require

### DIFF
--- a/lua/starfall/sflib.lua
+++ b/lua/starfall/sflib.lua
@@ -1332,7 +1332,7 @@ function SF.Require(name)
 		if ok then
 			return true
 		else
-			ErrorNoHalt(err)
+			ErrorNoHalt(err .. "\n")
 			return false
 		end
 	end


### PR DESCRIPTION
For some reason it might still give an error, so i think it would be more reliable to use the function already built into gmod
```
- Couldn't include file 'includes\modules\joystick.lua' - File not found or is empty (<nowhere>)
1. pcall - [C]:-1
 2. Require - addons/starfallex/lua/starfall/sflib.lua:1342
  3. r - addons/starfallex/lua/starfall/libs_cl/joystick.lua:1
   4. <unknown> - addons/starfallex/lua/starfall/sflib.lua:2448
    5. xpcall - [C]:-1
     6. compileModule - addons/starfallex/lua/starfall/sflib.lua:2448
      7. addModule - addons/starfallex/lua/starfall/sflib.lua:2466
       8. loadModules - addons/starfallex/lua/starfall/sflib.lua:2478
        9. <unknown> - addons/starfallex/lua/starfall/sflib.lua:2485
         10. <unknown> - addons/hook-library/lua/includes/modules/hook.lua:313
```