### PR TITLE
Potential bug fix: `SF.Instance:pushCpuCheck` (caused many random errors)

### DIFF
--- a/lua/starfall/instance.lua
+++ b/lua/starfall/instance.lua
@@ -616,7 +616,7 @@ function SF.Instance:setCheckCpu(runWithOps)
 			self.perf:check()
 		end
 		function self:pushCpuCheck(callback)
-			self.cpustatestack[#self.cpustatestack + 1] = (dgethook() or false)
+			self.cpustatestack[#self.cpustatestack + 1] = dgethook()
 			local enabled = callback~=nil
 			if SF.runningOps ~= enabled then
 				SF.runningOps = enabled
@@ -625,7 +625,7 @@ function SF.Instance:setCheckCpu(runWithOps)
 			dsethook(callback, "", 2000)
 		end
 		function self:popCpuCheck()
-			local callback = (table.remove(self.cpustatestack) or nil)
+			local callback = table.remove(self.cpustatestack)
 			dsethook(callback, "", 2000)
 			local enabled = callback~=nil
 			if SF.runningOps ~= enabled then


### PR DESCRIPTION
Potential fix for many random errors that occur under specific circumstances, this was slightly weird to debug cuz SF hook (i relied on my glua dbg for investigation).
At first, these errors started happening at random after someone spawned in SF chip, but I've managed to trace it down to an extent.
I have seen underflows happening as well (correlation: #2433), among this monstrosity, the following is a small log of errors (i originally run into this issue while i was fixing the docs, on the fix-docs-3 branch, so these line numbers may not match up exactly, just a heads up):
```
[starfall] CallFunctionProtected was passed a nil as the error message!
  1. error - [C]:-1
   2. Throw - addons/starfall/lua/starfall/sflib.lua:1440
    3. check - addons/starfall/lua/starfall/instance.lua:575
     4. unknown - addons/starfall/lua/starfall/instance.lua:619
      5. star_update_and_draw - addons/starfall/lua/starfall/toolscreen.lua:85
       6. DrawToolgunScreen - addons/starfall/lua/starfall/toolscreen.lua:158
        7. DrawToolScreen - addons/starfall/lua/weapons/gmod_tool/stools/starfall_processor.lua:270
         8. unknown - gamemodes/sandbox/entities/weapons/gmod_tool/cl_viewscreen.lua:62

[starfall] CallFunctionProtected was passed a nil as the error message!
  1. error - [C]:-1
   2. Throw - addons/starfall/lua/starfall/sflib.lua:1440
    3. check - addons/starfall/lua/starfall/instance.lua:575
     4. __eq - addons/starfall/lua/starfall/instance.lua:619
      5. isstring - lua/includes/util.lua:96
       6. unknown - lua/includes/modules/hook.lua:97

[starfall] CallFunctionProtected was passed a nil as the error message!
  1. error - [C]:-1
   2. Throw - addons/starfall/lua/starfall/sflib.lua:1440
    3. check - addons/starfall/lua/starfall/instance.lua:575
     4. unknown - addons/starfall/lua/starfall/instance.lua:619
      5. Write - lua/includes/extensions/file.lua:27
       6. v - addons/easychat/lua/easychat/modules/client/global_msg_history.lua:12
        7. unknown - lua/includes/modules/hook.lua:102

[starfall] CallFunctionProtected was passed a nil as the error message!
  1. error - [C]:-1
   2. Throw - addons/starfall/lua/starfall/sflib.lua:1440
    3. check - addons/starfall/lua/starfall/instance.lua:575
     4. unknown - addons/starfall/lua/starfall/instance.lua:619
      5. unknown - lua/includes/modules/hook.lua:97

[starfall] CallFunctionProtected was passed a nil as the error message!
  1. error - [C]:-1
   2. Throw - addons/starfall/lua/starfall/sflib.lua:1440
    3. check - addons/starfall/lua/starfall/instance.lua:575
     4. IsPlayer - addons/starfall/lua/starfall/instance.lua:619
      5. v - addons/easychat/lua/easychat/modules/dm_tab.lua:274
       6. unknown - lua/includes/modules/hook.lua:102

[starfall] CallFunctionProtected was passed a nil as the error message!
  1. error - [C]:-1
   2. Throw - addons/starfall/lua/starfall/sflib.lua:1440
    3. check - addons/starfall/lua/starfall/instance.lua:575
     4. unknown - addons/starfall/lua/starfall/instance.lua:619
      5. isstring - lua/includes/util.lua:96
       6. unknown - lua/includes/modules/hook.lua:97

[starfall] CallFunctionProtected was passed a nil as the error message!
  1. error - [C]:-1
   2. Throw - addons/starfall/lua/starfall/sflib.lua:1440
    3. check - addons/starfall/lua/starfall/instance.lua:575
     4. unknown - addons/starfall/lua/starfall/instance.lua:619
      5. unknown - lua/includes/modules/hook.lua:102
```

Reproduction steps: TBD.
