### PR TITLE
Fix the annoying clipping issue (`[src]`), and also prevent selection

### DIFF
--- a/src/main.scss
+++ b/src/main.scss
@@ -272,9 +272,9 @@ code {
   float: right;
   text-align: right;
   font-size: 15px;
-  top: 10px;
-  right: 10px;
-  position: absolute;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 .sf-reference {
   color: #059de3;


### PR DESCRIPTION
Using the [`error`](https://thegrb93.github.io/StarfallEx/#Libraries.builtins.error) function as a demonstration.

This PR brings 2 fixes:

- Removed `position: absolute; top: 10px; right: 10px`; `[src]` link now flows normally with `float: right` instead of being pulled out of document flow.

Visual aid, see no more clipping:
<img width="969" height="224" alt="image" src="https://github.com/user-attachments/assets/79869a24-e6f4-4346-bd58-33878cd66b63" />

---

- Added `user-select: none`; `[src]` text is no longer selectable (but it remains clickable.)

Clipboard before:
```
error(string msg, number or nil level)
[[src]](https://github.com/thegrb93/StarfallEx/blob/master/lua/starfall/libs_sh/builtins.lua#L1180)
Throws an error. Similar to 'throw' but throws whatever you want instead of an SF Error.

Parameters
```
Clipboard after:
```
error(string msg, number or nil level)
Throws an error. Similar to 'throw' but throws whatever you want instead of an SF Error.

Parameters
```
