### PR TITLE
Added screen effect functions

### DIFF
--- a/lua/starfall/examples/fisheye_screeneffect.lua
+++ b/lua/starfall/examples/fisheye_screeneffect.lua
@@ -1,0 +1,29 @@
+--@name Fish-eye effect
+--@client
+--@owneronly
+
+-- Enabling our HUD
+enableHud(owner(), true)
+
+-- Get screenspace texture
+local screenspace = render.getScreenEffectTexture()
+
+-- We should create material firstly
+local fisheye = material.create("Refract_DX90")
+-- There we set screen effect texture to refract it
+fisheye:setTexture("$basetexture", screenspace)
+-- Fish-eye $dudvmap and $normalmap
+fisheye:setTexture("$dudvmap", "models/effects/fisheyelens_dudv")
+fisheye:setTexture("$normalmap", "models/effects/fisheyelens_normal")
+-- Refract amount. Negative values will gave fish-eye effect like GoPro
+fisheye:setFloat("$refractamount", -0.07)
+
+-- To render effect, we will use DrawHUD
+hook.add("DrawHUD", "FisheyeEffect", function()
+    -- Update screenspace texture (to render it again with new information)
+    render.updateScreenEffectTexture()
+    -- And draw refracted texture (fish-eye)
+    render.setMaterial(fisheye)
+    render.drawTexturedRect(0, 0, render.getGameResolution())
+end)
+

--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -2811,9 +2811,8 @@ end
 -- @param number textureIndex? Texture index to update. (optional, default is 0)
 function render_library.updateScreenEffectTexture(textureIndex)
 	checkpermission(instance, nil, "render.screeneffect")
-  if textureIndex == nil then textureIndex = 0 end
-	checkluatype(textureIndex, TYPE_NUMBER)
-  render.UpdateScreenEffectTexture(textureIndex)
+	if textureIndex ~= nil then checkluatype(textureIndex, TYPE_NUMBER) else textureIndex = 0 end
+	render.UpdateScreenEffectTexture(textureIndex)
 end
 
 --- Obtain an texture of the screen. You must call render.updateScreenEffectTexture in order to update this texture with the currently rendered scene
@@ -2821,9 +2820,8 @@ end
 -- @param number textureIndex? Texture index to update. (optional, default is 0)
 -- @return string Requested texture
 function render_library.getScreenEffectTexture(textureIndex)
-  if textureIndex == nil then textureIndex = 0 end
-	checkluatype(textureIndex, TYPE_NUMBER)
-  return render.GetScreenEffectTexture(textureIndex):GetName()
+	if textureIndex ~= nil then checkluatype(textureIndex, TYPE_NUMBER) else textureIndex = 0 end
+	return render.GetScreenEffectTexture(textureIndex):GetName()
 end
 
 end

--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -2812,13 +2812,13 @@ end
 function render_library.updateScreenEffectTexture(textureIndex)
 	checkpermission(instance, nil, "render.screeneffect")
 	if textureIndex ~= nil then
-      checkluatype(textureIndex, TYPE_NUMBER)
-      if textureIndex < 0 or textureIndex > 3 then
-          SF.Throw("Invalid screen effect texture index: "..textureIndex, 2)
-      end
-  else
-      textureIndex = 0
-  end
+		checkluatype(textureIndex, TYPE_NUMBER)
+		if textureIndex < 0 or textureIndex > 3 then
+			SF.Throw("Invalid screen effect texture index: "..textureIndex, 2)
+		end
+	else
+		textureIndex = 0
+	end
 	render.UpdateScreenEffectTexture(textureIndex)
 end
 
@@ -2828,13 +2828,13 @@ end
 -- @return string Requested texture
 function render_library.getScreenEffectTexture(textureIndex)
 	if textureIndex ~= nil then
-      checkluatype(textureIndex, TYPE_NUMBER)
-      if textureIndex < 0 or textureIndex > 3 then
-          SF.Throw("Invalid screen effect texture index: "..textureIndex, 2)
-      end
-  else
-      textureIndex = 0
-  end
+		checkluatype(textureIndex, TYPE_NUMBER)
+		if textureIndex < 0 or textureIndex > 3 then
+			SF.Throw("Invalid screen effect texture index: "..textureIndex, 2)
+		end
+	else
+		textureIndex = 0
+	end
 	return render.GetScreenEffectTexture(textureIndex):GetName()
 end
 

--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -2811,7 +2811,14 @@ end
 -- @param number textureIndex? Texture index to update. (optional, default is 0)
 function render_library.updateScreenEffectTexture(textureIndex)
 	checkpermission(instance, nil, "render.screeneffect")
-	if textureIndex ~= nil then checkluatype(textureIndex, TYPE_NUMBER) else textureIndex = 0 end
+	if textureIndex ~= nil then
+      checkluatype(textureIndex, TYPE_NUMBER)
+      if textureIndex < 0 or textureIndex > 3 then
+          SF.Throw("Invalid screen effect texture index: "..textureIndex, 2)
+      end
+  else
+      textureIndex = 0
+  end
 	render.UpdateScreenEffectTexture(textureIndex)
 end
 
@@ -2820,7 +2827,14 @@ end
 -- @param number textureIndex? Texture index to update. (optional, default is 0)
 -- @return string Requested texture
 function render_library.getScreenEffectTexture(textureIndex)
-	if textureIndex ~= nil then checkluatype(textureIndex, TYPE_NUMBER) else textureIndex = 0 end
+	if textureIndex ~= nil then
+      checkluatype(textureIndex, TYPE_NUMBER)
+      if textureIndex < 0 or textureIndex > 3 then
+          SF.Throw("Invalid screen effect texture index: "..textureIndex, 2)
+      end
+  else
+      textureIndex = 0
+  end
 	return render.GetScreenEffectTexture(textureIndex):GetName()
 end
 

--- a/lua/starfall/libs_cl/render.lua
+++ b/lua/starfall/libs_cl/render.lua
@@ -27,6 +27,7 @@ registerprivilege("render.fog", "Render Fog", "Allows the user to control fog", 
 registerprivilege("render.hud", "Render Hud", "Allows the user to render to your hud", { client = { default = 5 } })
 registerprivilege("render.calcview", "Render CalcView", "Allows the use of the CalcView hook", { client = { default = 5 } })
 registerprivilege("render.screenshake", "Render Screen Shake", "Allows screen shaking", { client = { default = 5 } })
+registerprivilege("render.screeneffect", "Screenspace effects", "Allows the use of screenspace effects", { client = { default = 5 } })
 
 local cv_max_fonts = CreateConVar("sf_render_maxfonts", "30", { FCVAR_ARCHIVE })
 local cv_max_maxrenderviewsperframe = CreateConVar("sf_render_maxrenderviewsperframe", "2", { FCVAR_ARCHIVE })
@@ -2803,6 +2804,26 @@ function render_library.pixelVisible(position, radius)
 	local PixVis = pixhandle_bank:use(instance.player)
 	renderdata.usedPixelVis[#renderdata.usedPixelVis + 1] = PixVis
 	return util.PixelVisible(position, radius, PixVis)
+end
+
+--- Copies the entire screen to the screen effect texture, which can be acquired via render.getScreenEffectTexture (Requires HUD)
+-- @client
+-- @param number textureIndex? Texture index to update. (optional, default is 0)
+function render_library.updateScreenEffectTexture(textureIndex)
+	checkpermission(instance, nil, "render.screeneffect")
+  if textureIndex == nil then textureIndex = 0 end
+	checkluatype(textureIndex, TYPE_NUMBER)
+  render.UpdateScreenEffectTexture(textureIndex)
+end
+
+--- Obtain an texture of the screen. You must call render.updateScreenEffectTexture in order to update this texture with the currently rendered scene
+-- @client
+-- @param number textureIndex? Texture index to update. (optional, default is 0)
+-- @return string Requested texture
+function render_library.getScreenEffectTexture(textureIndex)
+  if textureIndex == nil then textureIndex = 0 end
+	checkluatype(textureIndex, TYPE_NUMBER)
+  return render.GetScreenEffectTexture(textureIndex):GetName()
 end
 
 end


### PR DESCRIPTION
* Added function `render.getScreenEffectTexture(textureId number)`
* Added function `render.updateScreenEffectTexture(textureId number)`
* Screen effect update requires permission `render.screeneffect`, by default this permission requires HUD
* Added example for simple fish-eye overlay