### PR TITLE
fix ent:setEyeTarget()

### DIFF
--- a/lua/starfall/libs_sh/entities.lua
+++ b/lua/starfall/libs_sh/entities.lua
@@ -1804,7 +1804,7 @@ function ents_methods:setEyeTarget(pos)
 	
 	vec = vunwrap(pos)
 	checkvector(vec)
-	checkpermission(instance,ent,"entities.canTool")
+	checkpermission(instance, ent, SERVER and "entities.canTool" or "entities.setRenderProperty")
 	
     Ent_SetEyeTarget(ent, vec)
 end


### PR DESCRIPTION
this makes it change the permission to use a clientside one, because it uses a server side only permission currently which throws errors.