### PR TITLE
Fix header whitelist pattern matching, add x-goog-api-key

### DIFF
--- a/lua/starfall/libs_sh/http.lua
+++ b/lua/starfall/libs_sh/http.lua
@@ -17,8 +17,8 @@ SF.RegisterLibrary("http")
 
 local headerWhitelist = SF.StringRestrictor(false)
 -- Feel free to pull-request if you need something
-for _, v in ipairs{"accept", "accept-language", "accept-encoding", "authorization", "content-type", "content-length"} do
-	headerWhitelist:addWhitelistEntry(v)
+for _, v in ipairs{"accept", "accept-language", "accept-encoding", "authorization", "content-type", "content-length", "x-goog-api-key"} do
+	headerWhitelist:addWhitelistEntry(string.PatternSafe(v))
 end
 
 return function(instance)


### PR DESCRIPTION
Whitelist entries containing hyphens (content-type, x-goog-api-key) failed to match because StringRestrictor.check uses string.match and '-' is a magic Lua pattern character. Wrap entries with string.PatternSafe to escape them.

Also adds x-goog-api-key to the whitelist for Google AI Studio / Gemini API authentication.