### PR TITLE
Support multi-line documentation for param/return/field annotations

### DIFF
--- a/lua/starfall/editor/docs.lua
+++ b/lua/starfall/editor/docs.lua
@@ -210,6 +210,7 @@ local parseAttributes = {
 				type = type,
 				value = value -- We need this in case the type isn't valid. Will be deleted after.
  			}
+			parsing.lastAttrType = "params"
 		else
 			ErrorNoHalt("Invalid param doc (" .. value .. ") in file: " .. curfile .. "\n")
 		end
@@ -224,6 +225,7 @@ local parseAttributes = {
 				description = description,
 				value = value
 			}
+			parsing.lastAttrType = "returns"
 		else
 			ErrorNoHalt("Invalid return doc (" .. value .. ") in file: " .. curfile .. "\n")
 		end
@@ -234,6 +236,7 @@ local parseAttributes = {
 			local t = parsing.fields
 			if not t then t = {} parsing.fields = t end
 			t[#t+1] = {name = name, description = description}
+			parsing.lastAttrType = "fields"
 		else
 			ErrorNoHalt("Invalid field doc (" .. value .. ") in file: " .. curfile .. "\n")
 		end
@@ -261,12 +264,23 @@ local function parse(parsing, data, lineN)
 		local parser = parseAttributes[attribute]
 		if parser then
 			parser(parsing, value, lineN)
+			if attribute ~= "param" and attribute ~= "return" and attribute ~= "field" then
+				parsing.lastAttrType = nil
+			end
 		else
 			ErrorNoHalt("Invalid attribute (" .. attribute .. ") in file: " .. curfile .. "\n")
 		end
 	else
-		local t = parsing.description
-		t[#t+1] = data
+		-- Append to the most recently added param/return/field description
+		local lastType = parsing.lastAttrType
+		local t = lastType and parsing[lastType]
+		if t and #t > 0 then
+			local entry = t[#t]
+			entry.description = entry.description .. "\n" .. data
+		else
+			local desc = parsing.description
+			desc[#desc+1] = data
+		end
 	end
 end
 


### PR DESCRIPTION
Fixed the annoying problem with `-- @param / return / field` annotations being limited to single-line.
This is especially useful for some functions, and will help make documentation easier to read.

---

Example candidate for demonstration purposes, the `options` argument:
```
--- Creates a particle effect (and attaches it to an entity).
-- @param Entity entity The entity to attach the particle effect to
-- @param string name The name of the effect to create (e.g. "smoke")
-- @param number pattach PATTACH enum
-- @param table? options Optional table of tables (indexes 1 to 64) having the following structure:
-- number attachtype - The particle attach type. See PATTACH enum. Default: PATTACH.ABSORIGIN
-- Entity entity - The parent entity. Default: NULL
-- Vector position - The offset position for the given control point. Default: nil
-- This only affects the control points of the particle effects and will do nothing if the effect doesn't use control points.
-- @return ParticleEffect ParticleEffect object.
```

<img width="500" height="300" alt="image" src="https://github.com/user-attachments/assets/2d98234a-6049-4bc9-ad2c-561652d4305c" />
