### PR TITLE
Update/optimize sf_holograms_display_owners

### DIFF
--- a/lua/entities/starfall_hologram/cl_init.lua
+++ b/lua/entities/starfall_hologram/cl_init.lua
@@ -210,26 +210,26 @@ local function HologramShowOwners()
 	surface.SetFont("DebugOverlay")
 
 	for _, ent in ipairs(ents.FindByClass("starfall_hologram")) do
-		local name, steamid = "No Owner", ""
-		local ply = SF.Permissions.getOwner(ent)
-
-		if ply == SF.Superuser then
-			name = "(Superuser)"
-		elseif IsValid(ply) then
-			name = ply:Name()
-			steamid = ply:SteamID()
-		else
-			ply = ent.SFHoloOwner
-
-			if IsValid(ply) then
-				name = ply:Name()
-				steamid = ply:SteamID()
-			end
-		end
-
 		local vec = ent:GetPos():ToScreen()
 
 		if vec.visible then
+			local name, steamid = "No Owner", ""
+			local ply = SF.Permissions.getOwner(ent)
+
+			if ply == SF.Superuser then
+				name = "(Superuser)"
+			elseif IsValid(ply) then
+				name = ply:Name()
+				steamid = ply:SteamID()
+			else
+				ply = ent.SFHoloOwner
+
+				if IsValid(ply) then
+					name = ply:Name()
+					steamid = ply:SteamID()
+				end
+			end
+
 			local w, h = surface.GetTextSize(name)
 
 			-- Draw nick

--- a/lua/entities/starfall_hologram/cl_init.lua
+++ b/lua/entities/starfall_hologram/cl_init.lua
@@ -34,7 +34,7 @@ local HoloRenderStack = SF.RenderStack({
 	end,
 	function(data)
 		if next(data.clips) then
-			return 
+			return
 [[local clipCount = 0
 local prevClip = render.EnableClipping(true)
 for _, clip in pairs(self.clips) do
@@ -192,7 +192,7 @@ hook.Add("NetworkEntityCreated", "starfall_hologram_rescale", function(holo)
 			holo:EnableMatrix("RenderMultiply", holo.HoloMatrix)
 		end
 
-		if not sf_userrenderbounds then        
+		if not sf_userrenderbounds then
 			local mins, maxs = holo:GetModelBounds()
 			if mins then
 				local scale = holo:GetScale()
@@ -206,39 +206,54 @@ hook.Add("NetworkEntityCreated", "starfall_hologram_rescale", function(holo)
 	end
 end)
 
-local function ShowHologramOwners()
-	for _, ent in ents.Iterator() do
-		if ent.IsSFHologram then
-			local name = "No Owner"
-			local steamID = ""
-			local ply = SF.Permissions.getOwner(ent)
+local function HologramShowOwners()
+	surface.SetFont("DebugOverlay")
 
-			if ply==SF.Superuser then
-				name = "(Superuser)"
-			elseif IsValid(ply) then
+	for _, ent in ipairs(ents.FindByClass("starfall_hologram")) do
+		local name, steamid = "No Owner", ""
+		local ply = SF.Permissions.getOwner(ent)
+
+		if ply == SF.Superuser then
+			name = "(Superuser)"
+		elseif IsValid(ply) then
+			name = ply:Name()
+			steamid = ply:SteamID()
+		else
+			ply = ent.SFHoloOwner
+
+			if IsValid(ply) then
 				name = ply:Name()
-				steamID = ply:SteamID()
-			else
-				ply = ent.SFHoloOwner
-				if IsValid(ply) then
-					name = ply:Name()
-					steamID = ply:SteamID()
-				end
+				steamid = ply:SteamID()
 			end
+		end
 
-			local vec = ent:GetPos():ToScreen()
+		local vec = ent:GetPos():ToScreen()
 
-			draw.DrawText(name .. "\n" .. steamID, "DermaDefault", vec.x, vec.y, Color(255, 0, 0, 255), 1)
+		if vec.visible then
+			local w, h = surface.GetTextSize(name)
+
+			-- Draw nick
+			surface.SetTextColor(0, 255, 255)
+			surface.SetTextPos(vec.x - w / 2, vec.y - h / 2)
+			surface.DrawText(name)
+
+			local w2, h2 = surface.GetTextSize(steamid)
+
+			-- Draw steamid
+			surface.SetTextColor(0, 255, 255)
+			surface.SetTextPos(vec.x - w2 / 2, vec.y + h / 2)
+			surface.DrawText(steamid)
 		end
 	end
 end
 
 local display_owners = false
+
 concommand.Add("sf_holograms_display_owners", function()
 	display_owners = not display_owners
 
 	if display_owners then
-		hook.Add("HUDPaint", "sf_holograms_showowners", ShowHologramOwners)
+		hook.Add("HUDPaint", "sf_holograms_showowners", HologramShowOwners)
 	else
 		hook.Remove("HUDPaint", "sf_holograms_showowners")
 	end


### PR DESCRIPTION
Optimizes/changes the design of the hologram display. For the most part, it now looks the same as the E2 display, but only blue.
I also plan to do a similar pr in wiremod to make them red and make it easier to understand which holograms belong to which addon
<img width="364" height="279" alt="image" src="https://github.com/user-attachments/assets/5524d0ee-e5d2-4b29-b16a-5d6beb3b94d7" />