### PR TITLE
Add `sf_notify_cl` ConVar to suppress popup notifications due to chip error on other clients

### DIFF
--- a/lua/entities/starfall_processor/cl_init.lua
+++ b/lua/entities/starfall_processor/cl_init.lua
@@ -151,7 +151,7 @@ hook.Add("StarfallError", "StarfallErrorReport", function(_, owner, client, main
 	if owner == local_player then
 		local notify_level = SF.CvarNotifyErrors:GetInt()
 		if Ent_IsWorld(client) or client == owner then
-			if notify_level ~= 0 and (notify_level ~= 2 or isNotifiable(message)) then
+			if notify_level ~= 0 then
 				SF.AddNotify(owner, message, "ERROR", 7, "ERROR1")
 			end
 		elseif client then

--- a/lua/entities/starfall_processor/cl_init.lua
+++ b/lua/entities/starfall_processor/cl_init.lua
@@ -131,6 +131,7 @@ end
 -- For 'sf_notify_cl 2': messages matching these substrings won't show notifications
 local silenced_messages = {
 	"CPU usage exceeded",
+	"RAM usage exceeded",
 	"User has blocked this player",
 	"Killed by user",
 	"Blocked by user",

--- a/lua/entities/starfall_processor/cl_init.lua
+++ b/lua/entities/starfall_processor/cl_init.lua
@@ -128,17 +128,34 @@ else
 	end
 end
 
+-- For 'sf_notify_cl 2': messages matching these substrings won't show notifications
+local silenced_messages = {
+	"CPU usage exceeded",
+	"User has blocked this player",
+	"Killed by user",
+	"Blocked by user",
+}
+
+-- Returns true if the error message should trigger a notification at 'sf_notify_cl 2'
+local function isNotifiable(message)
+	for i = 1, #silenced_messages do
+		if string.find(message, silenced_messages[i], 1, true) then return end
+	end
+	return true
+end
+
 hook.Add("StarfallError", "StarfallErrorReport", function(_, owner, client, main_file, message, traceback, should_notify)
 	if not Ent_IsValid(owner) then return end
 	local local_player = LocalPlayer()
 	if owner == local_player then
+		local notify_level = SF.CvarNotifyErrors:GetInt()
 		if Ent_IsWorld(client) or client == owner then
-			if SF.CvarNotifyErrors:GetBool() then
+			if notify_level ~= 0 and (notify_level ~= 2 or isNotifiable(message)) then
 				SF.AddNotify(owner, message, "ERROR", 7, "ERROR1")
 			end
 		elseif client then
 			if should_notify then
-				if SF.CvarNotifyErrors:GetBool() then
+				if notify_level >= 2 and (notify_level == 3 or isNotifiable(message)) then
 					SF.AddNotify(owner, string.format("Starfall '%s' errored for player %s", main_file, client:Nick()), "ERROR", 7, "SILENT")
 				end
 				print(message)

--- a/lua/entities/starfall_processor/cl_init.lua
+++ b/lua/entities/starfall_processor/cl_init.lua
@@ -133,10 +133,14 @@ hook.Add("StarfallError", "StarfallErrorReport", function(_, owner, client, main
 	local local_player = LocalPlayer()
 	if owner == local_player then
 		if Ent_IsWorld(client) or client == owner then
-			SF.AddNotify(owner, message, "ERROR", 7, "ERROR1")
+			if SF.CvarNotifyErrors:GetBool() then
+				SF.AddNotify(owner, message, "ERROR", 7, "ERROR1")
+			end
 		elseif client then
 			if should_notify then
-				SF.AddNotify(owner, string.format("Starfall '%s' errored for player %s", main_file, client:Nick()), "ERROR", 7, "SILENT")
+				if SF.CvarNotifyErrors:GetBool() then
+					SF.AddNotify(owner, string.format("Starfall '%s' errored for player %s", main_file, client:Nick()), "ERROR", 7, "SILENT")
+				end
 				print(message)
 			else
 				print(string.format("Starfall '%s' errored for player %s: %s", main_file, client:Nick(), message))

--- a/lua/starfall/instance.lua
+++ b/lua/starfall/instance.lua
@@ -26,7 +26,8 @@ else
 	SF.softLockProtectionOwner = CreateConVar("sf_timebuffersoftlock_cl_owner", 1, FCVAR_ARCHIVE, "Enable Cpu-time limiting on your own chips.")
 	SF.softLockProtectionSuperUser = CreateConVar("sf_timebuffersoftlock_superuser", 0, {FCVAR_ARCHIVE, FCVAR_REPLICATED}, "Determines whether CPU checks should be done for superusers as well?")
 	SF.RamCap = CreateConVar("sf_ram_max_cl", 1500000, FCVAR_ARCHIVE, "If ram exceeds this limit (in kB), starfalls will be terminated")
-	SF.CvarEnabled = CreateConVar( "sf_enabled_cl", "1", { FCVAR_ARCHIVE, FCVAR_USERINFO, FCVAR_DONTRECORD }, "Enable clientside starfall" )
+	SF.CvarEnabled = CreateConVar("sf_enabled_cl", "1", { FCVAR_ARCHIVE, FCVAR_USERINFO, FCVAR_DONTRECORD }, "Enable clientside starfall")
+	SF.CvarNotifyErrors = CreateConVar("sf_notify_cl", "1", FCVAR_ARCHIVE, "Show popup notifications for chip errors on other clients")
 end
 local ramlimit
 SF.CvarCallback(SF.RamCap, function(val) ramlimit = val end, "number")
@@ -140,7 +141,7 @@ function SF.Instance.Compile(code, mainfile, player, entity)
 
 		--owneronly directive
 		if CLIENT and fdata.owneronly and LocalPlayer() ~= player then continue end -- Don't compile owner-only files if not owner
-		
+
 		--realm directives
 		local serverorclient = fdata.serverorclient
 		if (serverorclient == "server" and CLIENT) or (serverorclient == "client" and SERVER) then continue end -- Don't compile files for other realm
@@ -205,7 +206,7 @@ function SF.Instance:CleanupWrappedEnt(ent)
 end
 
 function SF.Instance:CreateWrapper(metatable, typedata)
-	
+
 	local wrap, unwrap
 
 	-- Create wrapper based on what type of weakness specified
@@ -411,11 +412,11 @@ function SF.Instance:BuildEnvironment()
 
 		return RecursiveUnsanitize(original)
 	end
-	
+
 	for name, _ in pairs(SF.Libraries) do
 		self.Libraries[name] = {}
 	end
-	
+
 	for name, typedata in pairs(SF.Types) do
 		local methods = {}
 		local metatable = {__metatable = name, __index = methods, supertype = typedata.supertype, Methods = methods}
@@ -455,7 +456,7 @@ function SF.Instance:BuildEnvironment()
 			end
 		end
 	end
-	table.Inherit( self.env, self.Libraries ) 
+	table.Inherit( self.env, self.Libraries )
 	self.env._G = self.env
 	self:DoAliases()
 end

--- a/lua/starfall/instance.lua
+++ b/lua/starfall/instance.lua
@@ -27,7 +27,7 @@ else
 	SF.softLockProtectionSuperUser = CreateConVar("sf_timebuffersoftlock_superuser", 0, {FCVAR_ARCHIVE, FCVAR_REPLICATED}, "Determines whether CPU checks should be done for superusers as well?")
 	SF.RamCap = CreateConVar("sf_ram_max_cl", 1500000, FCVAR_ARCHIVE, "If ram exceeds this limit (in kB), starfalls will be terminated")
 	SF.CvarEnabled = CreateConVar("sf_enabled_cl", "1", { FCVAR_ARCHIVE, FCVAR_USERINFO, FCVAR_DONTRECORD }, "Enable clientside starfall")
-	SF.CvarNotifyErrors = CreateConVar("sf_notify_cl", "1", FCVAR_ARCHIVE, "Show popup notifications for chip errors on other clients")
+	SF.CvarNotifyErrors = CreateConVar("sf_notify_cl", "3", FCVAR_ARCHIVE, "Chip error notification level (0=off, 1=self only, 2=filter common spam, 3=all)")
 end
 local ramlimit
 SF.CvarCallback(SF.RamCap, function(val) ramlimit = val end, "number")


### PR DESCRIPTION
Now you can set `sf_notify_cl 1` in your console to suppress all popup notifications due to your chip erroring on other clients, or set it to `2` to always show notifications unless the error is related to cpu/ram/blocked/killed.
The default level is `3` which will show all notifications (as it used to).
Console prints remain unaffected.
