### PR TITLE
Add IsValid check to OnEntityCreated

### DIFF
--- a/lua/starfall/libs_sh/hook.lua
+++ b/lua/starfall/libs_sh/hook.lua
@@ -517,8 +517,6 @@ add("DoAnimationEvent")
 -- @param Entity ent The created entity. May be invalid if deleted before this hook runs.
 add("OnEntityCreated", nil, function(instance, ent)
 	timer.Simple(0, function()
-		if not IsValid(ent) then return end
-		
 		instance:runScriptHook("onentitycreated", instance.WrapObject(ent))
 	end)
 	return false


### PR DESCRIPTION
I don't understand why this isnt already included, as there is already a timer.Simple that wraps the object. It can be annoying sometimes in starfall that you have to do an IsValid check manually and it's not handled by the hook internally.