### PR TITLE
Whitelist DuckDuckGo (search engine)

### DIFF
--- a/lua/starfall/starfall_whitelist_default.lua
+++ b/lua/starfall/starfall_whitelist_default.lua
@@ -220,3 +220,11 @@ simple [[rawcdn.githack.com]]
 --- https://cdn.statically.io/gh/Metastruct/garrysmod-chatsounds/master/sound/chatsounds/autoadd/anime/i%20love%20you.ogg
 --- https://cdn.statically.io/img/statically.dev/w=300,h=500/cat.jpg
 simple [[cdn.statically.io]]
+
+-- DuckDuckGo (search engine)
+--- https://duckduckgo.com/?q=initial_request_to_extract_vqd_token
+--- Examples:
+--- https://duckduckgo.com/v.js?q=nocopyrightsounds&o=json&p=-1&s=0&vqd=4-xxxxxxxxxxxxxxxx&l=wt-wt
+simple [[duckduckgo.com]]
+simple [[html.duckduckgo.com]]
+simple [[noai.duckduckgo.com]]


### PR DESCRIPTION
I want to make search engine... Therefore I propose to whitelist DuckDuckGo (DDG).

To perform a search with DDG, a `vqd` token is required. It can be extracted by making a simple/random search HTTP request, for example: `https://duckduckgo.com/?q=initial_request_to_extract_vqd_token`.

After obtaining a `vqd` token, it is possible to perform searching, for example to fetch NCS videos (outputs json):
`https://duckduckgo.com/v.js?q=nocopyrightsounds&o=json&p=-1&s=0&vqd=4-xxxxxxxxxxxxxxxx&l=wt-wt&ia=videos`

`s` is optional and controls the pagination (e.g. use 60 to skip first 60 results).
`p` is optional for safe-search, but there are other optional flags/filtering that can be specified (video duration, etc).