### PR TITLE
Fix lua error

### DIFF
--- a/lua/starfall/sflib.lua
+++ b/lua/starfall/sflib.lua
@@ -581,7 +581,7 @@ end
 
 local function steamIdToConsoleSafeName(steamid)
 	local ply = player.GetBySteamID(steamid)
-	return Ent_IsValid(ply) and string.gsub(Ply_Nick(ply), '[%z\x01-\x1f\x7f;"\']', "") or ""
+	return ply and Ent_IsValid(ply) and string.gsub(Ply_Nick(ply), '[%z\x01-\x1f\x7f;"\']', "") or ""
 end
 
 --- Returns a class that can keep a list of users


### PR DESCRIPTION
Fixes:
```
- addons/starfallex/lua/starfall/sflib.lua:584: bad argument #1 to 'Ent_IsValid' (Entity expected, got boolean)
1. Ent_IsValid - [C]:-1
 2. steamIdToConsoleSafeName - addons/starfallex/lua/starfall/sflib.lua:584
  3. add - addons/starfallex/lua/starfall/sflib.lua:595
   4. callback - addons/starfallex/lua/starfall/sflib.lua:653
    5. <unknown> - addons/starfallex/lua/starfall/sflib.lua:1369
     6. <unknown> - lua/includes/modules/concommand.lua:60
```
