### PR TITLE
Add 'authorization' to header whitelist

### DIFF
--- a/lua/starfall/libs_sh/http.lua
+++ b/lua/starfall/libs_sh/http.lua
@@ -17,7 +17,7 @@ SF.RegisterLibrary("http")
 
 local headerWhitelist = SF.StringRestrictor(false)
 -- Feel free to pull-request if you need something
-for _, v in ipairs{"accept", "accept-language", "accept-encoding", "content-type", "content-length"} do
+for _, v in ipairs{"accept", "accept-language", "accept-encoding", "authorization", "content-type", "content-length"} do
 	headerWhitelist:addWhitelistEntry(v)
 end
 


### PR DESCRIPTION
Adds authorization to header whitelist which would make life much easier for (for example) those who don't rely on a proxy for their API keys.