### PR TITLE
Detour halo rendering to block in RT rendering

### DIFF
--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -2496,6 +2496,7 @@ function render_library.renderView(tbl)
 		changedFilterMin = renderdata.changedFilterMin,
 		prevClippingState = renderdata.prevClippingState,
 		noStencil = renderdata.noStencil,
+		usingRT = renderdata.usingRT,
 		pushedClippingPlanes = pushedClippingPlanes,
 		noPrevHaloHook = hook.GetTable().ShouldDrawHalos.SF==nil
 	}
@@ -2552,7 +2553,6 @@ function render_library.renderView(tbl)
 	renderdata.prevClippingState = prevData.prevClippingState
 	renderdata.noStencil = prevData.noStencil
 	renderdata.usingRT = prevData.usingRT
-	usingRT = prevData.usingRT
 	pushedClippingPlanes = prevData.pushedClippingPlanes
 
 	if prevData.noPrevHaloHook then

--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -131,7 +131,6 @@ local MATRIX_STACK_LIMIT = 8
 local matrix_stack = {}
 local view_matrix_stack = {}
 local renderingView = false
-local usingRT = false
 local renderingViewRt
 local drawViewerInView = false
 local MAX_CLIPPING_PLANES = 4
@@ -142,15 +141,8 @@ local pp = {
 	bloom = Material("pp/bloom"),			-- basetexture, levelr, levelg, levelb, colormul
 	colour = Material("pp/colour"),			-- fbtexture, pp_colour_*: addr, addg, addb, brightness, colour, contrast, mulr, mulg, mulb
 	downsample = Material("pp/downsample")	-- fbtexture, darken, multiply
+
 }
-
-local Halo_Render = SF.OG_Halo_Render or halo.Render
-SF.OG_Halo_Render = Halo_Render
-function halo.Render(entry)
-	if usingRT then return end
-	Halo_Render(entry)
-end
-
 local tex_screenEffect = render.GetScreenEffectTexture(0)
 
 local rt_bank = SF.ResourceHandler("render_rendertargets", "Render targets", "20", "The max number of user created rendertargets",
@@ -1242,7 +1234,6 @@ function render_library.selectRenderTarget(name)
 			view_matrix_stack[#view_matrix_stack + 1] = "End2D"
 			render.SetStencilEnable(false)
 			renderdata.usingRT = true
-			usingRT = true
 		end
 	else
 		if renderdata.usingRT and not renderdata.needRT then
@@ -1258,7 +1249,6 @@ function render_library.selectRenderTarget(name)
 				view_matrix_stack[i] = nil
 			end
 			renderdata.usingRT = false
-			usingRT = false
 			if renderdata.noStencil then -- Revert ALL stencil settings from screen
 				render.SetStencilEnable(true)
 				render.SetStencilFailOperation(STENCILOPERATION_KEEP)
@@ -2506,9 +2496,11 @@ function render_library.renderView(tbl)
 		changedFilterMin = renderdata.changedFilterMin,
 		prevClippingState = renderdata.prevClippingState,
 		noStencil = renderdata.noStencil,
-		usingRT = renderdata.usingRT,
-		pushedClippingPlanes = pushedClippingPlanes
+		pushedClippingPlanes = pushedClippingPlanes,
+		noPrevHaloHook = hook.GetTable().ShouldDrawHalos.SF==nil
 	}
+
+	hook.Add("ShouldDrawHalos","SF",function() return false end)
 
 	matrix_stack = { }
 	view_matrix_stack = { }
@@ -2562,6 +2554,10 @@ function render_library.renderView(tbl)
 	renderdata.usingRT = prevData.usingRT
 	usingRT = prevData.usingRT
 	pushedClippingPlanes = prevData.pushedClippingPlanes
+
+	if prevData.noPrevHaloHook then
+		hook.Remove("ShouldDrawHalos","SF")
+	end
 
 	renderingView = false
 	renderdata.renderingView = false

--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -2497,8 +2497,7 @@ function render_library.renderView(tbl)
 		prevClippingState = renderdata.prevClippingState,
 		noStencil = renderdata.noStencil,
 		usingRT = renderdata.usingRT,
-		pushedClippingPlanes = pushedClippingPlanes,
-		noPrevHaloHook = hook.GetTable().ShouldDrawHalos.SF==nil
+		pushedClippingPlanes = pushedClippingPlanes
 	}
 
 	hook.Add("ShouldDrawHalos","SF",function() return false end)
@@ -2555,9 +2554,7 @@ function render_library.renderView(tbl)
 	renderdata.usingRT = prevData.usingRT
 	pushedClippingPlanes = prevData.pushedClippingPlanes
 
-	if prevData.noPrevHaloHook then
-		hook.Remove("ShouldDrawHalos","SF")
-	end
+	hook.Remove("ShouldDrawHalos","SF")
 
 	renderingView = false
 	renderdata.renderingView = false

--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -131,6 +131,7 @@ local MATRIX_STACK_LIMIT = 8
 local matrix_stack = {}
 local view_matrix_stack = {}
 local renderingView = false
+local usingRT = false
 local renderingViewRt
 local drawViewerInView = false
 local MAX_CLIPPING_PLANES = 4
@@ -141,8 +142,15 @@ local pp = {
 	bloom = Material("pp/bloom"),			-- basetexture, levelr, levelg, levelb, colormul
 	colour = Material("pp/colour"),			-- fbtexture, pp_colour_*: addr, addg, addb, brightness, colour, contrast, mulr, mulg, mulb
 	downsample = Material("pp/downsample")	-- fbtexture, darken, multiply
-
 }
+
+local Halo_Render = SF.OG_Halo_Render or halo.Render
+SF.OG_Halo_Render = Halo_Render
+function halo.Render(entry)
+	if usingRT then return end
+	Halo_Render(entry)
+end
+
 local tex_screenEffect = render.GetScreenEffectTexture(0)
 
 local rt_bank = SF.ResourceHandler("render_rendertargets", "Render targets", "20", "The max number of user created rendertargets",
@@ -1234,6 +1242,7 @@ function render_library.selectRenderTarget(name)
 			view_matrix_stack[#view_matrix_stack + 1] = "End2D"
 			render.SetStencilEnable(false)
 			renderdata.usingRT = true
+			usingRT = true
 		end
 	else
 		if renderdata.usingRT and not renderdata.needRT then
@@ -1249,6 +1258,7 @@ function render_library.selectRenderTarget(name)
 				view_matrix_stack[i] = nil
 			end
 			renderdata.usingRT = false
+			usingRT = false
 			if renderdata.noStencil then -- Revert ALL stencil settings from screen
 				render.SetStencilEnable(true)
 				render.SetStencilFailOperation(STENCILOPERATION_KEEP)
@@ -2550,6 +2560,7 @@ function render_library.renderView(tbl)
 	renderdata.prevClippingState = prevData.prevClippingState
 	renderdata.noStencil = prevData.noStencil
 	renderdata.usingRT = prevData.usingRT
+	usingRT = prevData.usingRT
 	pushedClippingPlanes = prevData.pushedClippingPlanes
 
 	renderingView = false

--- a/lua/starfall/sflib.lua
+++ b/lua/starfall/sflib.lua
@@ -97,6 +97,18 @@ hook.Add("InitPostEntity","SF_SanitizeTypeMetatables",function()
 			return unpack(result)
 		end
 	end
+	if CLIENT and not (WireLib and WireLib.__old_renderhalos) then
+		local old_renderhalos = hook.GetTable().PostDrawEffects.RenderHalos
+		if old_renderhalos ~= nil then
+			hook.Add("PostDrawEffects","RenderHalos", function()
+				if hook.Run("ShouldDrawHalos") == false then return end
+
+				old_renderhalos()
+			end)
+		else
+			ErrorNoHalt("RenderHalos detour failed (RenderHalos hook not found)!")
+		end
+	end
 end)
 
 local removedHooks = setmetatable({}, {__index=function(t,k) local r={} t[k]=r return r end})


### PR DESCRIPTION
Kinda sucks but this is a general gmod issue
I see no better way to fix this problem...
```lua
local RT_NAME = "repro_halo_rt"
local RT_SIZE = 1024

local rt = GetRenderTarget( RT_NAME, RT_SIZE, RT_SIZE )

local rtMat = CreateMaterial("repro_halo_rt_mat", "UnlitGeneric", {
    ["$basetexture"] = "color/white",
    ["$translucent"] = 1,
})
rtMat:SetTexture("$basetexture", rt)

local TARGET        = NULL
local HALO_ON       = true
local POSTPROCESS   = false
local HALO_COLOR    = Color(0, 255, 0)

concommand.Add("repro_settarget", function()
    local tr = LocalPlayer():GetEyeTrace()
    if IsValid(tr.Entity) and not tr.Entity:IsWorld() then
        TARGET = tr.Entity
    end
end)

concommand.Add("repro_halo", function(_, _, args) HALO_ON = not HALO_ON end)
concommand.Add("repro_postprocess", function(_, _, args) POSTPROCESS = (tonumber(args[ 1 ]) or 0) ~= 0 end)

hook.Add("PreDrawHalos", "repro_halo_add", function()
    if HALO_ON and IsValid(TARGET) then
        halo.Add({TARGET}, HALO_COLOR, 2, 2, 1, true, false)
    end
end)

hook.Add("PreRender", "repro_capture", function()
    if not IsValid(TARGET) then return end

    local tpos = TARGET:GetPos()
    local origin = tpos + Vector(120, 0, 40)
    local ang = (tpos - origin):Angle()

    render.PushRenderTarget(rt)
        render.Clear(20, 20, 28, 255, true, true)

        render.RenderView({
            origin        = origin,
            angles        = ang,
            x             = 0,
            y             = 0,
            w             = RT_SIZE,
            h             = RT_SIZE,
            fov           = 75,
            drawhud       = false,
            drawviewmodel = false,
            dopostprocess = POSTPROCESS,
            bloomtone     = false,
        })
    render.PopRenderTarget()
end)

hook.Add("HUDPaint", "repro_blit", function()
    if not IsValid(TARGET) then return end

    local w, h = 384, 384
    local x = ScrW() / 2 - w - 24
    local y = (ScrH() / 2) - (h / 2)

    surface.SetDrawColor(0, 0, 0, 255)
    surface.DrawRect(x - 3, y - 3, w + 6, h + 6)

    surface.SetDrawColor(255, 255, 255, 255)
    surface.SetMaterial(rtMat)
    surface.DrawTexturedRect(x, y, w, h)

    draw.SimpleText(
        "halo " .. (HALO_ON and "ON (expect dim)" or "OFF (expect bright)") ..
        "   pp=" .. tostring(POSTPROCESS),
        "DermaDefault", x, y + h + 6, color_white
    )
end)
```
This reproduces the problem in glua

The only bug I really see is that this *may* result in some halos not rendering at all, even in the main stock Source/Gmod view, if a Starfall is using setRenderTarget. However, I am of the belief that until Gmod fixes this problem (as it is a gmod problem it seems) that this is preferable (halos being unavailable when using starfall rendertargets) vs. renderView being completely darkened and barely usable otherwise.