### PR TITLE
Add `wire.isConnected` function

### DIFF
--- a/lua/starfall/libs_sv/wire.lua
+++ b/lua/starfall/libs_sv/wire.lua
@@ -620,8 +620,9 @@ function wire_library.isConnected(ent, inputName)
 	ent = eunwrap(ent)
 	checkpermission(instance, ent, "wire.getInputs")
 
-	local input = ent.Inputs and ent.Inputs[inputName]
-	return Ent_IsValid(input and input.Src)
+	local inputs = Ent_GetTable(ent).Inputs or SF.Throw("Entity has no inputs", 2)
+	local input = inputs[inputName] or SF.Throw("Invalid input: " .. inputName, 2)
+	return Ent_IsValid(input.Src)
 end
 
 --- Returns a wirelink to a wire entity

--- a/lua/starfall/libs_sv/wire.lua
+++ b/lua/starfall/libs_sv/wire.lua
@@ -611,6 +611,20 @@ function wire_library.getOutputs(entO)
 	return parseEntity(entO, "Outputs")
 end
 
+--- Checks if a given input on an entity is connected to any output
+-- @param Entity ent Entity with input
+-- @param string inputName Input name to check
+-- @return boolean Whether the input is connected
+function wire_library.isConnected(ent, inputName)
+	checkluatype(inputName, TYPE_STRING)
+	ent = eunwrap(ent)
+	checkpermission(instance, ent, "wire.getInputs")
+
+	local input = ent.Inputs and ent.Inputs[inputName]
+	if input and Ent_IsValid(input.Src) then return true end
+	return false
+end
+
 --- Returns a wirelink to a wire entity
 -- @param Entity ent Wire entity
 -- @return Wirelink Wirelink of the entity

--- a/lua/starfall/libs_sv/wire.lua
+++ b/lua/starfall/libs_sv/wire.lua
@@ -621,8 +621,7 @@ function wire_library.isConnected(ent, inputName)
 	checkpermission(instance, ent, "wire.getInputs")
 
 	local input = ent.Inputs and ent.Inputs[inputName]
-	if input and Ent_IsValid(input.Src) then return true end
-	return false
+	return Ent_IsValid(input and input.Src)
 end
 
 --- Returns a wirelink to a wire entity


### PR DESCRIPTION
Untested.

For simplicity, to avoid having to get wirelink and then call `isWired`.