### PR TITLE
Add chat printing related functions to global SF table

### DIFF
--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -539,8 +539,6 @@ local function argsToChat(...)
 	return processed, length, size
 end
 
-SF.argsToChat = argsToChat
-
 if SERVER then
 	local function sendPrintToPlayer(ply, data, console)
 		net.Start("starfall_print")
@@ -551,8 +549,6 @@ if SERVER then
 		end
 		net.Send(ply)
 	end
-
-	SF.sendPrintToPlayer = sendPrintToPlayer
 
 	--- Prints a message to the player's chat.
 	-- @shared

--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -539,6 +539,8 @@ local function argsToChat(...)
 	return processed, length, size
 end
 
+SF.argsToChat = argsToChat
+
 if SERVER then
 	local function sendPrintToPlayer(ply, data, console)
 		net.Start("starfall_print")
@@ -549,6 +551,8 @@ if SERVER then
 		end
 		net.Send(ply)
 	end
+
+	SF.sendPrintToPlayer = sendPrintToPlayer
 
 	--- Prints a message to the player's chat.
 	-- @shared


### PR DESCRIPTION
Adds `argsToChat` and `sendPrintToPlayer` to the SF table to allow them to be used in other SF addons for convenience in not having to copy-paste entire code chunks to use the same functions.