### PR TITLE
Fix context menu lua errors

### DIFF
--- a/lua/entities/starfall_processor/shared.lua
+++ b/lua/entities/starfall_processor/shared.lua
@@ -139,10 +139,12 @@ local function MenuOpen( ContextMenu, Option, Entity, Trace )
 	end
 	local SubMenu = Option:AddSubMenu()
 	SubMenu:AddOption("Restart Clientside", function ()
+		if not Ent_IsValid(ent) then return end
 		ent:Compile()
 	end):SetIcon("icon16/arrow_refresh.png")
 
 	SubMenu:AddOption("Terminate Clientside", function ()
+		if not Ent_IsValid(ent) then return end
 		ent:Error({message = "Terminated", traceback = ""})
 	end):SetIcon("icon16/cancel.png")
 
@@ -156,10 +158,12 @@ local function MenuOpen( ContextMenu, Option, Entity, Trace )
 	if instance and instance.player == LocalPlayer() then
 		if ent:GetReuploadOnReload() then
 			SubMenu:AddOption("Disable reupload on reload", function ()
+				if not Ent_IsValid(ent) then return end
 				ent:SetReuploadOnReload(false)
 			end):SetIcon("icon16/cross.png")
 		else
 			SubMenu:AddOption("Enable reupload on reload", function ()
+				if not Ent_IsValid(ent) then return end
 				ent:SetReuploadOnReload(true)
 			end):SetIcon("icon16/tick.png")
 		end
@@ -168,6 +172,7 @@ local function MenuOpen( ContextMenu, Option, Entity, Trace )
 	if instance and instance.player ~= SF.Superuser and (instance.permissionRequest and instance.permissionRequest.overrides and table.Count(instance.permissionRequest.overrides) > 0
 				or instance.permissionOverrides and table.Count(instance.permissionOverrides) > 0) then
 		SubMenu:AddOption("Overriding Permissions", function ()
+			if not Ent_IsValid(ent) then return end
 			local pnl = vgui.Create("SFChipPermissions")
 			if pnl then pnl:OpenForChip(ent) end
 		end)


### PR DESCRIPTION
They occur when attempting to use a property on a chip that has already been removed

For example:
```
- addons/starfallex/lua/entities/starfall_processor/shared.lua:146: attempt to call method 'Error' (a nil value)
1. DoClick - addons/starfallex/lua/entities/starfall_processor/shared.lua:146
 2. OnMouseReleased - lua/vgui/dlabel.lua:253
  3. <unknown> - lua/vgui/dmenuoption.lua:77
```