### PR TITLE
Add ignoreConversions to `json.decode`

### DIFF
--- a/lua/starfall/libs_sh/json.lua
+++ b/lua/starfall/libs_sh/json.lua
@@ -36,11 +36,12 @@ end
 
 --- Convert JSON string to table
 -- @param string s String to decode
+-- @param boolean? ignoreConversions Optional. If true, ignore string to number conversions for table keys
 -- @return table Table representing the JSON object
-function json_library.decode(s)
+function json_library.decode(s, ignoreConversions)
 	SF.CheckLuaType(s, TYPE_STRING)
 	if #s > max_json:GetInt()*1e6 then SF.Throw("Input json data exceeds max allowed!", 2) end
-	return instance.Sanitize(util.JSONToTable(s))
+	return instance.Sanitize(util.JSONToTable(s, false, ignoreConversions))
 end
 
 end


### PR DESCRIPTION
https://wiki.facepunch.com/gmod/util.JSONToTable

> ignoreConversions (default = false):
> If this is false, keys are converted to numbers wherever possible. This means using [Player:SteamID64](https://wiki.facepunch.com/gmod/Player:SteamID64) as keys won't work.

I need access to this option, because I am using SteamID64 as table keys, and have to turn off automatic number conversion for it to work.
