### PR TITLE
Provide a more stable reference for argsToChat

### DIFF
--- a/lua/starfall/libs_sh/builtins.lua
+++ b/lua/starfall/libs_sh/builtins.lua
@@ -537,6 +537,14 @@ local function argsToChat(...)
 	return processed, length, size
 end
 
+-- for custom SF library developers:
+-- Use `instance.argsToChat` in your new code:
+--  *  `instance.argsToChat` provides a more reliable reference to the `argsToChat` function than `SF.argsToChat` does
+--  *  `SF` is a global table, while `instance` is per-instance, as the name implies..
+
+instance.argsToChat = argsToChat
+
+-- here for compatiblity with older SF library addons - See note above
 SF.argsToChat = argsToChat
 
 if SERVER then


### PR DESCRIPTION
The function `SF.argsToChat` changes with each instance created to the instance's use of `argsToChat`, this is no issue for the internals of Starfall as they use the `local function argsToChat`, but SF extensions that add their own libraries may use `SF.argsToChat` instead as it's conveniently on the `SF` global table.

The issue arises when multiple instances are placed, changing the reference of `SF.argsToChat`, and if the addons don't localize `SF.argsToChat`, their reference will break and not parse colors correctly due to a mismatched `col_meta`.

This PR solves the issue by adding a newer, more stable reference on the instance itself, which is unlikely to change compared to `SF.argsToChat`. `SF.argsToChat` remains as "legacy" for any potential SF addons that may use it, but a note is added to discourage use of it in any newer code.
