### PR TITLE
Clamp inputs to sane values on effects library

### DIFF
--- a/lua/starfall/libs_sh/effect.lua
+++ b/lua/starfall/libs_sh/effect.lua
@@ -265,7 +265,7 @@ end
 -- @param number magnitude The magnitude
 function effect_methods:setMagnitude(magnitude)
 	checkluatype(magnitude, TYPE_NUMBER)
-	if magnitude ~= magnitude or magnitude <=0 or magnitude > 1023 then SF.Throw("Magnitude is out of range (0, 1023)!", 2) end
+	if magnitude ~= magnitude or magnitude <=0 or magnitude > 1023 then SF.Throw("Magnitude is out of range (0, 1023): "..magnitude, 2) end
 	unwrap(self):SetMagnitude(magnitude)
 end
 
@@ -292,7 +292,7 @@ end
 -- @param number radius The radius
 function effect_methods:setRadius(radius)
 	checkluatype(radius, TYPE_NUMBER)
-	if radius ~= radius or radius <=0 or radius > 1023 then SF.Throw("Radius is out of range (0, 1023)!", 2) end
+	if radius ~= radius or radius <=0 or radius > 1023 then SF.Throw("Radius is out of range (0, 1023): "..radius, 2) end
 	unwrap(self):SetRadius(radius)
 end
 
@@ -300,7 +300,7 @@ end
 -- @param number scale The number scale
 function effect_methods:setScale(scale)
 	checkluatype(scale, TYPE_NUMBER)
-	if scale ~= scale or scale < -100 or scale > 100 then SF.Throw("Scale is out of range (-100, 100)!", 2) end
+	if scale ~= scale or scale < -100 or scale > 100 then SF.Throw("Scale is out of range (-100, 100): "..scale, 2) end
 	unwrap(self):SetScale(scale)
 end
 

--- a/lua/starfall/libs_sh/effect.lua
+++ b/lua/starfall/libs_sh/effect.lua
@@ -265,6 +265,7 @@ end
 -- @param number magnitude The magnitude
 function effect_methods:setMagnitude(magnitude)
 	checkluatype(magnitude, TYPE_NUMBER)
+	magnitude = math.Clamp(magnitude, 0, 1023)
 	unwrap(self):SetMagnitude(magnitude)
 end
 
@@ -291,6 +292,7 @@ end
 -- @param number radius The radius
 function effect_methods:setRadius(radius)
 	checkluatype(radius, TYPE_NUMBER)
+	radius = math.Clamp(radius, 0, 1023)
 	unwrap(self):SetRadius(radius)
 end
 
@@ -298,6 +300,7 @@ end
 -- @param number scale The number scale
 function effect_methods:setScale(scale)
 	checkluatype(scale, TYPE_NUMBER)
+	scale = math.Clamp(scale, -100, 100)
 	unwrap(self):SetScale(scale)
 end
 

--- a/lua/starfall/libs_sh/effect.lua
+++ b/lua/starfall/libs_sh/effect.lua
@@ -265,7 +265,7 @@ end
 -- @param number magnitude The magnitude
 function effect_methods:setMagnitude(magnitude)
 	checkluatype(magnitude, TYPE_NUMBER)
-	magnitude = math.Clamp(magnitude, 0, 1023)
+	if magnitude ~= magnitude or magnitude <=0 or magnitude > 1023 then SF.Throw("Magnitude is out of range (0, 1023)!", 2) end
 	unwrap(self):SetMagnitude(magnitude)
 end
 
@@ -292,7 +292,7 @@ end
 -- @param number radius The radius
 function effect_methods:setRadius(radius)
 	checkluatype(radius, TYPE_NUMBER)
-	radius = math.Clamp(radius, 0, 1023)
+	if radius ~= radius or radius <=0 or radius > 1023 then SF.Throw("Radius is out of range (0, 1023)!", 2) end
 	unwrap(self):SetRadius(radius)
 end
 
@@ -300,7 +300,7 @@ end
 -- @param number scale The number scale
 function effect_methods:setScale(scale)
 	checkluatype(scale, TYPE_NUMBER)
-	scale = math.Clamp(scale, -100, 100)
+	if scale ~= scale or scale < -100 or scale > 100 then SF.Throw("Scale is out of range (-100, 100)!", 2) end
 	unwrap(self):SetScale(scale)
 end
 


### PR DESCRIPTION
Fixes https://github.com/thegrb93/StarfallEx/issues/2421

The 0-1023 clamps are due to gmods base limits, no reason to above/below it anyways.
<img width="851" height="540" alt="image" src="https://github.com/user-attachments/assets/4510a275-6692-4d91-a770-20dcc99ba5e2" />
