### PR TITLE
Update starfall_whitelist_default.lua

### DIFF
--- a/lua/starfall/starfall_whitelist_default.lua
+++ b/lua/starfall/starfall_whitelist_default.lua
@@ -189,14 +189,10 @@ pattern [[([%w-_]+)%.dzcdn%.net/(.+)]]
 -- https://tts.cyzon.us/tts?text=test
 pattern [[tts.cyzon.us/(.+)]]
 
--- Revolt
+-- Stoat
 --- Examples:
----  https://static.revolt.chat/emoji/mutant/1f440.svg?rev=3
----  https://autumn.revolt.chat/emojis/01G7J9RTHKEPJM8DM19TX35M8N
----  https://autumn.revolt.chat/attachments/mmCR_bFMLEfBAE8mweH2u4o9_x6DiDtU9JXoSbdvZE/live-bocchi-reaction.gif
-simple [[static.revolt.chat]]
-simple [[autumn.revolt.chat]]
-simple [[cdn.revoltusercontent.com]]
+---  https://cdn.stoatusercontent.com/attachments/mmCR_bFMLEfBAE8mweH2u4o9_x6DiDtU9JXoSbdvZE/live-bocchi-reaction.gif
+simple [[cdn.stoatusercontent.com]]
 
 -- Youtube Converter API
 --- Examples:


### PR DESCRIPTION
Revolt renamed into Stoat some times ago, `cdn.revoltusercontent.com` was still working but it now just redirect to `cdn.stoatusercontent.com`