### PR TITLE
Add `Player:giveWeapon`

### DIFF
--- a/lua/starfall/libs_sv/players.lua
+++ b/lua/starfall/libs_sv/players.lua
@@ -22,6 +22,7 @@ registerprivilege("player.setPos", "Set Position", "Allows the user to teleport 
 registerprivilege("player.setEyeAngles", "SetEyeAngles", "Allows the user to rotate the view of a player to another orientation", { entities = {}, usergroups = { default = 1 } })
 registerprivilege("player.ignite", "Ignite", "Allows the user to ignite players", { entities = {}, usergroups = { default = 1 } })
 registerprivilege("player.addVelocity", "AddVelocity", "Allows the user to add velocity to a player", { entities = { default = 3 }, usergroups = { default = 1 } })
+registerprivilege("player.giveweapon", "GiveWeapon", "Gives a player a weapon", { usergroups = { default = 1 }, entities = {} })
 
 local PVSLimitCvar = CreateConVar("sf_pvs_pointlimit", 16, FCVAR_ARCHIVE, "The number of PVS points that can be set on each player, limit is shared across all chips")
 
@@ -191,6 +192,24 @@ end
 -- @return boolean True if the player has godmode
 function player_methods:hasGodMode()
 	return Ply_HasGodMode(getply(self))
+end
+
+--- Gives the player a weapon
+-- @param string weapon The class name of the weapon to give
+-- @param boolean? noAmmo Prevent giving ammo on weapon spawn?, Defaults to false.
+-- @return Weapon The weapon
+function player_methods:giveWeapon(weapon, noAmmo)
+	checkluatype(weapon, TYPE_STRING)
+	if noAmmo ~= nil then checkluatype(noAmmo, TYPE_BOOL) end
+	local ply = getply(self)
+    checkpermission(instance, ply, "player.giveweapon")
+
+    local wpnEntry = list.GetEntry("Weapon", weapon)
+    if wpnEntry and wpnEntry.Spawnable then
+        return wwrap(Ply_Give(ply, weapon, noAmmo))
+    else
+        SF.Throw("Invalid weapon!")
+    end
 end
 
 --- Drops the player's weapon

--- a/lua/starfall/libs_sv/players.lua
+++ b/lua/starfall/libs_sv/players.lua
@@ -201,15 +201,15 @@ end
 function player_methods:giveWeapon(weapon, noAmmo)
 	checkluatype(weapon, TYPE_STRING)
 	if noAmmo ~= nil then checkluatype(noAmmo, TYPE_BOOL) end
+
 	local ply = getply(self)
     checkpermission(instance, ply, "player.giveweapon")
 
     local wpnEntry = list.GetEntry("Weapon", weapon)
-    if wpnEntry and wpnEntry.Spawnable then
-        return wwrap(Ply_Give(ply, weapon, noAmmo))
-    else
-        SF.Throw("Invalid weapon!")
-    end
+    if not wpnEntry then SF.Throw(weapon .. " is not a Valid SWEP!") end
+    if not wpnEntry.Spawnable then SF.Throw(weapon .. " is not a Spawnable SWEP!") end
+
+    return wwrap(Ply_Give(ply, weapon, noAmmo))
 end
 
 --- Drops the player's weapon

--- a/lua/starfall/libs_sv/players.lua
+++ b/lua/starfall/libs_sv/players.lua
@@ -205,7 +205,7 @@ function player_methods:giveWeapon(weapon, noAmmo)
 	local ply = getply(self)
     checkpermission(instance, ply, "player.giveweapon")
 
-    local wpnEntry = list.GetEntry("Weapon", weapon)
+    local wpnEntry = list.GetForEdit("Weapon", true)[weapon]
     if not wpnEntry then SF.Throw(weapon .. " is not a Valid SWEP!") end
     if not wpnEntry.Spawnable then SF.Throw(weapon .. " is not a Spawnable SWEP!") end
 


### PR DESCRIPTION
Adds a `giveWeapon` function for `Player` that is Admin-Only by default, it is restricted to registered weapons as the GLua `Give` function is capable of spawning any entity, it is also restricted to weapons marked as `Spawnable` just to be safe.