### PR TITLE
Extend `Entity:getChipName()` to support FPGA and Wire Gates

### DIFF
--- a/lua/starfall/libs_sh/entities.lua
+++ b/lua/starfall/libs_sh/entities.lua
@@ -1068,15 +1068,27 @@ function ents_methods:isAlive()
 	return Ent_Alive(eunwrap(self))
 end
 
---- Returns the starfall or expression2's name
+--- Returns the starfall, wire gate, wire fpga or expression2's name
 -- @return string The name of the chip
 function ents_methods:getChipName()
 	local ent = eunwrap(self)
-	local GetGateName = Ent_GetTable(ent).GetGateName
+	local tbl = Ent_GetTable(ent)
+	local GetGateName = tbl.GetGateName
+	local GetOverlayData = tbl.GetOverlayData
+	local class = Ent_GetClass(ent)
 	if GetGateName then
 		return tostring(GetGateName(ent))
+	elseif class == "gmod_wire_fpga" then
+		local data = GetOverlayData and GetOverlayData(ent)
+		if not (data and data.name) then return "(none)" end
+		return tostring(data.name)
+	elseif class == "gmod_wire_gate" then
+		local data = GetOverlayData and GetOverlayData(ent)
+		if not (data and data.txt) then return "(none)" end
+		local lines = data.txt:Split("\n")
+		return lines[1]
 	else
-		SF.Throw("The entity is not a starfall or expression2!", 2)
+		SF.Throw("The entity is not a starfall, wire gate, wire fpga or expression2!", 2)
 	end
 end
 

--- a/lua/starfall/libs_sh/entities.lua
+++ b/lua/starfall/libs_sh/entities.lua
@@ -1085,7 +1085,7 @@ function ents_methods:getChipName()
 	elseif class == "gmod_wire_gate" then
 		local data = GetOverlayData and GetOverlayData(ent)
 		if not (data and data.txt) then return "(none)" end
-		local lines = data.txt:Split("\n")
+		local lines = string.Split(data.txt, "\n")
 		return lines[1]
 	else
 		SF.Throw("The entity is not a starfall, wire gate, wire fpga or expression2!", 2)


### PR DESCRIPTION
- Extends `Entity:getChipName()` to also work for Wire Gates and Wire FPGAs by grabbing the Overlay Data
  - Uses `ENT:GetOverlayData()` (checks if it exists too, in case of weird race conditions)
  - Overlay data is only grabbed if the entity is a FPGA or Gate (explicit class check)
  - If no overlay data is returned, it simply returns `"(none)"`
  - Works on both Client and Server
- Doc string includes new chips
- Error message updated to reflect new chips as well

<img width="326" height="178" alt="Entity:getChipName() modification working" src="https://github.com/user-attachments/assets/4c41127e-6fde-4d93-8cf1-c25662f13f48" />
