### PR TITLE
Don't clamp Effect scale

### DIFF
--- a/lua/starfall/libs_sh/effect.lua
+++ b/lua/starfall/libs_sh/effect.lua
@@ -300,7 +300,6 @@ end
 -- @param number scale The number scale
 function effect_methods:setScale(scale)
 	checkluatype(scale, TYPE_NUMBER)
-	if scale ~= scale or scale < -100 or scale > 100 then SF.Throw("Scale is out of range (-100, 100): "..scale, 2) end
 	unwrap(self):SetScale(scale)
 end
 


### PR DESCRIPTION
Effect Scale should not be clamped. Scale is used in bullet tracer effects and controls the speed that the tracer flies at, where a scale of 1 means the bullet travels at 1 hu/s. At a maximum of 100 hu/s, they become unreasonably slow and can last a very long time, which is undesirable for anything that is trying to use the tracer effects as intended.